### PR TITLE
Add health-check maintenance pages and CI/CD documentation

### DIFF
--- a/docs/superpowers/specs/2026-04-13-cicd-docs-maintenance-pages-design.md
+++ b/docs/superpowers/specs/2026-04-13-cicd-docs-maintenance-pages-design.md
@@ -1,0 +1,123 @@
+# CI/CD Documentation Page & Maintenance Pages
+
+## Context
+
+The portfolio project is about to go through a server migration from Windows to Debian 12. During this transition (and any future downtime), interactive demo pages that depend on backend APIs will break silently — users see errors or blank states instead of a professional maintenance message.
+
+Additionally, the CI/CD pipeline was recently rebuilt (unified workflow, QA environment, agent automation) and this work should be showcased on the portfolio site as a documentation page demonstrating DevOps skills.
+
+## Goals
+
+- Show a professional maintenance screen on interactive demo pages when the backend is down
+- Add a CI/CD pipeline documentation page that explains the pipeline and why it's designed for a solo developer
+- Reorder the site header navigation to match the homepage card order
+
+## Health-Check Maintenance Screen
+
+### HealthGate Component
+
+A shared client component at `frontend/src/components/health-gate.tsx` that wraps each interactive demo page.
+
+**Behavior:**
+1. On mount, fetches the given health endpoint with a 3-second timeout
+2. While checking: renders a minimal loading skeleton (matching page background) to avoid layout flash
+3. If healthy (200 response): renders children (the demo page)
+4. If unhealthy (fetch fails, timeout, non-200): renders the maintenance screen
+
+**Props:**
+- `endpoint` — health check URL (e.g., `https://api.kylebradshaw.dev/chat/health`)
+- `stack` — display name for the service (e.g., "Python AI Services")
+- `docsHref` — link back to the documentation page (e.g., `/ai`)
+- `children` — the demo content to render when healthy
+
+### Maintenance Screen Design
+
+Style A from brainstorming: informative with context.
+
+- Wrench icon (🔧)
+- "Server Maintenance" heading
+- Maintenance message from `NEXT_PUBLIC_MAINTENANCE_MESSAGE` env var. Fallback: "The backend services are currently offline for maintenance. Please check back later."
+- Context box explaining what's happening
+- Back link to the documentation page for that stack
+
+### Health Endpoints Per Page
+
+| Page | Health Endpoint | Stack Label | Docs Link |
+|------|----------------|-------------|-----------|
+| `/ai/rag` | `{API_URL}/chat/health` | Python AI Services | `/ai` |
+| `/ai/debug` | `{API_URL}/debug/health` | Python AI Services | `/ai` |
+| `/java/tasks` (+ sub-pages) | `{GATEWAY_URL}/actuator/health` | Java Task Management | `/java` |
+| `/java/dashboard` | `{GATEWAY_URL}/actuator/health` | Java Task Management | `/java` |
+| `/go/ecommerce` (+ sub-pages) | `{GO_ECOMMERCE_URL}/health` | Go Ecommerce | `/go` |
+| `/go/login` | `{GO_AUTH_URL}/health` | Go Ecommerce | `/go` |
+| `/go/register` | `{GO_AUTH_URL}/health` | Go Ecommerce | `/go` |
+
+The `API_URL`, `GATEWAY_URL`, `GO_ECOMMERCE_URL`, and `GO_AUTH_URL` values come from the existing `NEXT_PUBLIC_*` env vars already used by each page.
+
+For pages with layouts that wrap multiple sub-pages (`/java/tasks/layout.tsx`, `/go/ecommerce/layout.tsx`), the HealthGate wraps at the layout level so all child pages inherit the health check.
+
+### Maintenance Message Env Var
+
+`NEXT_PUBLIC_MAINTENANCE_MESSAGE` — set in Vercel. Initial value: "Migrating to Linux for improved performance and reliability."
+
+Updated via `vercel env` when the reason for downtime changes. Falls back to a generic message if not set.
+
+## CI/CD Pipeline Documentation Page
+
+### Route
+
+`/cicd` — new top-level page. Static content, no backend dependency, no HealthGate needed.
+
+### Navigation
+
+Added to `SiteHeader` after Infrastructure & Deployment. Full header reordered to match homepage card order:
+
+**New nav order:** Go, Infrastructure & Deployment, Java, AI, CI/CD
+
+### Content Sections
+
+1. **Overview** — what the pipeline does, diagram of the full flow (PR → quality checks → QA deploy → prod deploy)
+2. **Why a unified workflow** — rationale for consolidating 3 workflows into 1, why path filtering was removed for simplicity
+3. **Trigger matrix** — table showing what runs on PR-to-qa, push-to-qa, push-to-main
+4. **Quality gates** — list of all checks (lint, test, security, k8s validation) with brief descriptions
+5. **QA environment** — separate namespaces, Kustomize overlays, CORS scoping, how QA mirrors production
+6. **Image tagging strategy** — `:qa-<sha>` vs `:latest`, GHCR registry
+7. **Deploy mechanism** — SSH via Tailscale to Windows/Linux PC, kubectl apply, selective restarts
+8. **Why no branch protection** — solo developer, code already reviewed in QA, branch protection would be one person approving their own PR
+9. **Agent automation** — how Claude Code agents drive the spec-to-QA pipeline, worktree lifecycle, the "ship it" flow
+10. **Smoke tests** — health endpoint checks for QA, Playwright for production
+
+### Implementation
+
+Standard Next.js page component with shadcn/ui typography. Diagrams rendered as styled HTML/CSS (same approach as existing architecture diagrams on `/ai`, `/java`, `/go` overview pages). Code snippets in `<pre>` blocks showing YAML fragments and workflow configuration.
+
+## Files Changed
+
+| Action | File | Purpose |
+|---|---|---|
+| Create | `frontend/src/components/health-gate.tsx` | Shared health-check wrapper component + maintenance screen |
+| Create | `frontend/src/app/cicd/page.tsx` | CI/CD pipeline documentation page |
+| Modify | `frontend/src/components/site-header.tsx` | Add CI/CD link, reorder nav: Go, AWS, Java, AI, CI/CD |
+| Modify | `frontend/src/app/ai/rag/page.tsx` | Wrap content with HealthGate |
+| Modify | `frontend/src/app/ai/debug/page.tsx` | Wrap content with HealthGate |
+| Modify | `frontend/src/app/java/tasks/layout.tsx` | Wrap with HealthGate (covers tasks + sub-pages) |
+| Modify | `frontend/src/app/java/dashboard/page.tsx` | Wrap with HealthGate |
+| Modify | `frontend/src/app/go/ecommerce/layout.tsx` | Wrap with HealthGate (covers ecommerce + sub-pages) |
+| Modify | `frontend/src/app/go/login/page.tsx` | Wrap with HealthGate |
+| Modify | `frontend/src/app/go/register/page.tsx` | Wrap with HealthGate |
+
+**Vercel env var:** `NEXT_PUBLIC_MAINTENANCE_MESSAGE` — added to production environment.
+
+## Verification
+
+1. **HealthGate works when backend is up:** demo pages render normally
+2. **HealthGate works when backend is down:** maintenance screen appears with correct stack name, message, and back link
+3. **Maintenance message env var:** setting/unsetting `NEXT_PUBLIC_MAINTENANCE_MESSAGE` changes the displayed text
+4. **CI/CD page:** renders with all sections, diagrams display correctly, code snippets are readable
+5. **Navigation:** header order matches homepage card order, CI/CD link works
+6. **Preflight:** `make preflight-frontend` passes (lint, tsc, build)
+
+## Follow-up (Out of Scope)
+
+- Separate QA database instances (address during Debian 12 migration)
+- Live health status indicators on the CI/CD page (could show real-time stack health)

--- a/frontend/src/app/ai/debug/page.tsx
+++ b/frontend/src/app/ai/debug/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { DebugForm } from "@/components/DebugForm";
 import { AgentTimeline, AgentEvent } from "@/components/AgentTimeline";
+import { HealthGate } from "@/components/HealthGate";
 
 export default function DebugPage() {
   const [events, setEvents] = useState<AgentEvent[]>([]);
@@ -13,6 +14,7 @@ export default function DebugPage() {
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
   const debugApiUrl = `${apiUrl}/debug`;
+  const debugHealthUrl = `${apiUrl}/debug/health`;
 
   // Auto-scroll timeline as events arrive
   useEffect(() => {
@@ -107,50 +109,52 @@ export default function DebugPage() {
   );
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto max-w-6xl px-6 py-12">
-        {/* Navigation */}
-        <Link
-          href="/ai"
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          &larr; Back
-        </Link>
+    <HealthGate endpoint={debugHealthUrl} stack="Python AI Services" docsHref="/ai">
+      <div className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto max-w-6xl px-6 py-12">
+          {/* Navigation */}
+          <Link
+            href="/ai"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            &larr; Back
+          </Link>
 
-        {/* Header */}
-        <h1 className="mt-8 text-3xl font-bold">Debug Assistant</h1>
-        <p className="mt-2 text-muted-foreground leading-relaxed">
-          Index a Python project, describe a bug, and let the agent search
-          through your code to diagnose the issue.
-        </p>
+          {/* Header */}
+          <h1 className="mt-8 text-3xl font-bold">Debug Assistant</h1>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            Index a Python project, describe a bug, and let the agent search
+            through your code to diagnose the issue.
+          </p>
 
-        {/* Error Banner */}
-        {error && (
-          <div className="mt-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {error}
-          </div>
-        )}
+          {/* Error Banner */}
+          {error && (
+            <div className="mt-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
 
-        {/* 2-column grid */}
-        <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
-          {/* Left: Form */}
-          <div>
-            <h2 className="mb-4 text-lg font-semibold">Configure Debug Session</h2>
-            <DebugForm onSubmit={handleSubmit} isLoading={isLoading} />
-          </div>
+          {/* 2-column grid */}
+          <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
+            {/* Left: Form */}
+            <div>
+              <h2 className="mb-4 text-lg font-semibold">Configure Debug Session</h2>
+              <DebugForm onSubmit={handleSubmit} isLoading={isLoading} />
+            </div>
 
-          {/* Right: Timeline */}
-          <div className="flex flex-col">
-            <h2 className="mb-4 text-lg font-semibold">Agent Timeline</h2>
-            <div
-              ref={timelineRef}
-              className="flex-1 overflow-y-auto rounded-xl border border-foreground/10 bg-card p-4 min-h-96 max-h-[60vh]"
-            >
-              <AgentTimeline events={events} />
+            {/* Right: Timeline */}
+            <div className="flex flex-col">
+              <h2 className="mb-4 text-lg font-semibold">Agent Timeline</h2>
+              <div
+                ref={timelineRef}
+                className="flex-1 overflow-y-auto rounded-xl border border-foreground/10 bg-card p-4 min-h-96 max-h-[60vh]"
+              >
+                <AgentTimeline events={events} />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/ai/rag/page.tsx
+++ b/frontend/src/app/ai/rag/page.tsx
@@ -6,6 +6,7 @@ import { ChatWindow, Message, Source } from "@/components/ChatWindow";
 import { MessageInput } from "@/components/MessageInput";
 import { FileUpload } from "@/components/FileUpload";
 import { DocumentList, Document } from "@/components/DocumentList";
+import { HealthGate } from "@/components/HealthGate";
 
 export default function RagDemo() {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -14,6 +15,7 @@ export default function RagDemo() {
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
   const ingestionBaseUrl = `${apiUrl}/ingestion`;
+  const chatHealthUrl = `${apiUrl}/chat/health`;
 
   const fetchDocuments = useCallback(async () => {
     try {
@@ -153,31 +155,33 @@ export default function RagDemo() {
   );
 
   return (
-    <div className="flex h-screen flex-col bg-background text-foreground">
-      {/* Header */}
-      <header className="flex items-center justify-between border-b px-6 py-3">
-        <div className="flex items-center gap-4">
-          <Link
-            href="/ai"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            &larr; Back
-          </Link>
-          <h1 className="text-lg font-semibold">Document Q&A Assistant</h1>
-        </div>
-        <div className="flex items-center gap-4">
-          {documents?.length > 0 && (
-            <DocumentList documents={documents} onDelete={handleDelete} />
-          )}
-          <FileUpload onUploaded={handleUploaded} />
-        </div>
-      </header>
+    <HealthGate endpoint={chatHealthUrl} stack="Python AI Services" docsHref="/ai">
+      <div className="flex h-screen flex-col bg-background text-foreground">
+        {/* Header */}
+        <header className="flex items-center justify-between border-b px-6 py-3">
+          <div className="flex items-center gap-4">
+            <Link
+              href="/ai"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              &larr; Back
+            </Link>
+            <h1 className="text-lg font-semibold">Document Q&A Assistant</h1>
+          </div>
+          <div className="flex items-center gap-4">
+            {documents?.length > 0 && (
+              <DocumentList documents={documents} onDelete={handleDelete} />
+            )}
+            <FileUpload onUploaded={handleUploaded} />
+          </div>
+        </header>
 
-      {/* Chat */}
-      <ChatWindow messages={messages} />
+        {/* Chat */}
+        <ChatWindow messages={messages} />
 
-      {/* Input */}
-      <MessageInput onSend={handleSend} disabled={isStreaming} />
-    </div>
+        {/* Input */}
+        <MessageInput onSend={handleSend} disabled={isStreaming} />
+      </div>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/cicd/page.tsx
+++ b/frontend/src/app/cicd/page.tsx
@@ -1,0 +1,350 @@
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const pipelineFlowDiagram = `flowchart LR
+  subgraph PR["Pull Request to qa"]
+    direction LR
+    A[PR Created] --> B[Quality Checks]
+    B --> C{All Pass?}
+    C -->|Yes| D[Ready for Review]
+    C -->|No| E[Fix & Push]
+    E --> B
+  end
+
+  subgraph QA["Push to qa"]
+    direction LR
+    F[PR Merged] --> G[Quality Checks]
+    G --> H[Build Images]
+    H --> I[Deploy to QA]
+    I --> J[Smoke Tests]
+  end
+
+  subgraph Prod["Push to main"]
+    direction LR
+    K[Ship It] --> L[Quality Checks]
+    L --> M[Build Images]
+    M --> N[Deploy to Prod]
+    N --> O[Smoke Tests]
+  end
+`;
+
+const qaArchitectureDiagram = `flowchart TB
+  subgraph Minikube["Minikube Cluster"]
+    subgraph ProdNS["Production Namespaces"]
+      direction LR
+      P1[ai-services]
+      P2[java-tasks]
+      P3[go-ecommerce]
+      P4[monitoring]
+    end
+    subgraph QANS["QA Namespaces"]
+      direction LR
+      Q1[ai-services-qa]
+      Q2[java-tasks-qa]
+      Q3[go-ecommerce-qa]
+    end
+  end
+
+  CF1[api.kylebradshaw.dev] --> P1
+  CF2[qa-api.kylebradshaw.dev] --> Q1
+
+  QANS -.->|shared infra| ProdNS
+`;
+
+export default function CICDPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="mt-8 text-3xl font-bold">CI/CD Pipeline</h1>
+
+        {/* Overview */}
+        <section className="mt-8">
+          <p className="text-muted-foreground leading-relaxed">
+            A unified GitHub Actions pipeline built for a solo developer. One
+            workflow file handles all quality checks, image builds, and
+            deployments for three service stacks (Python, Java, Go) and a Next.js
+            frontend. Designed to automate everything from code push to production
+            deploy, with a QA environment for visual inspection before shipping.
+          </p>
+        </section>
+
+        {/* Pipeline Flow */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Pipeline Flow</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Three triggers, one workflow. Every code change follows the same path
+            through quality gates before reaching production.
+          </p>
+          <div className="mt-4">
+            <MermaidDiagram chart={pipelineFlowDiagram} />
+          </div>
+        </section>
+
+        {/* Why Unified */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Why a Unified Workflow</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            The project originally had three separate workflow files — one per
+            language stack. Each ran its own lint, test, and build jobs. For a
+            solo developer, this created unnecessary complexity: three files to
+            maintain, three sets of CI status checks to monitor, and path-based
+            filtering that occasionally skipped checks when cross-stack changes
+            were made.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Consolidating into a single workflow simplified everything. All
+            quality gates run unconditionally on every trigger — no path
+            filtering, no change detection for quality checks. This is slower
+            (every push runs all checks regardless of what changed) but simpler
+            and catches cross-stack issues that path filtering would miss.
+          </p>
+        </section>
+
+        {/* Trigger Matrix */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Trigger Matrix</h2>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-2 pr-4 text-left font-medium">Job</th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    PR to qa
+                  </th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    Push to qa
+                  </th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    Push to main
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Quality checks</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Build images</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Deploy</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">QA</td>
+                  <td className="py-2 px-4 text-center">Prod</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Smoke tests</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Quality Gates */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Quality Gates</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            22 parallel jobs run on every trigger. All must pass before images are
+            built.
+          </p>
+          <div className="mt-4 grid gap-3">
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Python</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Ruff lint + format, pytest with coverage (ingestion, chat, debug),
+                Bandit SAST, pip-audit
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Java</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Checkstyle, unit tests (4 services), integration tests with
+                Testcontainers
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Go</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                golangci-lint, go test -race (3 services), migration pipeline test
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Frontend</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                ESLint, TypeScript type check, Next.js build, npm audit
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Security</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Gitleaks (secrets), Hadolint (Dockerfiles), CORS guardrail (no
+                wildcard origins)
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Infrastructure</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                K8s manifest validation (kubeconform + kind dry-run), Grafana
+                dashboard sync, Compose smoke test
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* QA Environment */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">QA Environment</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            QA runs in the same Minikube cluster as production using separate
+            Kubernetes namespaces. Kustomize overlays patch the base manifests to
+            set QA-specific CORS origins, database names, and ingress hosts —
+            without duplicating the manifests themselves.
+          </p>
+          <div className="mt-4">
+            <MermaidDiagram chart={qaArchitectureDiagram} />
+          </div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-2 pr-4 text-left font-medium">
+                    Production
+                  </th>
+                  <th className="py-2 px-4 text-left font-medium">QA</th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">ai-services</td>
+                  <td className="py-2 px-4">ai-services-qa</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">java-tasks</td>
+                  <td className="py-2 px-4">java-tasks-qa</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">go-ecommerce</td>
+                  <td className="py-2 px-4">go-ecommerce-qa</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Image Tagging */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Image Tagging</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            All 10 service images are built in a single matrix job and pushed to
+            GitHub Container Registry. QA images use a commit-pinned tag for
+            traceability; production uses <code>:latest</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm">
+{`# QA (push to qa branch)
+ghcr.io/kabradshaw1/portfolio/ingestion:qa-abc1234
+
+# Production (push to main branch)
+ghcr.io/kabradshaw1/portfolio/ingestion:latest`}
+          </pre>
+        </section>
+
+        {/* Deploy Mechanism */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Deploy Mechanism</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            GitHub Actions joins a Tailscale VPN to reach the home server, then
+            deploys via SSH. Kustomize overlays are built on the runner and piped
+            to the server via <code>kubectl apply</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm">
+{`# CI runner joins Tailscale VPN
+- uses: tailscale/github-action@v3
+
+# Build overlay locally, apply remotely
+kubectl kustomize k8s/overlays/qa/ | \\
+  ssh PC@100.79.113.84 "kubectl apply -f -"
+
+# Restart deployments to pull new images
+ssh PC@100.79.113.84 \\
+  "kubectl rollout restart deployment -n ai-services-qa"`}
+          </pre>
+        </section>
+
+        {/* No Branch Protection */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Why No Branch Protection</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            This is a solo developer project. By the time code reaches{" "}
+            <code>main</code>, it has passed all quality checks on the PR, been
+            deployed to QA, and been visually inspected. Branch protection
+            requiring PR approval would mean one person approving their own PR —
+            ceremony with no value.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            The real protection is the CI pipeline itself: 22 quality gates that
+            run on every push. If any fail, the deploy doesn&apos;t happen.
+          </p>
+        </section>
+
+        {/* Agent Automation */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Agent Automation</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            Claude Code agents drive the development workflow from spec to
+            production. The pipeline is designed so agents can operate
+            autonomously through the QA stage, with human review at two points:
+            PR approval and the &ldquo;ship it&rdquo; command.
+          </p>
+          <div className="mt-4 rounded-lg border border-border p-4">
+            <ol className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                <strong className="text-foreground">1. Spec &rarr; Plan:</strong>{" "}
+                Agent brainstorms design, writes implementation plan
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  2. Implement &rarr; PR:
+                </strong>{" "}
+                Agent creates feature branch, implements, pushes, creates PR to{" "}
+                <code>qa</code>
+              </li>
+              <li>
+                <strong className="text-foreground">3. CI Watch:</strong> Agent
+                monitors CI, fixes lint/format/config failures autonomously
+              </li>
+              <li>
+                <strong className="text-foreground">4. QA Deploy:</strong> Kyle
+                reviews PR, merges. QA deploys automatically.
+              </li>
+              <li>
+                <strong className="text-foreground">5. Ship It:</strong> Kyle
+                inspects QA, tells agent to ship. Agent merges to main, watches
+                prod deploy, cleans up.
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        {/* Smoke Tests */}
+        <section className="mt-12 mb-16">
+          <h2 className="text-xl font-semibold">Smoke Tests</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            After every deployment, automated smoke tests verify the services are
+            healthy. QA runs health endpoint checks against{" "}
+            <code>qa-api.kylebradshaw.dev</code>. Production runs Playwright
+            tests against the live site — including an end-to-end RAG flow that
+            uploads a PDF, asks a question, and verifies a streamed response.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/go/ecommerce/layout.tsx
+++ b/frontend/src/app/go/ecommerce/layout.tsx
@@ -1,5 +1,11 @@
+"use client";
+
 import { GoSubHeader } from "@/components/go/GoSubHeader";
 import { AiAssistantDrawer } from "@/components/go/AiAssistantDrawer";
+import { HealthGate } from "@/components/HealthGate";
+
+const goEcommerceUrl =
+  process.env.NEXT_PUBLIC_GO_ECOMMERCE_URL || "http://localhost:8092";
 
 export default function GoEcommerceLayout({
   children,
@@ -7,10 +13,14 @@ export default function GoEcommerceLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <HealthGate
+      endpoint={`${goEcommerceUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
       <GoSubHeader />
       {children}
       <AiAssistantDrawer />
-    </>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/go/login/page.tsx
+++ b/frontend/src/app/go/login/page.tsx
@@ -6,12 +6,22 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { GoGoogleLoginButton } from "@/components/go/GoGoogleLoginButton";
 import { useGoAuth } from "@/components/go/GoAuthProvider";
+import { HealthGate } from "@/components/HealthGate";
+
+const goAuthUrl =
+  process.env.NEXT_PUBLIC_GO_AUTH_URL || "http://localhost:8091";
 
 export default function GoLoginPage() {
   return (
-    <Suspense fallback={<div className="mx-auto max-w-sm px-6 py-12">Loading…</div>}>
-      <GoLoginPageInner />
-    </Suspense>
+    <HealthGate
+      endpoint={`${goAuthUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <Suspense fallback={<div className="mx-auto max-w-sm px-6 py-12">Loading…</div>}>
+        <GoLoginPageInner />
+      </Suspense>
+    </HealthGate>
   );
 }
 

--- a/frontend/src/app/go/register/page.tsx
+++ b/frontend/src/app/go/register/page.tsx
@@ -6,6 +6,10 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { GoGoogleLoginButton } from "@/components/go/GoGoogleLoginButton";
 import { useGoAuth } from "@/components/go/GoAuthProvider";
+import { HealthGate } from "@/components/HealthGate";
+
+const goAuthUrl =
+  process.env.NEXT_PUBLIC_GO_AUTH_URL || "http://localhost:8091";
 
 export default function GoRegisterPage() {
   const router = useRouter();
@@ -34,58 +38,64 @@ export default function GoRegisterPage() {
   );
 
   return (
-    <div className="mx-auto max-w-sm px-6 py-12">
-      <h1 className="text-2xl font-bold">Create account</h1>
-      <form onSubmit={handleSubmit} className="mt-6 space-y-3">
-        <input
-          type="text"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-          disabled={busy}
-          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
-        />
-        <input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          disabled={busy}
-          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
-        />
-        <input
-          type="password"
-          placeholder="Password (min 8 chars)"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          minLength={8}
-          disabled={busy}
-          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
-        />
-        <Button type="submit" disabled={busy} className="w-full">
-          {busy ? "Creating account…" : "Create account"}
-        </Button>
-      </form>
+    <HealthGate
+      endpoint={`${goAuthUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <div className="mx-auto max-w-sm px-6 py-12">
+        <h1 className="text-2xl font-bold">Create account</h1>
+        <form onSubmit={handleSubmit} className="mt-6 space-y-3">
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            disabled={busy}
+            className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            disabled={busy}
+            className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
+          />
+          <input
+            type="password"
+            placeholder="Password (min 8 chars)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={8}
+            disabled={busy}
+            className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
+          />
+          <Button type="submit" disabled={busy} className="w-full">
+            {busy ? "Creating account…" : "Create account"}
+          </Button>
+        </form>
 
-      <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
-        <div className="h-px flex-1 bg-foreground/10" />
-        <span>or</span>
-        <div className="h-px flex-1 bg-foreground/10" />
+        <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
+          <div className="h-px flex-1 bg-foreground/10" />
+          <span>or</span>
+          <div className="h-px flex-1 bg-foreground/10" />
+        </div>
+
+        <GoGoogleLoginButton />
+
+        {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link href="/go/login" className="underline hover:text-foreground">
+            Sign in
+          </Link>
+        </p>
       </div>
-
-      <GoGoogleLoginButton />
-
-      {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
-
-      <p className="mt-6 text-center text-sm text-muted-foreground">
-        Already have an account?{" "}
-        <Link href="/go/login" className="underline hover:text-foreground">
-          Sign in
-        </Link>
-      </p>
-    </div>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/java/dashboard/page.tsx
+++ b/frontend/src/app/java/dashboard/page.tsx
@@ -1,10 +1,26 @@
+"use client";
+
 import { Suspense } from "react";
+import { HealthGate } from "@/components/HealthGate";
 import { DashboardClient } from "./dashboard-client";
+
+const gatewayUrl =
+  process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:8080";
 
 export default function DashboardPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading…</div>}>
-      <DashboardClient />
-    </Suspense>
+    <HealthGate
+      endpoint={`${gatewayUrl}/actuator/health`}
+      stack="Java Task Management"
+      docsHref="/java"
+    >
+      <Suspense
+        fallback={
+          <div className="p-6 text-sm text-muted-foreground">Loading…</div>
+        }
+      >
+        <DashboardClient />
+      </Suspense>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/java/tasks/layout.tsx
+++ b/frontend/src/app/java/tasks/layout.tsx
@@ -1,4 +1,10 @@
+"use client";
+
 import { JavaSubHeader } from "@/components/java/JavaSubHeader";
+import { HealthGate } from "@/components/HealthGate";
+
+const gatewayUrl =
+  process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:8080";
 
 export default function JavaTasksLayout({
   children,
@@ -6,9 +12,13 @@ export default function JavaTasksLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <HealthGate
+      endpoint={`${gatewayUrl}/actuator/health`}
+      stack="Java Task Management"
+      docsHref="/java"
+    >
       <JavaSubHeader />
       {children}
-    </>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -109,6 +109,24 @@ export default function Home() {
               </CardContent>
             </Card>
           </Link>
+          <Link href="/cicd" className="block">
+            <Card className="hover:ring-foreground/20 transition-all">
+              <CardHeader>
+                <CardTitle>CI/CD Pipeline</CardTitle>
+                <CardDescription>
+                  Unified GitHub Actions workflow with QA environment and agent
+                  automation
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-sm">
+                  A single workflow handles quality checks, image builds, and
+                  deployments for three service stacks — designed for a solo
+                  developer with automated spec-to-production delivery.
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/components/HealthGate.tsx
+++ b/frontend/src/components/HealthGate.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+interface HealthGateProps {
+  endpoint: string;
+  stack: string;
+  docsHref: string;
+  children: React.ReactNode;
+}
+
+export function HealthGate({ endpoint, stack, docsHref, children }: HealthGateProps) {
+  const [status, setStatus] = useState<"checking" | "healthy" | "unhealthy">("checking");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    fetch(endpoint, { signal: controller.signal })
+      .then((res) => {
+        setStatus(res.ok ? "healthy" : "unhealthy");
+      })
+      .catch(() => {
+        setStatus("unhealthy");
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+      });
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, [endpoint]);
+
+  if (status === "checking") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-background">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (status === "unhealthy") {
+    const message =
+      process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
+      "The backend services are currently offline for maintenance. Please check back later.";
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-background px-6">
+        <div className="max-w-md text-center">
+          <div className="text-5xl">🔧</div>
+          <h2 className="mt-4 text-2xl font-bold text-foreground">
+            Server Maintenance
+          </h2>
+          <p className="mt-3 text-muted-foreground">{message}</p>
+          <div className="mt-6 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
+            <strong className="text-foreground">{stack}</strong> is currently
+            unavailable.
+          </div>
+          <Link
+            href={docsHref}
+            className="mt-6 inline-block text-sm text-primary hover:underline"
+          >
+            &larr; View documentation instead
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -23,17 +23,20 @@ export function SiteHeader() {
             Kyle Bradshaw
           </Link>
           <nav className="flex items-center gap-4">
-            <Link href="/ai" className={navLinkClass("/ai")}>
-              AI
-            </Link>
-            <Link href="/java" className={navLinkClass("/java")}>
-              Java
-            </Link>
             <Link href="/go" className={navLinkClass("/go")}>
               Go
             </Link>
             <Link href="/aws" className={navLinkClass("/aws")}>
               AWS
+            </Link>
+            <Link href="/java" className={navLinkClass("/java")}>
+              Java
+            </Link>
+            <Link href="/ai" className={navLinkClass("/ai")}>
+              AI
+            </Link>
+            <Link href="/cicd" className={navLinkClass("/cicd")}>
+              CI/CD
             </Link>
           </nav>
         </div>


### PR DESCRIPTION
## Summary

- Add `HealthGate` component that checks backend health on page load, shows maintenance screen when services are down
- Wrap all interactive demo pages (AI rag/debug, Java tasks/dashboard, Go ecommerce/login/register) with health gates
- Add CI/CD pipeline documentation page at `/cicd` with full technical walkthrough (diagrams, trigger matrix, code snippets)
- Add CI/CD card to homepage
- Reorder site header navigation to match homepage card order: Go, AWS, Java, AI, CI/CD
- Add `NEXT_PUBLIC_MAINTENANCE_MESSAGE` env var to Vercel (set to "Migrating to Linux for improved performance and reliability.")

## Test plan

- [ ] Verify demo pages render normally when backend is up
- [ ] Verify maintenance screen appears when backend is down (stop Ollama/services)
- [ ] Verify CI/CD page renders with all sections and diagrams
- [ ] Verify nav order matches homepage: Go, AWS, Java, AI, CI/CD
- [ ] Verify `make preflight-frontend` passes (lint, tsc, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)