### PR TITLE
feat(go): harden services for production readiness

### DIFF
--- a/go/ai-service/cmd/server/main.go
+++ b/go/ai-service/cmd/server/main.go
@@ -149,7 +149,13 @@ func main() {
 	apphttp.RegisterChatRoutes(router, a, jwtSecret, limiter)
 	apphttp.RegisterMetricsRoute(router)
 
-	srv := &http.Server{Addr: ":" + port, Handler: router}
+	srv := &http.Server{
+		Addr:         ":" + port,
+		Handler:      router,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 120 * time.Second, // longer for LLM streaming responses
+		IdleTimeout:  60 * time.Second,
+	}
 
 	go func() {
 		slog.Info("ai-service starting",

--- a/go/auth-service/cmd/server/main.go
+++ b/go/auth-service/cmd/server/main.go
@@ -25,6 +25,11 @@ import (
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
+const (
+	accessTokenTTLMs  = 900_000     // 15 minutes
+	refreshTokenTTLMs = 604_800_000 // 7 days
+)
+
 func main() {
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
@@ -68,7 +73,17 @@ func main() {
 	defer func() { _ = shutdownTracer(ctx) }()
 
 	// Connect to Postgres
-	pool, err := pgxpool.New(ctx, databaseURL)
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		log.Fatalf("failed to parse database config: %v", err)
+	}
+	poolConfig.MaxConns = 10
+	poolConfig.MinConns = 2
+	poolConfig.MaxConnIdleTime = 5 * time.Minute
+	poolConfig.MaxConnLifetime = 30 * time.Minute
+	poolConfig.HealthCheckPeriod = 30 * time.Second
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		log.Fatalf("failed to connect to database: %v", err)
 	}
@@ -85,7 +100,7 @@ func main() {
 		OnStateChange: resilience.ObserveStateChange,
 	})
 	userRepo := repository.NewUserRepository(pool, pgBreaker)
-	authSvc := service.NewAuthService(userRepo, jwtSecret, 900000, 604800000)
+	authSvc := service.NewAuthService(userRepo, jwtSecret, accessTokenTTLMs, refreshTokenTTLMs)
 	googleClient := google.NewClient(googleClientID, googleClientSecret, googleTokenURL, googleUserinfoURL)
 	authHandler := handler.NewAuthHandler(authSvc, googleClient)
 	healthHandler := handler.NewHealthHandler(pool)
@@ -109,8 +124,11 @@ func main() {
 
 	// Start server
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: router,
+		Addr:         ":" + port,
+		Handler:      router,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
 	}
 
 	go func() {

--- a/go/k8s/deployments/ai-service.yml
+++ b/go/k8s/deployments/ai-service.yml
@@ -34,6 +34,14 @@ spec:
                 secretKeyRef:
                   name: go-secrets
                   key: jwt-secret
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               memory: "64Mi"
@@ -41,12 +49,19 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "500m"
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /health
               port: 8093
             initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8093
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /health

--- a/go/k8s/deployments/auth-service.yml
+++ b/go/k8s/deployments/auth-service.yml
@@ -44,6 +44,14 @@ spec:
                 secretKeyRef:
                   name: go-secrets
                   key: google-client-secret
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               memory: "64Mi"
@@ -57,3 +65,9 @@ spec:
               port: 8091
             initialDelaySeconds: 5
             periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8091
+            initialDelaySeconds: 15
+            periodSeconds: 30

--- a/go/k8s/deployments/ecommerce-service.yml
+++ b/go/k8s/deployments/ecommerce-service.yml
@@ -34,6 +34,14 @@ spec:
                 secretKeyRef:
                   name: go-secrets
                   key: jwt-secret
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               memory: "64Mi"
@@ -47,3 +55,9 @@ spec:
               port: 8092
             initialDelaySeconds: 5
             periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8092
+            initialDelaySeconds: 15
+            periodSeconds: 30

--- a/go/k8s/kustomization.yaml
+++ b/go/k8s/kustomization.yaml
@@ -16,4 +16,7 @@ resources:
   - services/ai-service.yml
   - services/auth-service.yml
   - services/ecommerce-service.yml
+  - pdb/auth-pdb.yml
+  - pdb/ecommerce-pdb.yml
+  - pdb/ai-pdb.yml
   - ingress.yml

--- a/go/k8s/pdb/ai-pdb.yml
+++ b/go/k8s/pdb/ai-pdb.yml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: go-ai-service-pdb
+  namespace: go-ecommerce
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: go-ai-service

--- a/go/k8s/pdb/auth-pdb.yml
+++ b/go/k8s/pdb/auth-pdb.yml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: go-auth-service-pdb
+  namespace: go-ecommerce
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: go-auth-service

--- a/go/k8s/pdb/ecommerce-pdb.yml
+++ b/go/k8s/pdb/ecommerce-pdb.yml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: go-ecommerce-service-pdb
+  namespace: go-ecommerce
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: go-ecommerce-service


### PR DESCRIPTION
Add HTTP server timeouts to auth-service and ai-service to prevent slow clients from exhausting connections. Add K8s security contexts (non-root, read-only filesystem, drop all capabilities), liveness probes for auth and ecommerce, startup probe for ai-service, and Pod Disruption Budgets for zero-downtime node drains. Tune auth-service pgx pool and extract JWT token lifetime magic numbers into named constants.