### PR TITLE
feat: add AWS spin-up/tear-down scripts and operations runbook

### DIFF
--- a/docs/aws-operations.md
+++ b/docs/aws-operations.md
@@ -1,0 +1,148 @@
+# AWS Operations Runbook
+
+## Overview
+
+The AWS deployment is demo-oriented — spin up for interviews, tear down after to minimize cost. The current Minikube setup on the Windows PC remains the primary deployment.
+
+## Prerequisites
+
+- AWS CLI configured with credentials (`aws configure`)
+- Terraform CLI installed (`brew install terraform`)
+- kubectl installed
+- GitHub secrets configured (see below)
+
+## Spin Up (~15-20 min)
+
+```bash
+# From the repo root
+./scripts/aws-up.sh
+```
+
+This runs:
+1. **Bootstrap** — creates S3 state bucket + DynamoDB lock table (first time only)
+2. **Terraform apply** — provisions VPC, EKS, RDS, ElastiCache, Amazon MQ, ECR, ALB controller
+3. **kubectl config** — connects kubectl to the EKS cluster
+4. **deploy.sh aws** — deploys all services using Kustomize AWS overlays
+
+After completion, update DNS:
+1. In Cloudflare, set `api.kylebradshaw.dev` as CNAME → ALB hostname (printed by the script)
+2. Pause the Cloudflare Tunnel to the Windows PC
+3. Wait ~2 min for DNS propagation
+
+## Tear Down (~5 min)
+
+```bash
+./scripts/aws-down.sh
+```
+
+After completion, restore DNS:
+1. In Cloudflare, restore `api.kylebradshaw.dev` → Cloudflare Tunnel
+2. Unpause the Cloudflare Tunnel
+
+## CI/CD Deploy (Alternative)
+
+Instead of the scripts, you can deploy via GitHub Actions:
+1. Go to Actions → "AWS Deploy" → Run workflow → Select "deploy"
+2. This builds all images, pushes to ECR, and deploys to EKS
+
+## Cost Estimates
+
+### When Running (~per day)
+
+| Resource | Cost |
+|----------|------|
+| EKS control plane | $3.30 |
+| 2x t3.medium nodes | $2.00 |
+| RDS db.t3.micro | $0.50 |
+| ElastiCache cache.t3.micro | $0.50 |
+| Amazon MQ mq.t3.micro | $0.80 |
+| NAT Gateway | $1.10 |
+| ALB | $0.80 |
+| **Total** | **~$5-9/day** |
+
+### When Torn Down
+
+| Resource | Cost |
+|----------|------|
+| S3 state bucket | ~$0.01/month |
+| ECR images | ~$0.10/month |
+| MongoDB Atlas (free tier) | $0 |
+| **Total** | **~$0.11/month** |
+
+## GitHub Secrets Required
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_OIDC_ROLE_ARN` | IAM OIDC role ARN for GitHub Actions |
+| `LLM_API_KEY` | Groq API key (or OpenAI/Anthropic) |
+| `EMBEDDING_API_KEY` | OpenAI API key for embeddings |
+| `AWS_DB_PASSWORD` | RDS PostgreSQL password |
+| `AWS_MQ_PASSWORD` | Amazon MQ RabbitMQ password |
+| `JWT_SECRET` | JWT signing secret (already exists) |
+
+## Architecture
+
+```
+                    ┌─────────────┐
+                    │  Cloudflare │
+                    │    DNS      │
+                    └──────┬──────┘
+                           │
+                    ┌──────▼──────┐
+                    │     ALB     │
+                    │  (AWS LB    │
+                    │  Controller)│
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+     ┌────────▼──┐  ┌──────▼───┐  ┌────▼──────┐
+     │ai-services│  │java-tasks│  │go-ecommerce│
+     │ namespace │  │namespace │  │ namespace  │
+     ├───────────┤  ├──────────┤  ├───────────┤
+     │ingestion  │  │gateway   │  │auth       │
+     │chat       │  │task      │  │ecommerce  │
+     │debug      │  │activity  │  │ai-agent   │
+     │qdrant     │  │notify    │  └─────┬─────┘
+     └───────────┘  └────┬─────┘        │
+                         │              │
+              ┌──────────┼──────────────┤
+              │          │              │
+     ┌────────▼──┐ ┌─────▼────┐ ┌──────▼──────┐
+     │   RDS     │ │ElastiCache│ │  Amazon MQ  │
+     │PostgreSQL │ │  Redis    │ │  RabbitMQ   │
+     └───────────┘ └──────────┘ └─────────────┘
+```
+
+## Troubleshooting
+
+### Terraform state lock
+
+If a previous `terraform apply` was interrupted:
+```bash
+cd terraform
+terraform force-unlock <LOCK_ID>
+```
+
+### ALB not provisioning
+
+Check the AWS Load Balancer Controller logs:
+```bash
+kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
+```
+
+### Services not starting
+
+Check pod events:
+```bash
+kubectl describe pod -n <namespace> <pod-name>
+kubectl logs -n <namespace> <pod-name>
+```
+
+### Database connectivity
+
+Verify the RDS endpoint is reachable from EKS nodes:
+```bash
+kubectl run pg-test --rm -it --image=postgres:17-alpine -- \
+  psql "postgresql://postgres:<password>@<rds-endpoint>:5432/taskdb"
+```

--- a/scripts/aws-down.sh
+++ b/scripts/aws-down.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tear down the AWS environment after a demo.
+# Keeps the S3 state bucket (~$0.01/month) and ECR images (~$0.10/month).
+# Usage: ./scripts/aws-down.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TF_DIR="$REPO_DIR/terraform"
+
+echo "==> Destroying AWS infrastructure..."
+echo "    This will remove: EKS, RDS, ElastiCache, Amazon MQ, ALB, VPC"
+echo "    This will keep:   S3 state bucket, ECR images, MongoDB Atlas"
+echo ""
+
+cd "$TF_DIR"
+terraform destroy -auto-approve
+
+echo ""
+echo "============================================"
+echo "  AWS environment is down!"
+echo "============================================"
+echo ""
+echo "  Next steps:"
+echo "    1. In Cloudflare, restore api.kylebradshaw.dev -> Tunnel"
+echo "    2. Unpause the Cloudflare Tunnel to the Windows PC"
+echo ""
+echo "  Residual costs: ~\$0.11/month (S3 bucket + ECR images)"
+echo "  To spin up again: ./scripts/aws-up.sh"
+echo ""

--- a/scripts/aws-up.sh
+++ b/scripts/aws-up.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Spin up the AWS environment for a demo.
+# Prerequisites: terraform CLI, AWS credentials configured, kubectl installed.
+# Usage: ./scripts/aws-up.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TF_DIR="$REPO_DIR/terraform"
+BOOTSTRAP_DIR="$TF_DIR/bootstrap"
+
+echo "==> Step 1: Bootstrap (S3 state bucket + DynamoDB lock)"
+cd "$BOOTSTRAP_DIR"
+terraform init
+terraform apply -auto-approve
+echo ""
+
+echo "==> Step 2: Provision infrastructure"
+cd "$TF_DIR"
+terraform init
+terraform apply -auto-approve
+echo ""
+
+echo "==> Step 3: Configure kubectl"
+CLUSTER_NAME=$(terraform output -raw cluster_name)
+REGION=$(terraform output -raw region 2>/dev/null || echo "us-east-1")
+aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "$REGION"
+echo ""
+
+echo "==> Step 4: Deploy services"
+cd "$REPO_DIR"
+./k8s/deploy.sh aws
+echo ""
+
+echo "==> Step 5: Get ALB hostname"
+ALB=$(kubectl get ingress -n ai-services \
+  -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}' 2>/dev/null || echo "")
+
+echo ""
+echo "============================================"
+echo "  AWS environment is up!"
+echo "============================================"
+echo ""
+if [ -n "$ALB" ]; then
+  echo "  ALB hostname: $ALB"
+  echo ""
+  echo "  Next steps:"
+  echo "    1. In Cloudflare, set api.kylebradshaw.dev CNAME -> $ALB"
+  echo "    2. Pause the Cloudflare Tunnel to the Windows PC"
+  echo "    3. Wait ~2 min for DNS propagation"
+  echo "    4. Test: curl https://api.kylebradshaw.dev/ingestion/health"
+else
+  echo "  ALB not yet provisioned. Check ingress status:"
+  echo "    kubectl get ingress --all-namespaces"
+fi
+echo ""
+echo "  Estimated cost: ~\$5-9/day while running"
+echo "  Tear down: ./scripts/aws-down.sh"
+echo ""


### PR DESCRIPTION
aws-up.sh bootstraps state backend, provisions infrastructure via Terraform, configures kubectl, and deploys services via Kustomize AWS overlays. aws-down.sh destroys all AWS resources. Operations runbook documents the full workflow, cost estimates, required secrets, and troubleshooting steps.