### PR TITLE
feat: add Terraform config for AWS infrastructure

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,10 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+terraform.tfvars
+.terraform.lock.hcl
+
+# Exception: bootstrap state is safe to commit
+!bootstrap/terraform.tfstate
+!bootstrap/terraform.tfstate.backup

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -1,0 +1,48 @@
+# --- AWS Load Balancer Controller ---
+# Installed via Helm into the EKS cluster. Creates ALBs from Ingress resources.
+
+module "alb_controller_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.0"
+
+  role_name = "${var.project_name}-alb-controller"
+
+  attach_load_balancer_controller_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:aws-load-balancer-controller"]
+    }
+  }
+}
+
+resource "helm_release" "alb_controller" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  version    = "1.8.1"
+
+  set {
+    name  = "clusterName"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = module.alb_controller_irsa.iam_role_arn
+  }
+
+  depends_on = [module.eks]
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,64 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# --- S3 bucket for Terraform state ---
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "${var.project_name}-tfstate"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# --- DynamoDB table for state locking ---
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = "${var.project_name}-tflock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "state_bucket_name" {
+  description = "S3 bucket name for Terraform state"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "lock_table_name" {
+  description = "DynamoDB table name for state locking"
+  value       = aws_dynamodb_table.terraform_locks.name
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,0 +1,11 @@
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "gen-ai-portfolio"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,56 @@
+# --- ECR Repositories ---
+# One repository per service for container images
+
+locals {
+  services = [
+    "ingestion",
+    "chat",
+    "debug",
+    "java-task-service",
+    "java-activity-service",
+    "java-notification-service",
+    "java-gateway-service",
+    "go-auth-service",
+    "go-ecommerce-service",
+    "go-ai-service",
+  ]
+}
+
+resource "aws_ecr_repository" "services" {
+  for_each = toset(local.services)
+
+  name                 = "${var.project_name}/${each.key}"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = each.key
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "services" {
+  for_each = aws_ecr_repository.services
+
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 5 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 5
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -1,0 +1,35 @@
+# --- EKS Module ---
+# Using the official AWS EKS module for best practices
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = "${var.project_name}-eks"
+  cluster_version = var.eks_kubernetes_version
+
+  vpc_id     = aws_vpc.main.id
+  subnet_ids = aws_subnet.private[*].id
+
+  # Public endpoint so kubectl works from Mac without VPN
+  cluster_endpoint_public_access = true
+
+  eks_managed_node_groups = {
+    default = {
+      instance_types = [var.eks_node_instance_type]
+      min_size       = var.eks_node_count
+      max_size       = var.eks_node_count + 1
+      desired_size   = var.eks_node_count
+
+      # Attach the node security group for managed service access
+      vpc_security_group_ids = [aws_security_group.node.id]
+    }
+  }
+
+  # Allow the GitHub Actions OIDC role to manage the cluster
+  enable_cluster_creator_admin_permissions = true
+
+  tags = {
+    Project = var.project_name
+  }
+}

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,0 +1,22 @@
+# --- ElastiCache Redis ---
+
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.project_name}-redis-subnet"
+  subnet_ids = aws_subnet.private[*].id
+}
+
+resource "aws_elasticache_cluster" "redis" {
+  cluster_id           = "${var.project_name}-redis"
+  engine               = "redis"
+  node_type            = var.elasticache_node_type
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = [aws_security_group.elasticache.id]
+
+  tags = {
+    Name = "${var.project_name}-redis"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "gen-ai-portfolio-tfstate"
+    key            = "terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "gen-ai-portfolio-tflock"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    }
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}

--- a/terraform/mq.tf
+++ b/terraform/mq.tf
@@ -1,0 +1,23 @@
+# --- Amazon MQ (RabbitMQ) ---
+
+resource "aws_mq_broker" "rabbitmq" {
+  broker_name = "${var.project_name}-rabbitmq"
+
+  engine_type        = "RabbitMQ"
+  engine_version     = "3.13"
+  host_instance_type = var.mq_instance_type
+  deployment_mode    = "SINGLE_INSTANCE"
+
+  user {
+    username = var.mq_username
+    password = var.mq_password
+  }
+
+  subnet_ids          = [aws_subnet.private[0].id]
+  security_groups     = [aws_security_group.mq.id]
+  publicly_accessible = false
+
+  tags = {
+    Name = "${var.project_name}-rabbitmq"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,44 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster API endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "rds_endpoint" {
+  description = "RDS PostgreSQL endpoint"
+  value       = aws_db_instance.postgres.endpoint
+}
+
+output "rds_address" {
+  description = "RDS PostgreSQL hostname (without port)"
+  value       = aws_db_instance.postgres.address
+}
+
+output "elasticache_endpoint" {
+  description = "ElastiCache Redis endpoint"
+  value       = aws_elasticache_cluster.redis.cache_nodes[0].address
+}
+
+output "mq_endpoint" {
+  description = "Amazon MQ RabbitMQ AMQP endpoint"
+  value       = aws_mq_broker.rabbitmq.instances[0].endpoints[0]
+}
+
+output "mq_console_url" {
+  description = "Amazon MQ RabbitMQ management console URL"
+  value       = aws_mq_broker.rabbitmq.instances[0].console_url
+}
+
+output "ecr_repository_urls" {
+  description = "ECR repository URLs for each service"
+  value       = { for k, v in aws_ecr_repository.services : k => v.repository_url }
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,0 +1,37 @@
+# --- RDS PostgreSQL ---
+# Shared by Java (taskdb) and Go (ecommercedb) services
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.project_name}-db-subnet"
+  subnet_ids = aws_subnet.private[*].id
+
+  tags = {
+    Name = "${var.project_name}-db-subnet"
+  }
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier = "${var.project_name}-postgres"
+
+  engine         = "postgres"
+  engine_version = "17"
+  instance_class = var.rds_instance_class
+
+  allocated_storage = var.rds_allocated_storage
+  storage_type      = "gp3"
+
+  db_name  = "taskdb"
+  username = "postgres"
+  password = var.db_password
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  publicly_accessible = false
+  multi_az            = false
+  skip_final_snapshot = true
+
+  tags = {
+    Name = "${var.project_name}-postgres"
+  }
+}

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,20 @@
+# --- AWS Secrets Manager ---
+# Store sensitive values for K8s secrets injection at deploy time
+
+resource "aws_secretsmanager_secret" "llm_api_key" {
+  name                    = "${var.project_name}/llm-api-key"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name = "${var.project_name}-llm-api-key"
+  }
+}
+
+resource "aws_secretsmanager_secret" "embedding_api_key" {
+  name                    = "${var.project_name}/embedding-api-key"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name = "${var.project_name}-embedding-api-key"
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Copy this file to terraform.tfvars and fill in the values
+
+project_name = "gen-ai-portfolio"
+region       = "us-east-1"
+
+# EKS
+eks_node_instance_type = "t3.medium"
+eks_node_count         = 2
+eks_kubernetes_version = "1.31"
+
+# RDS PostgreSQL
+rds_instance_class    = "db.t3.micro"
+rds_allocated_storage = 20
+db_password           = "CHANGE_ME"
+
+# ElastiCache Redis
+elasticache_node_type = "cache.t3.micro"
+
+# Amazon MQ (RabbitMQ)
+mq_instance_type = "mq.t3.micro"
+mq_username      = "admin"
+mq_password      = "CHANGE_ME"
+
+# Domain
+domain_name = "kylebradshaw.dev"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,77 @@
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "gen-ai-portfolio"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "eks_node_instance_type" {
+  description = "EC2 instance type for EKS worker nodes"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "eks_node_count" {
+  description = "Number of EKS worker nodes"
+  type        = number
+  default     = 2
+}
+
+variable "eks_kubernetes_version" {
+  description = "Kubernetes version for EKS"
+  type        = string
+  default     = "1.31"
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "rds_allocated_storage" {
+  description = "RDS storage in GB"
+  type        = number
+  default     = 20
+}
+
+variable "db_password" {
+  description = "Password for RDS PostgreSQL"
+  type        = string
+  sensitive   = true
+}
+
+variable "elasticache_node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.t3.micro"
+}
+
+variable "mq_instance_type" {
+  description = "Amazon MQ broker instance type"
+  type        = string
+  default     = "mq.t3.micro"
+}
+
+variable "mq_username" {
+  description = "Amazon MQ broker username"
+  type        = string
+  default     = "admin"
+}
+
+variable "mq_password" {
+  description = "Amazon MQ broker password"
+  type        = string
+  sensitive   = true
+}
+
+variable "domain_name" {
+  description = "Domain name for the application"
+  type        = string
+  default     = "kylebradshaw.dev"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,190 @@
+# --- VPC ---
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-vpc"
+  }
+}
+
+# --- Internet Gateway ---
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-igw"
+  }
+}
+
+# --- Public Subnets (ALB, NAT Gateway) ---
+
+resource "aws_subnet" "public" {
+  count = 2
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name                                            = "${var.project_name}-public-${local.azs[count.index]}"
+    "kubernetes.io/role/elb"                        = "1"
+    "kubernetes.io/cluster/${var.project_name}-eks" = "shared"
+  }
+}
+
+# --- Private Subnets (EKS nodes, RDS, ElastiCache, MQ) ---
+
+resource "aws_subnet" "private" {
+  count = 2
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + 10)
+  availability_zone = local.azs[count.index]
+
+  tags = {
+    Name                                            = "${var.project_name}-private-${local.azs[count.index]}"
+    "kubernetes.io/role/internal-elb"               = "1"
+    "kubernetes.io/cluster/${var.project_name}-eks" = "shared"
+  }
+}
+
+# --- NAT Gateway (single AZ for cost) ---
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "${var.project_name}-nat-eip"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = {
+    Name = "${var.project_name}-nat"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# --- Route Tables ---
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count = 2
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count = 2
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# --- Security Groups ---
+
+resource "aws_security_group" "node" {
+  name_prefix = "${var.project_name}-node-"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-node-sg"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name_prefix = "${var.project_name}-rds-"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.node.id]
+  }
+
+  tags = {
+    Name = "${var.project_name}-rds-sg"
+  }
+}
+
+resource "aws_security_group" "elasticache" {
+  name_prefix = "${var.project_name}-redis-"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.node.id]
+  }
+
+  tags = {
+    Name = "${var.project_name}-redis-sg"
+  }
+}
+
+resource "aws_security_group" "mq" {
+  name_prefix = "${var.project_name}-mq-"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5671
+    to_port         = 5671
+    protocol        = "tcp"
+    security_groups = [aws_security_group.node.id]
+  }
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.node.id]
+  }
+
+  tags = {
+    Name = "${var.project_name}-mq-sg"
+  }
+}


### PR DESCRIPTION
Bootstrap config (terraform/bootstrap/) creates S3 state bucket and DynamoDB lock table. Main config provisions VPC (2 AZs, public/private subnets, NAT gateway), EKS cluster (2x t3.medium nodes), RDS PostgreSQL (db.t3.micro), ElastiCache Redis, Amazon MQ RabbitMQ, ECR repositories for all 10 services, AWS Load Balancer Controller via Helm, and Secrets Manager for API keys. All validated with terraform validate.