### PR TITLE
feat: restore E2E staging checks and update CI/CD docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /services/ingestion
     schedule:
       interval: weekly
-    target-branch: staging
+    target-branch: qa
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -16,7 +16,7 @@ updates:
     directory: /services/chat
     schedule:
       interval: weekly
-    target-branch: staging
+    target-branch: qa
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -28,7 +28,7 @@ updates:
     directory: /frontend
     schedule:
       interval: weekly
-    target-branch: staging
+    target-branch: qa
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
@@ -38,7 +38,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    target-branch: staging
+    target-branch: qa
     open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,40 @@ jobs:
       - name: Build
         run: npm run build
 
+  e2e-mocked:
+    name: E2E Staging Checks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/qa'
+    needs: [frontend-checks]
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+
   k8s-manifest-validation:
     name: K8s Manifest Validation
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Current ADRs:
 
 **Per-branch rules for Claude Code:**
 
-- **On a feature branch:** implement, commit, push, create PR to `qa`. Don't ask before pushing — just push. The CI pipeline catches problems.
+- **On a feature branch:** implement, commit, push, create PR to `qa`. Don't ask before pushing or creating the PR — just do it. The CI pipeline catches problems.
 - **On `qa`:** commit and push autonomously. Don't ask before pushing. Watch CI after pushing and debug failures. For CI fixes: lint errors, formatting, type errors, and config issues are fine to fix autonomously. For anything that changes application behavior (logic, API contracts, data flow), stop and check with Kyle before fixing.
 - **On `main`:** never push autonomously. When Kyle explicitly says to merge/ship to main, handle the full flow: merge `qa` into `main`, push, watch CI, debug minor failures, clean up worktree, delete feature branch (local + remote).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,15 @@ Current ADRs:
 
 **Per-branch rules for Claude Code:**
 
-- **On a feature branch:** implement, commit, push, and wait for all CI checks to pass before creating the PR to `qa`. Don't ask before pushing or creating the PR — just do it. If CI fails, fix it and push again. Only create the PR once all checks are green.
+- **On a feature branch:** The full autonomous flow is:
+  1. **Spec approved** — Kyle reviews and approves the spec. This is the human gate.
+  2. **Plan + execute** — Write the implementation plan and execute it. Don't ask to approve the plan — just do it.
+  3. **Push** — Commit and push. Don't ask before pushing.
+  4. **Watch CI** — Monitor the GitHub Actions run. Wait for all checks to complete.
+  5. **If CI passes** — Create the PR to `qa` and notify Kyle.
+  6. **If CI fails** — Debug the failure. Before fixing, check that the fix still complies with the spec that started this work. Push the fix and go back to step 4. Repeat until all checks are green, then create the PR.
+  
+  Don't ask for approval at any point in this flow. The spec review is the gate — everything after that is autonomous.
 - **On `qa`:** commit and push autonomously. Don't ask before pushing. Watch CI after pushing and debug failures. For CI fixes: lint errors, formatting, type errors, and config issues are fine to fix autonomously. For anything that changes application behavior (logic, API contracts, data flow), stop and check with Kyle before fixing.
 - **On `main`:** never push autonomously. When Kyle explicitly says to merge/ship to main, handle the full flow: merge `qa` into `main`, push, watch CI, debug minor failures, clean up worktree, delete feature branch (local + remote).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,8 +149,8 @@ Current ADRs:
 
 **Per-branch rules for Claude Code:**
 
-- **On a feature branch:** implement, commit, push, create PR to `qa`.
-- **On `qa`:** commit and push when Kyle asks. Watch CI after pushing and debug failures. For CI fixes: lint errors, formatting, type errors, and config issues are fine to fix autonomously. For anything that changes application behavior (logic, API contracts, data flow), stop and check with Kyle before fixing.
+- **On a feature branch:** implement, commit, push, create PR to `qa`. Don't ask before pushing — just push. The CI pipeline catches problems.
+- **On `qa`:** commit and push autonomously. Don't ask before pushing. Watch CI after pushing and debug failures. For CI fixes: lint errors, formatting, type errors, and config issues are fine to fix autonomously. For anything that changes application behavior (logic, API contracts, data flow), stop and check with Kyle before fixing.
 - **On `main`:** never push autonomously. When Kyle explicitly says to merge/ship to main, handle the full flow: merge `qa` into `main`, push, watch CI, debug minor failures, clean up worktree, delete feature branch (local + remote).
 
 Claude Code determines the current branch via `git branch --show-current` and follows the rules for that branch. No special mode or prompt needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Current ADRs:
 
 **Per-branch rules for Claude Code:**
 
-- **On a feature branch:** implement, commit, push, create PR to `qa`. Don't ask before pushing or creating the PR — just do it. The CI pipeline catches problems.
+- **On a feature branch:** implement, commit, push, and wait for all CI checks to pass before creating the PR to `qa`. Don't ask before pushing or creating the PR — just do it. If CI fails, fix it and push again. Only create the PR once all checks are green.
 - **On `qa`:** commit and push autonomously. Don't ask before pushing. Watch CI after pushing and debug failures. For CI fixes: lint errors, formatting, type errors, and config issues are fine to fix autonomously. For anything that changes application behavior (logic, API contracts, data flow), stop and check with Kyle before fixing.
 - **On `main`:** never push autonomously. When Kyle explicitly says to merge/ship to main, handle the full flow: merge `qa` into `main`, push, watch CI, debug minor failures, clean up worktree, delete feature branch (local + remote).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,3 +188,6 @@ Single unified workflow (`.github/workflows/ci.yml`) handles all CI/CD:
 **Compose-smoke realism:** Job 3 (`compose-smoke`) runs the Python AI stack via `docker-compose.yml` with a mocked Ollama. Any change to Python service configuration (env vars, ports, depends_on, env_file references) must be reflected in BOTH `docker-compose.yml` and the corresponding k8s manifests under `k8s/ai-services/`, or compose-smoke will drift from prod and stop catching real regressions.
 
 **Tailscale authkey:** Expires every 90 days (free plan). Regenerate at Tailscale admin → Keys and update `TAILSCALE_AUTHKEY` in GitHub repo secrets.
+
+## Browser Console Configuration
+When I need to configure something in a console, first check to see if you can do it from the command line tool.  If not, then please give me a link to the exact pages I will need to visit, and as much details as you can about what I will need to do.  Consoles I have visited in c

--- a/docs/brainstorm/CLAUDE.md
+++ b/docs/brainstorm/CLAUDE.md
@@ -1,0 +1,1 @@
+Your job is to help me brainstorm.  I want to give you an idea or a project, and I want to you think of as many questions as you can, to help me think through it.  When you get an answer, please create a .txt file with fallow up questions.  When passed a text file, please ask those questions

--- a/docs/debian-12-dual-boot.md
+++ b/docs/debian-12-dual-boot.md
@@ -1,0 +1,403 @@
+# Debian 12 Dual Boot Install on Windows PC
+
+Step-by-step guide for installing Debian 12 alongside Windows on the PC at 100.79.113.84 (RTX 3090). Assumes SSH access from the Mac and prior Debian install experience.
+
+## Prerequisites
+
+- USB flash drive (4GB+)
+- Physical access to the Windows PC for BIOS/boot menu and installer
+- Keyboard + monitor connected to the PC
+- Back up anything important on the Windows side (Minikube PVCs, scripts, etc.)
+
+## Phase 1: Prepare on Windows (Before Reboot)
+
+### 1.1 Back Up Critical Files
+
+On the Windows PC, back up anything not in git:
+
+```
+C:\Users\PC\Scripts\Restart-Services.ps1
+C:\Users\PC\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+```
+
+Also note down:
+- Minikube config and any custom K8s manifests not in the repo
+- Cloudflared tunnel config (usually `C:\Users\PC\.cloudflared\config.yml`)
+- Ollama model list (`ollama list`)
+- Any environment variables or registry tweaks
+
+### 1.2 Shrink the Windows Partition
+
+1. Open **Disk Management** (right-click Start > Disk Management)
+2. Right-click the main NTFS partition (usually `C:`) > **Shrink Volume**
+3. Allocate at least **100 GB** for Debian (more if you plan to use it heavily)
+4. Leave the freed space as **Unallocated** — the Debian installer will use it
+5. Note which disk number and partition layout you see — you'll need this during install
+
+### 1.3 Create the Bootable USB
+
+Download the Debian 12 netinst ISO from https://www.debian.org/download
+
+On the Windows PC, use **Rufus** to write the ISO to the USB drive:
+1. Download Rufus from https://rufus.ie
+2. Insert USB drive
+3. Select the Debian ISO
+4. Partition scheme: **GPT** (for UEFI — almost certainly what this PC uses)
+5. File system: **FAT32**
+6. Click Start, wait for completion
+
+### 1.4 Check BIOS Settings
+
+Reboot into BIOS (usually DEL or F2 at POST):
+- **Secure Boot:** Note whether it's enabled or disabled. If enabled, you'll need to handle module signing for NVIDIA drivers later. Consider disabling it to simplify the NVIDIA setup.
+- **Boot order:** Make sure USB boot is enabled
+- Save and exit
+
+## Phase 2: Install Debian 12
+
+### 2.1 Boot the Installer
+
+1. Insert the USB drive
+2. Reboot and press **F12** (or your BIOS boot menu key) to select the USB
+3. Choose **Graphical Install** or **Install** (text mode works fine too)
+
+### 2.2 Walk Through the Installer
+
+Most of this is straightforward — the key steps:
+
+- **Language/locale/keyboard:** Your preference
+- **Hostname:** Something like `pc-debian` (different from the Windows hostname to avoid confusion)
+- **Domain:** Leave blank
+- **Root password:** Set one, or leave blank to give your user sudo via the installer
+- **User account:** Create your user (e.g., `kyle`)
+- **Clock/timezone:** Match your location
+
+### 2.3 Partition the Disk (Important Step)
+
+Choose **Manual** partitioning for full control.
+
+You'll see the existing Windows partitions plus the unallocated space you freed earlier. In the free space, create:
+
+| Mount Point | Size | Type | Notes |
+|---|---|---|---|
+| `/` | 40-60 GB | ext4 | Root filesystem |
+| `/home` | Remaining space minus swap | ext4 | User data |
+| swap | 8-16 GB | swap | Match your RAM size or half of it |
+
+Alternatively, for simplicity: just create a single `/` partition using all the free space, plus a swap partition. The installer will also offer a swap file option.
+
+**Do NOT touch the existing Windows partitions (NTFS, EFI System Partition, Recovery).** If you see an existing EFI System Partition (~100-500 MB, FAT32), the Debian bootloader (GRUB) will install there alongside the Windows bootloader.
+
+### 2.4 Software Selection
+
+At the **tasksel** screen:
+- Deselect **Debian desktop environment** and any DE (GNOME, KDE, etc.) — you'll be SSHing in, no desktop needed
+- Select **SSH server**
+- Select **standard system utilities**
+
+This keeps the install minimal, which is what you want for a headless server you access over SSH.
+
+### 2.5 Install GRUB
+
+- Install GRUB to the EFI partition when prompted
+- The installer should detect Windows and add it to the GRUB menu automatically
+
+### 2.6 Reboot
+
+Remove the USB drive when prompted. On reboot, you should see the GRUB menu with:
+- Debian GNU/Linux
+- Windows Boot Manager
+
+Test both options to confirm dual boot works.
+
+## Phase 3: Post-Install Debian Setup (Over SSH)
+
+From here, work from your Mac over SSH.
+
+### 3.1 Find the Debian IP and SSH In
+
+If you're on Tailscale, the IP may differ from the Windows Tailscale IP since it's a different OS. On the PC (with keyboard/monitor still connected):
+
+```bash
+ip addr show
+```
+
+Note the LAN IP, then from your Mac:
+
+```bash
+ssh kyle@<debian-ip>
+```
+
+### 3.2 Set Up SSH Key Auth
+
+From your Mac:
+
+```bash
+ssh-copy-id kyle@<debian-ip>
+```
+
+### 3.3 Update and Install Essentials
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y curl wget git build-essential software-properties-common
+```
+
+### 3.4 Install Node.js (for Claude Code later)
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+
+### 3.5 Install Tailscale (to Keep the Same SSH Workflow)
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+Authenticate when prompted. After this, you'll have a stable Tailscale IP for the Debian install, and can SSH in the same way you do with Windows.
+
+## Phase 4: NVIDIA Driver Setup
+
+This is the part that can be tricky. Do this over SSH from your Mac.
+
+### 4.1 Add Non-Free Repositories
+
+Edit the apt sources:
+
+```bash
+sudo nano /etc/apt/sources.list
+```
+
+Make sure each `deb` line includes `non-free non-free-firmware`. For example:
+
+```
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+```
+
+Then update:
+
+```bash
+sudo apt update
+```
+
+### 4.2 Install Kernel Headers
+
+Required for building the NVIDIA kernel module:
+
+```bash
+sudo apt install -y linux-headers-$(uname -r)
+```
+
+### 4.3 Blacklist Nouveau
+
+The open-source nouveau driver conflicts with the proprietary NVIDIA driver:
+
+```bash
+sudo bash -c 'cat > /etc/modprobe.d/blacklist-nouveau.conf << EOF
+blacklist nouveau
+options nouveau modeset=0
+EOF'
+
+sudo update-initramfs -u
+```
+
+### 4.4 Install the NVIDIA Driver
+
+```bash
+sudo apt install -y nvidia-driver firmware-misc-nonfree
+```
+
+This pulls in the appropriate driver version for Debian 12. For an RTX 3090, the packaged driver (535.x+) supports it fully.
+
+Reboot after install:
+
+```bash
+sudo reboot
+```
+
+### 4.5 Verify the Driver
+
+After reboot, SSH back in and check:
+
+```bash
+nvidia-smi
+```
+
+You should see the RTX 3090 listed with driver version and CUDA version. If this works, the hard part is done.
+
+### 4.6 If Secure Boot Is Enabled
+
+If you left Secure Boot on, the NVIDIA kernel module needs to be signed. During the `nvidia-driver` install, Debian will prompt you to set a MOK (Machine Owner Key) password. On the next reboot:
+
+1. The MOK Manager appears before GRUB
+2. Select **Enroll MOK**
+3. Enter the password you set during install
+4. Continue boot
+
+If you missed this or it didn't work, easiest fix is to disable Secure Boot in BIOS and rebuild the module:
+
+```bash
+sudo dpkg-reconfigure nvidia-driver
+sudo reboot
+```
+
+### 4.7 Install CUDA Toolkit (Optional — If You Need CUDA Beyond Ollama)
+
+```bash
+sudo apt install -y nvidia-cuda-toolkit
+nvcc --version
+```
+
+Ollama bundles its own CUDA runtime, so this is only needed if you plan to run other CUDA workloads.
+
+## Phase 5: Install Ollama
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+Verify it detects the GPU:
+
+```bash
+ollama serve &
+ollama run qwen2.5:14b "Hello"
+```
+
+Check that the output of `ollama serve` mentions the RTX 3090 / CUDA.
+
+Pull the models you need:
+
+```bash
+ollama pull qwen2.5:14b
+ollama pull nomic-embed-text
+```
+
+### 5.1 Make Ollama Start on Boot
+
+Ollama's install script typically creates a systemd service. Verify:
+
+```bash
+sudo systemctl enable ollama
+sudo systemctl start ollama
+sudo systemctl status ollama
+```
+
+### 5.2 Bind Ollama to All Interfaces
+
+By default Ollama only listens on localhost. To reach it from other machines or K8s pods:
+
+```bash
+sudo systemctl edit ollama
+```
+
+Add:
+
+```
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0"
+```
+
+Then restart:
+
+```bash
+sudo systemctl restart ollama
+```
+
+## Phase 6: Switching Between OSes
+
+### At Boot
+
+GRUB shows the OS selection menu for ~5 seconds, then boots the default (Debian). To boot Windows, select it from the menu.
+
+To change the default OS or timeout, edit `/etc/default/grub` on the Debian side:
+
+```bash
+sudo nano /etc/default/grub
+```
+
+- `GRUB_DEFAULT=0` — Debian is first (default), Windows is typically entry 2 or higher
+- `GRUB_TIMEOUT=10` — seconds to wait before auto-booting default
+
+After editing:
+
+```bash
+sudo update-grub
+```
+
+### Remote Switching (Over SSH)
+
+You can reboot into Windows from Debian remotely:
+
+```bash
+# Find the Windows entry number
+grep -i windows /boot/grub/grub.cfg
+
+# Set Windows as next boot (one-time), then reboot
+sudo grub-reboot 2  # adjust number based on grep output
+sudo reboot
+```
+
+To get back to Debian from Windows, you'd need to reboot and either:
+- Let GRUB timeout to the Debian default, or
+- Have someone select Debian from the GRUB menu, or
+- Set the BIOS to always show the boot menu
+
+### Network Considerations
+
+Each OS will have its own Tailscale IP. Your Mac SSH config can have entries for both:
+
+```
+# ~/.ssh/config on your Mac
+Host pc-windows
+    HostName 100.79.113.84
+    User PC
+
+Host pc-debian
+    HostName <debian-tailscale-ip>
+    User kyle
+```
+
+## Troubleshooting
+
+### GRUB Doesn't Show Windows
+
+```bash
+sudo os-prober
+sudo update-grub
+```
+
+If `os-prober` is disabled by default (Debian 12 does this), enable it:
+
+```bash
+echo 'GRUB_DISABLE_OS_PROBER=false' | sudo tee -a /etc/default/grub
+sudo update-grub
+```
+
+### nvidia-smi Shows "No devices found"
+
+1. Confirm the GPU is visible: `lspci | grep -i nvidia`
+2. Check if nouveau is still loaded: `lsmod | grep nouveau` (should be empty)
+3. Check if nvidia module is loaded: `lsmod | grep nvidia`
+4. If not loaded: `sudo modprobe nvidia` and check `dmesg | tail` for errors
+5. Secure Boot issue? See section 4.6
+
+### SSH Connection Refused After Debian Install
+
+- Verify `sshd` is running: `sudo systemctl status ssh`
+- Check firewall: `sudo iptables -L` (Debian 12 has no firewall rules by default)
+- Verify the IP: `ip addr show`
+
+### Lost Windows After Debian Install
+
+This shouldn't happen if you didn't touch the Windows partitions. But if GRUB doesn't show Windows:
+
+```bash
+sudo apt install os-prober
+sudo os-prober
+sudo update-grub
+```

--- a/docs/superpowers/plans/2026-04-13-cicd-docs-maintenance-pages.md
+++ b/docs/superpowers/plans/2026-04-13-cicd-docs-maintenance-pages.md
@@ -1,0 +1,939 @@
+# CI/CD Documentation Page & Maintenance Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add health-check maintenance screens to all interactive demo pages and a CI/CD pipeline documentation page to the portfolio site.
+
+**Architecture:** A shared `<HealthGate>` client component checks a health endpoint on mount and renders either the demo content or a maintenance screen. The CI/CD page is a static documentation page using the same layout pattern as the existing `/ai`, `/java`, `/go` overview pages. The site header navigation is reordered to match the homepage card order.
+
+**Tech Stack:** Next.js, TypeScript, React, shadcn/ui, Mermaid (diagrams)
+
+**Spec:** `docs/superpowers/specs/2026-04-13-cicd-docs-maintenance-pages-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `frontend/src/components/HealthGate.tsx` | Health-check wrapper: checks endpoint on mount, renders children or maintenance screen |
+| `frontend/src/app/cicd/page.tsx` | CI/CD pipeline documentation page with diagrams and code snippets |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/SiteHeader.tsx` | Reorder nav links (Go, AWS, Java, AI, CI/CD), add CI/CD link |
+| `frontend/src/app/ai/rag/page.tsx` | Wrap content with HealthGate |
+| `frontend/src/app/ai/debug/page.tsx` | Wrap content with HealthGate |
+| `frontend/src/app/java/tasks/layout.tsx` | Wrap content with HealthGate |
+| `frontend/src/app/java/dashboard/page.tsx` | Wrap content with HealthGate |
+| `frontend/src/app/go/ecommerce/layout.tsx` | Wrap content with HealthGate |
+| `frontend/src/app/go/login/page.tsx` | Wrap content with HealthGate |
+| `frontend/src/app/go/register/page.tsx` | Wrap content with HealthGate |
+
+---
+
+## Task 1: Create HealthGate Component
+
+**Files:**
+- Create: `frontend/src/components/HealthGate.tsx`
+
+- [ ] **Step 1: Create the HealthGate component**
+
+```tsx
+// frontend/src/components/HealthGate.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+interface HealthGateProps {
+  endpoint: string;
+  stack: string;
+  docsHref: string;
+  children: React.ReactNode;
+}
+
+export function HealthGate({ endpoint, stack, docsHref, children }: HealthGateProps) {
+  const [status, setStatus] = useState<"checking" | "healthy" | "unhealthy">("checking");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    fetch(endpoint, { signal: controller.signal })
+      .then((res) => {
+        setStatus(res.ok ? "healthy" : "unhealthy");
+      })
+      .catch(() => {
+        setStatus("unhealthy");
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+      });
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, [endpoint]);
+
+  if (status === "checking") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-background">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (status === "unhealthy") {
+    const message =
+      process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
+      "The backend services are currently offline for maintenance. Please check back later.";
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-background px-6">
+        <div className="max-w-md text-center">
+          <div className="text-5xl">🔧</div>
+          <h2 className="mt-4 text-2xl font-bold text-foreground">
+            Server Maintenance
+          </h2>
+          <p className="mt-3 text-muted-foreground">{message}</p>
+          <div className="mt-6 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
+            <strong className="text-foreground">{stack}</strong> is currently
+            unavailable.
+          </div>
+          <Link
+            href={docsHref}
+            className="mt-6 inline-block text-sm text-primary hover:underline"
+          >
+            &larr; View documentation instead
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors related to HealthGate.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/HealthGate.tsx
+git commit -m "feat: add HealthGate component for backend health checks"
+```
+
+---
+
+## Task 2: Wrap AI Demo Pages with HealthGate
+
+**Files:**
+- Modify: `frontend/src/app/ai/rag/page.tsx`
+- Modify: `frontend/src/app/ai/debug/page.tsx`
+
+- [ ] **Step 1: Wrap the RAG demo page**
+
+In `frontend/src/app/ai/rag/page.tsx`, add the import at the top (after the existing imports):
+
+```tsx
+import { HealthGate } from "@/components/HealthGate";
+```
+
+Then wrap the return JSX. The current return starts with:
+```tsx
+return (
+    <div className="flex h-screen flex-col bg-background text-foreground">
+```
+
+Change the return to:
+```tsx
+  const chatHealthUrl = `${apiUrl}/chat/health`;
+
+  return (
+    <HealthGate endpoint={chatHealthUrl} stack="Python AI Services" docsHref="/ai">
+      <div className="flex h-screen flex-col bg-background text-foreground">
+```
+
+And add the closing `</HealthGate>` before the final `);`:
+```tsx
+      </div>
+    </HealthGate>
+  );
+```
+
+- [ ] **Step 2: Wrap the Debug demo page**
+
+In `frontend/src/app/ai/debug/page.tsx`, add the import:
+
+```tsx
+import { HealthGate } from "@/components/HealthGate";
+```
+
+The debug page's return starts with a containing `<div>`. Wrap similarly:
+
+```tsx
+  const debugHealthUrl = `${apiUrl}/debug/health`;
+
+  return (
+    <HealthGate endpoint={debugHealthUrl} stack="Python AI Services" docsHref="/ai">
+```
+
+And close `</HealthGate>` before the final `);`.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/ai/rag/page.tsx frontend/src/app/ai/debug/page.tsx
+git commit -m "feat: add health gate to AI demo pages"
+```
+
+---
+
+## Task 3: Wrap Java Demo Pages with HealthGate
+
+**Files:**
+- Modify: `frontend/src/app/java/tasks/layout.tsx`
+- Modify: `frontend/src/app/java/dashboard/page.tsx`
+
+- [ ] **Step 1: Wrap the Java tasks layout**
+
+The Java tasks layout at `frontend/src/app/java/tasks/layout.tsx` currently wraps children with a `JavaSubHeader`. Adding HealthGate here covers all task sub-pages (task list, project detail, task detail, reset-password).
+
+This layout is currently a server component (no "use client" directive). HealthGate is a client component, so the layout needs to become a client component OR we wrap children in a client component. The simplest approach: add "use client" and import HealthGate.
+
+Replace the entire file content:
+
+```tsx
+"use client";
+
+import { JavaSubHeader } from "@/components/java/JavaSubHeader";
+import { HealthGate } from "@/components/HealthGate";
+
+const gatewayUrl =
+  process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:8080";
+
+export default function JavaTasksLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <HealthGate
+      endpoint={`${gatewayUrl}/actuator/health`}
+      stack="Java Task Management"
+      docsHref="/java"
+    >
+      <JavaSubHeader />
+      {children}
+    </HealthGate>
+  );
+}
+```
+
+- [ ] **Step 2: Wrap the Java dashboard page**
+
+The dashboard page at `frontend/src/app/java/dashboard/page.tsx` is a server component that renders a Suspense boundary around `DashboardClient`. Replace the entire file:
+
+```tsx
+"use client";
+
+import { Suspense } from "react";
+import { HealthGate } from "@/components/HealthGate";
+import { DashboardClient } from "./dashboard-client";
+
+const gatewayUrl =
+  process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:8080";
+
+export default function DashboardPage() {
+  return (
+    <HealthGate
+      endpoint={`${gatewayUrl}/actuator/health`}
+      stack="Java Task Management"
+      docsHref="/java"
+    >
+      <Suspense
+        fallback={
+          <div className="p-6 text-sm text-muted-foreground">Loading…</div>
+        }
+      >
+        <DashboardClient />
+      </Suspense>
+    </HealthGate>
+  );
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/java/tasks/layout.tsx frontend/src/app/java/dashboard/page.tsx
+git commit -m "feat: add health gate to Java demo pages"
+```
+
+---
+
+## Task 4: Wrap Go Demo Pages with HealthGate
+
+**Files:**
+- Modify: `frontend/src/app/go/ecommerce/layout.tsx`
+- Modify: `frontend/src/app/go/login/page.tsx`
+- Modify: `frontend/src/app/go/register/page.tsx`
+
+- [ ] **Step 1: Wrap the Go ecommerce layout**
+
+The Go ecommerce layout at `frontend/src/app/go/ecommerce/layout.tsx` currently renders GoSubHeader, children, and AiAssistantDrawer. It's a server component. Replace the entire file:
+
+```tsx
+"use client";
+
+import { GoSubHeader } from "@/components/go/GoSubHeader";
+import { AiAssistantDrawer } from "@/components/go/AiAssistantDrawer";
+import { HealthGate } from "@/components/HealthGate";
+
+const goEcommerceUrl =
+  process.env.NEXT_PUBLIC_GO_ECOMMERCE_URL || "http://localhost:8092";
+
+export default function GoEcommerceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <HealthGate
+      endpoint={`${goEcommerceUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <GoSubHeader />
+      {children}
+      <AiAssistantDrawer />
+    </HealthGate>
+  );
+}
+```
+
+- [ ] **Step 2: Wrap the Go login page**
+
+In `frontend/src/app/go/login/page.tsx`, add the import after the existing imports:
+
+```tsx
+import { HealthGate } from "@/components/HealthGate";
+```
+
+The page renders a `<Suspense>` wrapper around `<GoLoginPageInner />`. Wrap the Suspense in HealthGate. Find the return in the `GoLoginPage` function:
+
+```tsx
+export default function GoLoginPage() {
+  return (
+    <Suspense fallback={<div className="mx-auto max-w-sm px-6 py-12">Loading…</div>}>
+      <GoLoginPageInner />
+    </Suspense>
+  );
+}
+```
+
+Replace with:
+
+```tsx
+const goAuthUrl =
+  process.env.NEXT_PUBLIC_GO_AUTH_URL || "http://localhost:8091";
+
+export default function GoLoginPage() {
+  return (
+    <HealthGate
+      endpoint={`${goAuthUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <Suspense fallback={<div className="mx-auto max-w-sm px-6 py-12">Loading…</div>}>
+        <GoLoginPageInner />
+      </Suspense>
+    </HealthGate>
+  );
+}
+```
+
+Note: move the `const goAuthUrl` declaration OUTSIDE the component function, at module level (before the function definition).
+
+- [ ] **Step 3: Wrap the Go register page**
+
+In `frontend/src/app/go/register/page.tsx`, add the import:
+
+```tsx
+import { HealthGate } from "@/components/HealthGate";
+```
+
+The page directly renders the form. Wrap the return. Find the return in `GoRegisterPage`:
+
+Add a module-level constant before the component:
+
+```tsx
+const goAuthUrl =
+  process.env.NEXT_PUBLIC_GO_AUTH_URL || "http://localhost:8091";
+```
+
+Then wrap the component's return with HealthGate. The current return starts with a `<div>`. Change to:
+
+```tsx
+  return (
+    <HealthGate
+      endpoint={`${goAuthUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <div className="...">
+        {/* existing content */}
+      </div>
+    </HealthGate>
+  );
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/go/ecommerce/layout.tsx frontend/src/app/go/login/page.tsx frontend/src/app/go/register/page.tsx
+git commit -m "feat: add health gate to Go demo pages"
+```
+
+---
+
+## Task 5: Reorder SiteHeader Navigation and Add CI/CD Link
+
+**Files:**
+- Modify: `frontend/src/components/SiteHeader.tsx`
+
+- [ ] **Step 1: Reorder nav links and add CI/CD**
+
+Replace the `<nav>` block in `frontend/src/components/SiteHeader.tsx` (lines 25-37):
+
+```tsx
+          <nav className="flex items-center gap-4">
+            <Link href="/ai" className={navLinkClass("/ai")}>
+              AI
+            </Link>
+            <Link href="/java" className={navLinkClass("/java")}>
+              Java
+            </Link>
+            <Link href="/go" className={navLinkClass("/go")}>
+              Go
+            </Link>
+            <Link href="/aws" className={navLinkClass("/aws")}>
+              AWS
+            </Link>
+          </nav>
+```
+
+With:
+
+```tsx
+          <nav className="flex items-center gap-4">
+            <Link href="/go" className={navLinkClass("/go")}>
+              Go
+            </Link>
+            <Link href="/aws" className={navLinkClass("/aws")}>
+              AWS
+            </Link>
+            <Link href="/java" className={navLinkClass("/java")}>
+              Java
+            </Link>
+            <Link href="/ai" className={navLinkClass("/ai")}>
+              AI
+            </Link>
+            <Link href="/cicd" className={navLinkClass("/cicd")}>
+              CI/CD
+            </Link>
+          </nav>
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/SiteHeader.tsx
+git commit -m "feat: reorder nav to match homepage, add CI/CD link"
+```
+
+---
+
+## Task 6: Create CI/CD Pipeline Documentation Page
+
+**Files:**
+- Create: `frontend/src/app/cicd/page.tsx`
+
+- [ ] **Step 1: Create the CI/CD documentation page**
+
+This is a large static page following the same pattern as `/ai/page.tsx` — Mermaid diagrams, prose sections, and code snippets. Create `frontend/src/app/cicd/page.tsx`:
+
+```tsx
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const pipelineFlowDiagram = `flowchart LR
+  subgraph PR["Pull Request to qa"]
+    direction LR
+    A[PR Created] --> B[Quality Checks]
+    B --> C{All Pass?}
+    C -->|Yes| D[Ready for Review]
+    C -->|No| E[Fix & Push]
+    E --> B
+  end
+
+  subgraph QA["Push to qa"]
+    direction LR
+    F[PR Merged] --> G[Quality Checks]
+    G --> H[Build Images]
+    H --> I[Deploy to QA]
+    I --> J[Smoke Tests]
+  end
+
+  subgraph Prod["Push to main"]
+    direction LR
+    K[Ship It] --> L[Quality Checks]
+    L --> M[Build Images]
+    M --> N[Deploy to Prod]
+    N --> O[Smoke Tests]
+  end
+`;
+
+const qaArchitectureDiagram = `flowchart TB
+  subgraph Minikube["Minikube Cluster"]
+    subgraph ProdNS["Production Namespaces"]
+      direction LR
+      P1[ai-services]
+      P2[java-tasks]
+      P3[go-ecommerce]
+      P4[monitoring]
+    end
+    subgraph QANS["QA Namespaces"]
+      direction LR
+      Q1[ai-services-qa]
+      Q2[java-tasks-qa]
+      Q3[go-ecommerce-qa]
+    end
+  end
+
+  CF1[api.kylebradshaw.dev] --> P1
+  CF2[qa-api.kylebradshaw.dev] --> Q1
+
+  QANS -.->|shared infra| ProdNS
+`;
+
+export default function CICDPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="mt-8 text-3xl font-bold">CI/CD Pipeline</h1>
+
+        {/* Overview */}
+        <section className="mt-8">
+          <p className="text-muted-foreground leading-relaxed">
+            A unified GitHub Actions pipeline built for a solo developer. One
+            workflow file handles all quality checks, image builds, and
+            deployments for three service stacks (Python, Java, Go) and a Next.js
+            frontend. Designed to automate everything from code push to production
+            deploy, with a QA environment for visual inspection before shipping.
+          </p>
+        </section>
+
+        {/* Pipeline Flow */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Pipeline Flow</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Three triggers, one workflow. Every code change follows the same path
+            through quality gates before reaching production.
+          </p>
+          <div className="mt-4">
+            <MermaidDiagram chart={pipelineFlowDiagram} />
+          </div>
+        </section>
+
+        {/* Why Unified */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Why a Unified Workflow</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            The project originally had three separate workflow files — one per
+            language stack. Each ran its own lint, test, and build jobs. For a
+            solo developer, this created unnecessary complexity: three files to
+            maintain, three sets of CI status checks to monitor, and path-based
+            filtering that occasionally skipped checks when cross-stack changes
+            were made.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Consolidating into a single workflow simplified everything. All
+            quality gates run unconditionally on every trigger — no path
+            filtering, no change detection for quality checks. This is slower
+            (every push runs all checks regardless of what changed) but simpler
+            and catches cross-stack issues that path filtering would miss.
+          </p>
+        </section>
+
+        {/* Trigger Matrix */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Trigger Matrix</h2>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-2 pr-4 text-left font-medium">Job</th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    PR to qa
+                  </th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    Push to qa
+                  </th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    Push to main
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Quality checks</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Build images</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Deploy</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">QA</td>
+                  <td className="py-2 px-4 text-center">Prod</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Smoke tests</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Quality Gates */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Quality Gates</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            22 parallel jobs run on every trigger. All must pass before images are
+            built.
+          </p>
+          <div className="mt-4 grid gap-3">
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Python</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Ruff lint + format, pytest with coverage (ingestion, chat, debug),
+                Bandit SAST, pip-audit
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Java</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Checkstyle, unit tests (4 services), integration tests with
+                Testcontainers
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Go</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                golangci-lint, go test -race (3 services), migration pipeline test
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Frontend</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                ESLint, TypeScript type check, Next.js build, npm audit
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Security</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Gitleaks (secrets), Hadolint (Dockerfiles), CORS guardrail (no
+                wildcard origins)
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Infrastructure</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                K8s manifest validation (kubeconform + kind dry-run), Grafana
+                dashboard sync, Compose smoke test
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* QA Environment */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">QA Environment</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            QA runs in the same Minikube cluster as production using separate
+            Kubernetes namespaces. Kustomize overlays patch the base manifests to
+            set QA-specific CORS origins, database names, and ingress hosts —
+            without duplicating the manifests themselves.
+          </p>
+          <div className="mt-4">
+            <MermaidDiagram chart={qaArchitectureDiagram} />
+          </div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-2 pr-4 text-left font-medium">
+                    Production
+                  </th>
+                  <th className="py-2 px-4 text-left font-medium">QA</th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">ai-services</td>
+                  <td className="py-2 px-4">ai-services-qa</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">java-tasks</td>
+                  <td className="py-2 px-4">java-tasks-qa</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">go-ecommerce</td>
+                  <td className="py-2 px-4">go-ecommerce-qa</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Image Tagging */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Image Tagging</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            All 10 service images are built in a single matrix job and pushed to
+            GitHub Container Registry. QA images use a commit-pinned tag for
+            traceability; production uses <code>:latest</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm">
+{`# QA (push to qa branch)
+ghcr.io/kabradshaw1/portfolio/ingestion:qa-abc1234
+
+# Production (push to main branch)
+ghcr.io/kabradshaw1/portfolio/ingestion:latest`}
+          </pre>
+        </section>
+
+        {/* Deploy Mechanism */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Deploy Mechanism</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            GitHub Actions joins a Tailscale VPN to reach the home server, then
+            deploys via SSH. Kustomize overlays are built on the runner and piped
+            to the server via <code>kubectl apply</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm">
+{`# CI runner joins Tailscale VPN
+- uses: tailscale/github-action@v3
+
+# Build overlay locally, apply remotely
+kubectl kustomize k8s/overlays/qa/ | \\
+  ssh PC@100.79.113.84 "kubectl apply -f -"
+
+# Restart deployments to pull new images
+ssh PC@100.79.113.84 \\
+  "kubectl rollout restart deployment -n ai-services-qa"`}
+          </pre>
+        </section>
+
+        {/* No Branch Protection */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Why No Branch Protection</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            This is a solo developer project. By the time code reaches{" "}
+            <code>main</code>, it has passed all quality checks on the PR, been
+            deployed to QA, and been visually inspected. Branch protection
+            requiring PR approval would mean one person approving their own PR —
+            ceremony with no value.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            The real protection is the CI pipeline itself: 22 quality gates that
+            run on every push. If any fail, the deploy doesn&apos;t happen.
+          </p>
+        </section>
+
+        {/* Agent Automation */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Agent Automation</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            Claude Code agents drive the development workflow from spec to
+            production. The pipeline is designed so agents can operate
+            autonomously through the QA stage, with human review at two points:
+            PR approval and the &ldquo;ship it&rdquo; command.
+          </p>
+          <div className="mt-4 rounded-lg border border-border p-4">
+            <ol className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                <strong className="text-foreground">1. Spec &rarr; Plan:</strong>{" "}
+                Agent brainstorms design, writes implementation plan
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  2. Implement &rarr; PR:
+                </strong>{" "}
+                Agent creates feature branch, implements, pushes, creates PR to{" "}
+                <code>qa</code>
+              </li>
+              <li>
+                <strong className="text-foreground">3. CI Watch:</strong> Agent
+                monitors CI, fixes lint/format/config failures autonomously
+              </li>
+              <li>
+                <strong className="text-foreground">4. QA Deploy:</strong> Kyle
+                reviews PR, merges. QA deploys automatically.
+              </li>
+              <li>
+                <strong className="text-foreground">5. Ship It:</strong> Kyle
+                inspects QA, tells agent to ship. Agent merges to main, watches
+                prod deploy, cleans up.
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        {/* Smoke Tests */}
+        <section className="mt-12 mb-16">
+          <h2 className="text-xl font-semibold">Smoke Tests</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            After every deployment, automated smoke tests verify the services are
+            healthy. QA runs health endpoint checks against{" "}
+            <code>qa-api.kylebradshaw.dev</code>. Production runs Playwright
+            tests against the live site — including an end-to-end RAG flow that
+            uploads a PDF, asks a question, and verifies a streamed response.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles and the page builds**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/app/cicd/page.tsx
+git commit -m "feat: add CI/CD pipeline documentation page"
+```
+
+---
+
+## Task 7: Add CI/CD Card to Homepage
+
+**Files:**
+- Modify: `frontend/src/app/page.tsx`
+
+- [ ] **Step 1: Add CI/CD card after the AI card**
+
+In `frontend/src/app/page.tsx`, find the closing `</Link>` of the AI Engineer card (around line 111). After it, before the closing `</div>` of the grid, add:
+
+```tsx
+          <Link href="/cicd" className="block">
+            <Card className="hover:ring-foreground/20 transition-all">
+              <CardHeader>
+                <CardTitle>CI/CD Pipeline</CardTitle>
+                <CardDescription>
+                  Unified GitHub Actions workflow with QA environment and agent
+                  automation
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-sm">
+                  A single workflow handles quality checks, image builds, and
+                  deployments for three service stacks — designed for a solo
+                  developer with automated spec-to-production delivery.
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd frontend && npx tsc --noEmit 2>&1 | head -20`
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/app/page.tsx
+git commit -m "feat: add CI/CD card to homepage"
+```
+
+---
+
+## Task 8: Preflight Validation
+
+- [ ] **Step 1: Run full frontend preflight**
+
+Run: `cd /Users/kylebradshaw/repos/gen_ai_engineer && make preflight-frontend`
+
+Expected: lint, tsc, and build all pass.
+
+- [ ] **Step 2: Fix any issues found**
+
+If lint or type errors appear, fix them and commit.
+
+- [ ] **Step 3: Add Vercel env var**
+
+Run:
+```bash
+printf 'Migrating to Linux for improved performance and reliability.' | vercel env add NEXT_PUBLIC_MAINTENANCE_MESSAGE production
+```
+
+Expected: Environment variable added.
+
+- [ ] **Step 4: Verify git log**
+
+Run: `git log --oneline main..HEAD`
+
+Expected: 7 commits covering HealthGate component, AI/Java/Go page wrapping, SiteHeader reorder, CI/CD page, homepage card.

--- a/docs/superpowers/plans/2026-04-13-cicd-rebuild.md
+++ b/docs/superpowers/plans/2026-04-13-cicd-rebuild.md
@@ -1,0 +1,1077 @@
+# CI/CD Pipeline Rebuild & QA Environment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace three GitHub Actions workflows with one unified workflow, add a QA environment with separate Minikube namespaces, and update CLAUDE.md with the new agent-driven workflow.
+
+**Architecture:** Single `ci.yml` handles PR-to-qa (checks only), push-to-qa (checks + build + deploy QA + smoke), and push-to-main (checks + build + deploy prod + smoke). QA uses separate K8s namespaces sharing prod database instances but with separate databases. Kustomize QA overlays patch namespaces, CORS, DB names, and ingress hosts.
+
+**Tech Stack:** GitHub Actions, Kustomize, Kubernetes (Minikube), Cloudflare Tunnel, Vercel, GHCR
+
+**Spec:** `docs/superpowers/specs/2026-04-13-cicd-rebuild-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `.github/workflows/ci.yml` | Unified workflow (rewrite of existing) |
+| `k8s/overlays/qa/kustomization.yaml` | QA overlay for Python AI services |
+| `k8s/overlays/qa/namespace.yml` | ai-services-qa namespace |
+| `k8s/overlays/qa/ollama.yml` | Ollama ExternalName in QA namespace |
+| `java/k8s/overlays/qa/kustomization.yaml` | QA overlay for Java services |
+| `java/k8s/overlays/qa/namespace.yml` | java-tasks-qa namespace |
+| `go/k8s/overlays/qa/kustomization.yaml` | QA overlay for Go services |
+| `go/k8s/overlays/qa/namespace.yml` | go-ecommerce-qa namespace |
+| `docs/adr/cicd-rebuild-qa-environment.md` | ADR documenting design decisions |
+| `docs/qa-workflow-guide.md` | Step-by-step workflow guide for Kyle |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `CLAUDE.md` | New branching model, agent push rules, worktree conventions |
+| `.gitignore` | Add `.claude/worktrees/` |
+| `Makefile` | Add `worktree-cleanup` target |
+| `k8s/deploy.sh` | Accept `qa` as third environment |
+| `docs/adr/cicd-pipeline.md` | Mark as superseded by new ADR |
+
+### Deleted Files
+
+| File | Reason |
+|------|--------|
+| `.github/workflows/java-ci.yml` | Replaced by unified ci.yml |
+| `.github/workflows/go-ci.yml` | Replaced by unified ci.yml |
+
+---
+
+## Task 1: QA Kustomize Overlay — Python AI Services
+
+**Files:**
+- Create: `k8s/overlays/qa/kustomization.yaml`
+- Create: `k8s/overlays/qa/namespace.yml`
+- Create: `k8s/overlays/qa/ollama.yml`
+
+- [ ] **Step 1: Create the QA namespace manifest**
+
+```yaml
+# k8s/overlays/qa/namespace.yml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-services-qa
+```
+
+- [ ] **Step 2: Create the Ollama ExternalName service for QA namespace**
+
+The prod overlay at `k8s/overlays/minikube/ollama.yml` defines an ExternalName service in `ai-services`. QA needs the same in `ai-services-qa`.
+
+```yaml
+# k8s/overlays/qa/ollama.yml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: ai-services-qa
+spec:
+  type: ExternalName
+  externalName: host.minikube.internal
+```
+
+- [ ] **Step 3: Create the QA Kustomize overlay**
+
+This overlay references the base `ai-services` resources, overrides the namespace, patches CORS and Qdrant collection name, and adds the QA host to ingress.
+
+```yaml
+# k8s/overlays/qa/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../ai-services
+  - namespace.yml
+  - ollama.yml
+
+namespace: ai-services-qa
+
+patches:
+  # --- CORS: allow QA frontend ---
+  - target:
+      kind: ConfigMap
+      name: ingestion-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/COLLECTION_NAME
+        value: "documents_qa"
+      - op: replace
+        path: /data/QDRANT_HOST
+        value: "qdrant.ai-services.svc.cluster.local"
+  - target:
+      kind: ConfigMap
+      name: chat-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/COLLECTION_NAME
+        value: "documents_qa"
+      - op: replace
+        path: /data/QDRANT_HOST
+        value: "qdrant.ai-services.svc.cluster.local"
+  - target:
+      kind: ConfigMap
+      name: debug-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/QDRANT_HOST
+        value: "qdrant.ai-services.svc.cluster.local"
+  # --- Ingress: QA host ---
+  - target:
+      kind: Ingress
+      name: ai-services-ingress
+    patch: |
+      - op: add
+        path: /spec/rules/0/host
+        value: "qa-api.kylebradshaw.dev"
+  # --- Remove Qdrant deployment (shared with prod) ---
+  - target:
+      kind: Deployment
+      name: qdrant
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: qdrant
+  - target:
+      kind: Service
+      name: qdrant
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: qdrant.ai-services.svc.cluster.local
+```
+
+- [ ] **Step 4: Validate the overlay builds**
+
+Run: `kubectl kustomize k8s/overlays/qa/ | head -100`
+
+Expected: YAML output with namespace `ai-services-qa`, ConfigMaps showing `ALLOWED_ORIGINS: https://qa.kylebradshaw.dev,http://localhost:3000`, ingress with `host: qa-api.kylebradshaw.dev`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add k8s/overlays/qa/
+git commit -m "k8s: add QA Kustomize overlay for Python AI services"
+```
+
+---
+
+## Task 2: QA Kustomize Overlay — Java Services
+
+**Files:**
+- Create: `java/k8s/overlays/qa/kustomization.yaml`
+- Create: `java/k8s/overlays/qa/namespace.yml`
+
+- [ ] **Step 1: Create the QA namespace manifest**
+
+```yaml
+# java/k8s/overlays/qa/namespace.yml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: java-tasks-qa
+```
+
+- [ ] **Step 2: Create the QA Kustomize overlay**
+
+Java QA shares the infrastructure pods (postgres, mongodb, redis, rabbitmq) from `java-tasks` namespace via cross-namespace DNS. Only application services are deployed in QA.
+
+```yaml
+# java/k8s/overlays/qa/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../
+  - namespace.yml
+
+namespace: java-tasks-qa
+
+patches:
+  # --- CORS ---
+  - target:
+      kind: ConfigMap
+      name: gateway-service-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+  - target:
+      kind: ConfigMap
+      name: task-service-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/POSTGRES_HOST
+        value: "postgres.java-tasks.svc.cluster.local"
+      - op: replace
+        path: /data/RABBITMQ_HOST
+        value: "rabbitmq.java-tasks.svc.cluster.local"
+      - op: replace
+        path: /data/REDIS_HOST
+        value: "redis.java-tasks.svc.cluster.local"
+  - target:
+      kind: ConfigMap
+      name: activity-service-config
+    patch: |
+      - op: replace
+        path: /data/MONGODB_HOST
+        value: "mongodb.java-tasks.svc.cluster.local"
+      - op: replace
+        path: /data/RABBITMQ_HOST
+        value: "rabbitmq.java-tasks.svc.cluster.local"
+  - target:
+      kind: ConfigMap
+      name: notification-service-config
+    patch: |
+      - op: replace
+        path: /data/REDIS_HOST
+        value: "redis.java-tasks.svc.cluster.local"
+      - op: replace
+        path: /data/RABBITMQ_HOST
+        value: "rabbitmq.java-tasks.svc.cluster.local"
+  - target:
+      kind: ConfigMap
+      name: gateway-service-config
+    patch: |
+      - op: replace
+        path: /data/REDIS_HOST
+        value: "redis.java-tasks.svc.cluster.local"
+  # --- Ingress: QA host ---
+  - target:
+      kind: Ingress
+      name: java-tasks-ingress
+    patch: |
+      - op: add
+        path: /spec/rules/0/host
+        value: "qa-api.kylebradshaw.dev"
+  # --- Remove infrastructure deployments (shared with prod) ---
+  - target:
+      kind: Deployment
+      name: postgres
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: postgres
+  - target:
+      kind: Deployment
+      name: mongodb
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: mongodb
+  - target:
+      kind: Deployment
+      name: redis
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: redis
+  - target:
+      kind: Deployment
+      name: rabbitmq
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: rabbitmq
+  # --- Remove infrastructure services (replace with ExternalName) ---
+  - target:
+      kind: Service
+      name: postgres
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: postgres.java-tasks.svc.cluster.local
+  - target:
+      kind: Service
+      name: mongodb
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: mongodb.java-tasks.svc.cluster.local
+  - target:
+      kind: Service
+      name: redis
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: redis.java-tasks.svc.cluster.local
+  - target:
+      kind: Service
+      name: rabbitmq
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: rabbitmq.java-tasks.svc.cluster.local
+  # --- Remove PVC (no local storage needed) ---
+  - target:
+      kind: PersistentVolumeClaim
+      name: postgres-pvc
+    patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: postgres-pvc
+  # --- Remove rabbitmq ingress (not needed for QA) ---
+  - target:
+      kind: Ingress
+      name: rabbitmq-ingress
+    patch: |
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: rabbitmq-ingress
+```
+
+- [ ] **Step 3: Validate the overlay builds**
+
+Run: `kubectl kustomize java/k8s/overlays/qa/ | head -100`
+
+Expected: YAML with namespace `java-tasks-qa`, cross-namespace DNS for infrastructure, QA CORS origins.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add java/k8s/overlays/qa/
+git commit -m "k8s: add QA Kustomize overlay for Java services"
+```
+
+---
+
+## Task 3: QA Kustomize Overlay — Go Services
+
+**Files:**
+- Create: `go/k8s/overlays/qa/kustomization.yaml`
+- Create: `go/k8s/overlays/qa/namespace.yml`
+
+- [ ] **Step 1: Create the QA namespace manifest**
+
+```yaml
+# go/k8s/overlays/qa/namespace.yml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-ecommerce-qa
+```
+
+- [ ] **Step 2: Create the QA Kustomize overlay**
+
+```yaml
+# go/k8s/overlays/qa/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../
+  - namespace.yml
+
+namespace: go-ecommerce-qa
+
+patches:
+  # --- CORS + QA database ---
+  - target:
+      kind: ConfigMap
+      name: auth-service-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/DATABASE_URL
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/ecommercedb_qa?sslmode=disable"
+  - target:
+      kind: ConfigMap
+      name: ecommerce-service-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/DATABASE_URL
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/ecommercedb_qa?sslmode=disable"
+      - op: replace
+        path: /data/REDIS_URL
+        value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
+      - op: replace
+        path: /data/RABBITMQ_URL
+        value: "amqp://guest:guest@rabbitmq.java-tasks.svc.cluster.local:5672"
+  - target:
+      kind: ConfigMap
+      name: ai-service-config
+    patch: |
+      - op: replace
+        path: /data/ALLOWED_ORIGINS
+        value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      - op: replace
+        path: /data/OLLAMA_URL
+        value: "http://ollama.ai-services.svc.cluster.local:11434"
+      - op: replace
+        path: /data/ECOMMERCE_URL
+        value: "http://go-ecommerce-service:8092"
+      - op: replace
+        path: /data/REDIS_URL
+        value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
+  # --- Ingress: QA host ---
+  - target:
+      kind: Ingress
+      name: go-ecommerce-ingress
+    patch: |
+      - op: add
+        path: /spec/rules/0/host
+        value: "qa-api.kylebradshaw.dev"
+  # --- Migration jobs: point at QA database ---
+  - target:
+      kind: Job
+      name: go-auth-migrate
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/ecommercedb_qa?sslmode=disable"
+  - target:
+      kind: Job
+      name: go-ecommerce-migrate
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/ecommercedb_qa?sslmode=disable"
+```
+
+- [ ] **Step 3: Validate the overlay builds**
+
+Run: `kubectl kustomize go/k8s/overlays/qa/ | head -100`
+
+Expected: YAML with namespace `go-ecommerce-qa`, `ecommercedb_qa` in DATABASE_URLs, Redis DB 1, QA CORS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/k8s/overlays/qa/
+git commit -m "k8s: add QA Kustomize overlay for Go services"
+```
+
+---
+
+## Task 4: Extend deploy.sh for QA
+
+**Files:**
+- Modify: `k8s/deploy.sh`
+
+- [ ] **Step 1: Update deploy.sh to accept `qa` environment**
+
+The script currently accepts `minikube` or `aws`. Add `qa` as a third option. QA deploys to separate namespaces, skips monitoring, and creates the `ecommercedb_qa` database if it doesn't exist.
+
+In `k8s/deploy.sh`, replace the environment validation block and add QA-specific logic:
+
+Replace the existing validation (lines 14-17):
+```bash
+if [ "$ENV" != "minikube" ] && [ "$ENV" != "aws" ]; then
+  echo "Usage: $0 [minikube|aws]"
+  exit 1
+fi
+```
+
+With:
+```bash
+if [ "$ENV" != "minikube" ] && [ "$ENV" != "aws" ] && [ "$ENV" != "qa" ]; then
+  echo "Usage: $0 [minikube|aws|qa]"
+  exit 1
+fi
+```
+
+Then, after the existing Minikube-specific setup block (line 25), add the QA deploy path. When `ENV=qa`, the script should:
+1. Apply QA Kustomize overlays (not base manifests)
+2. Skip monitoring (shared with prod)
+3. Create `ecommercedb_qa` database on the existing PostgreSQL if it doesn't exist
+4. Wait for QA application services only
+
+Add this block after the Minikube ingress setup:
+
+```bash
+# --- QA-specific deploy ---
+if [ "$ENV" = "qa" ]; then
+  echo "==> Creating QA database (ecommercedb_qa) if not exists..."
+  kubectl exec deployment/postgres -n java-tasks -- \
+    psql -U taskuser -d taskdb -c "SELECT 1 FROM pg_database WHERE datname='ecommercedb_qa'" | grep -q 1 || \
+    kubectl exec deployment/postgres -n java-tasks -- \
+      psql -U taskuser -d taskdb -c "CREATE DATABASE ecommercedb_qa;"
+
+  echo "==> Deploying ai-services-qa..."
+  kubectl apply -k "$SCRIPT_DIR/overlays/qa"
+
+  echo "==> Deploying java-tasks-qa..."
+  kubectl apply -k "$REPO_DIR/java/k8s/overlays/qa"
+
+  echo "==> Deploying go-ecommerce-qa..."
+  kubectl apply -k "$REPO_DIR/go/k8s/overlays/qa"
+
+  echo "==> Waiting for QA application services..."
+  kubectl wait --for=condition=available --timeout=180s deployment/ingestion -n ai-services-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/chat -n ai-services-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/debug -n ai-services-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/task-service -n java-tasks-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/activity-service -n java-tasks-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/notification-service -n java-tasks-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/gateway-service -n java-tasks-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/go-auth-service -n go-ecommerce-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/go-ecommerce-service -n go-ecommerce-qa
+  kubectl wait --for=condition=available --timeout=180s deployment/go-ai-service -n go-ecommerce-qa
+
+  echo ""
+  echo "==> QA environment deployed!"
+  echo "    Backend: qa-api.kylebradshaw.dev"
+  echo "    Frontend: qa.kylebradshaw.dev"
+  exit 0
+fi
+```
+
+- [ ] **Step 2: Verify the updated script parses correctly**
+
+Run: `bash -n k8s/deploy.sh`
+
+Expected: No output (no syntax errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k8s/deploy.sh
+git commit -m "k8s: extend deploy.sh to support QA environment"
+```
+
+---
+
+## Task 5: Unified GitHub Actions Workflow
+
+**Files:**
+- Rewrite: `.github/workflows/ci.yml`
+- Delete: `.github/workflows/java-ci.yml`
+- Delete: `.github/workflows/go-ci.yml`
+
+- [ ] **Step 1: Write the unified workflow**
+
+This is the largest file (~600 lines). It consolidates all jobs from `ci.yml`, `java-ci.yml`, and `go-ci.yml` into a single workflow with conditional deploy jobs. Reference the existing files for exact job definitions — copy them, remove `needs: [changes]` dependencies and `if: needs.changes.outputs.*` conditionals, then add the new deploy/smoke jobs.
+
+Key changes from current `ci.yml`:
+- Triggers: `pull_request: [qa]` + `push: [qa, main]` (replaces `push: ["**"]` + `pull_request: [main]`)
+- Remove `changes` job and all `if: needs.changes.outputs.*` conditionals — all checks always run
+- Remove `e2e-staging` job (staging branch retired)
+- Add Go lint/test jobs (from `go-ci.yml`)
+- Add Java integration tests (from `java-ci.yml`)
+- Consolidate all Docker builds into one matrix job
+- Add `deploy-qa` job (conditional on push to qa)
+- Rename `deploy` to `deploy-prod` (conditional on push to main)
+- Add `smoke-qa` job
+
+Write the complete workflow to `.github/workflows/ci.yml`. The file will be large (~600 lines). Key sections:
+
+**Triggers:**
+```yaml
+name: CI/CD
+
+on:
+  pull_request:
+    branches: [qa]
+  push:
+    branches: [qa, main]
+```
+
+**Quality gates** (no `needs: changes` dependency, no `if` conditionals — all run always):
+- `python-lint` — ruff check + format
+- `python-tests` — matrix pytest (ingestion, chat, debug)
+- `java-lint` — checkstyle
+- `java-unit-tests` — matrix (task, activity, notification, gateway)
+- `java-integration-tests` — Gradle integrationTest
+- `go-lint` — matrix golangci-lint (auth, ecommerce, ai-service)
+- `go-tests` — matrix go test -race (auth, ecommerce, ai-service)
+- `go-migration-test` — PostgreSQL + golang-migrate
+- `frontend-checks` — lint, tsc, build
+- `grafana-dashboard-sync` — dashboard JSON sync
+- `k8s-manifest-validation` — kubeconform + kind dry-run + policy
+- `compose-smoke` — Docker Compose smoke with mock-ollama
+- `security-bandit`, `security-pip-audit`, `security-npm-audit`, `security-gitleaks`, `security-hadolint`, `security-cors-check`
+
+**Build images** (conditional: push only):
+```yaml
+build-images:
+  name: Build Image (${{ matrix.service }})
+  runs-on: ubuntu-latest
+  if: github.event_name == 'push'
+  needs: [python-lint, python-tests, java-lint, java-unit-tests, go-lint, go-tests, frontend-checks, security-gitleaks, security-hadolint]
+  permissions:
+    packages: write
+  strategy:
+    matrix:
+      include:
+        - service: ingestion
+          context: services
+          file: services/ingestion/Dockerfile
+          image: ingestion
+        - service: chat
+          context: services
+          file: services/chat/Dockerfile
+          image: chat
+        - service: debug
+          context: services
+          file: services/debug/Dockerfile
+          image: debug
+        - service: java-task-service
+          context: java/task-service
+          file: java/task-service/Dockerfile
+          image: java-task-service
+          pre-build: cd java && ./gradlew :task-service:bootJar --no-daemon
+        - service: java-activity-service
+          context: java/activity-service
+          file: java/activity-service/Dockerfile
+          image: java-activity-service
+          pre-build: cd java && ./gradlew :activity-service:bootJar --no-daemon
+        - service: java-notification-service
+          context: java/notification-service
+          file: java/notification-service/Dockerfile
+          image: java-notification-service
+          pre-build: cd java && ./gradlew :notification-service:bootJar --no-daemon
+        - service: java-gateway-service
+          context: java/gateway-service
+          file: java/gateway-service/Dockerfile
+          image: java-gateway-service
+          pre-build: cd java && ./gradlew :gateway-service:bootJar --no-daemon
+        - service: go-auth-service
+          context: go
+          file: go/auth-service/Dockerfile
+          image: go-auth-service
+        - service: go-ecommerce-service
+          context: go
+          file: go/ecommerce-service/Dockerfile
+          image: go-ecommerce-service
+        - service: go-ai-service
+          context: go
+          file: go/ai-service/Dockerfile
+          image: go-ai-service
+```
+
+Image tags:
+- Push to `qa`: `ghcr.io/${{ github.repository }}/${{ matrix.image }}:qa-${{ github.sha }}`
+- Push to `main`: `ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest`
+
+**Deploy QA** (conditional: push to qa):
+```yaml
+deploy-qa:
+  name: Deploy QA
+  runs-on: ubuntu-latest
+  needs: [build-images]
+  if: github.event_name == 'push' && github.ref == 'refs/heads/qa'
+```
+
+Uses the same SSH + Tailscale pattern as current deploy job, but runs `kubectl apply -k` with the QA overlays and restarts QA namespace deployments.
+
+**Deploy prod** (conditional: push to main):
+Preserves the existing `deploy` job logic exactly (SSH, selective restarts based on change detection). Add the `changes` detection job back but ONLY as a dependency of `deploy-prod` — not of quality gates.
+
+**Smoke tests** (one for QA, one for prod):
+```yaml
+smoke-qa:
+  if: github.event_name == 'push' && github.ref == 'refs/heads/qa'
+  # Hit qa-api.kylebradshaw.dev health endpoints
+
+smoke-prod:
+  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  # Existing production smoke tests (Playwright)
+```
+
+- [ ] **Step 2: Delete the old workflow files**
+
+```bash
+git rm .github/workflows/java-ci.yml
+git rm .github/workflows/go-ci.yml
+```
+
+- [ ] **Step 3: Validate workflow YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: unified workflow replacing ci.yml, java-ci.yml, go-ci.yml
+
+Single workflow handles PR checks (qa), QA deploy (push to qa),
+and production deploy (push to main). Removes change detection
+for quality gates — all checks always run."
+```
+
+---
+
+## Task 6: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Replace the Branching & Workflow section**
+
+Replace the existing "Branching & Workflow" section (lines 140-157) with:
+
+```markdown
+## Branching & Workflow
+
+- `main` — production. Pushes trigger deploy + post-deploy smoke tests.
+- `qa` — pre-production QA environment. PRs trigger quality checks. Pushes trigger build + deploy to QA + smoke tests.
+- Feature branches (`agent/feat-*`) — created by agents from `main`, short-lived, deleted after merge.
+- `staging` — retired. Replaced by `qa`.
+
+**Per-branch rules for Claude Code:**
+
+- **On a feature branch:** implement, commit, push, create PR to `qa`.
+- **On `qa`:** commit and push when Kyle asks. Watch CI after pushing and debug failures. For CI fixes: lint errors, formatting, type errors, and config issues are fine to fix autonomously. For anything that changes application behavior (logic, API contracts, data flow), stop and check with Kyle before fixing.
+- **On `main`:** never push autonomously. When Kyle explicitly says to merge/ship to main, handle the full flow: merge `qa` into `main`, push, watch CI, debug minor failures, clean up worktree, delete feature branch (local + remote).
+
+Claude Code determines the current branch via `git branch --show-current` and follows the rules for that branch. No special mode or prompt needed.
+
+**Agent worktrees:** Agents create worktrees in `.claude/worktrees/<branch-name>/` for feature work. Worktrees are cleaned up as part of the "ship to main" flow.
+```
+
+- [ ] **Step 2: Update the CI/CD Pipeline section**
+
+Replace the existing "CI/CD Pipeline" section (lines 172-184) with:
+
+```markdown
+## CI/CD Pipeline
+
+Single unified workflow (`.github/workflows/ci.yml`) handles all CI/CD:
+
+| Trigger | What runs |
+|---------|-----------|
+| PR to `qa` | All quality checks (lint, test, security, k8s validation) |
+| Push to `qa` | Quality checks + build all images + deploy to QA + smoke QA |
+| Push to `main` | Quality checks + build all images + deploy to prod + smoke prod |
+
+**Quality:** ruff lint/format, pytest + coverage, tsc, Next.js build, checkstyle, golangci-lint, Go tests
+**Security:** Bandit (SAST), pip-audit, npm audit, gitleaks, Hadolint, CORS guardrail
+**Deploy:** GHCR images built in CI → SSH to Windows PC → kubectl apply Kustomize overlays
+**QA:** `qa-api.kylebradshaw.dev` (backend), `qa.kylebradshaw.dev` (frontend on Vercel)
+
+**Compose-smoke realism:** Job 3 (`compose-smoke`) runs the Python AI stack via `docker-compose.yml` with a mocked Ollama. Any change to Python service configuration (env vars, ports, depends_on, env_file references) must be reflected in BOTH `docker-compose.yml` and the corresponding k8s manifests under `k8s/ai-services/`, or compose-smoke will drift from prod and stop catching real regressions.
+
+**Tailscale authkey:** Expires every 90 days (free plan). Regenerate at Tailscale admin → Keys and update `TAILSCALE_AUTHKEY` in GitHub repo secrets.
+```
+
+- [ ] **Step 3: Remove the "Do not use git worktrees" line**
+
+Delete line 157: `**Do not use git worktrees or the EnterWorktree/ExitWorktree tools.**`
+
+- [ ] **Step 4: Update the Minikube namespaces list in Infrastructure section**
+
+Add QA namespaces to the Minikube section (after line 26):
+
+```markdown
+  - `ai-services-qa` namespace: QA copies of Python AI services (shared Qdrant with prod)
+  - `java-tasks-qa` namespace: QA copies of Java services (shared infra with prod)
+  - `go-ecommerce-qa` namespace: QA copies of Go services (shared infra with prod)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with new branching model and agent workflow"
+```
+
+---
+
+## Task 7: Update .gitignore and Makefile
+
+**Files:**
+- Modify: `.gitignore`
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add worktree exclusion to .gitignore**
+
+Add after the `.superpowers/` line (line 49):
+
+```
+# Agent worktrees
+.claude/worktrees/
+```
+
+- [ ] **Step 2: Add worktree-cleanup target to Makefile**
+
+Add at the end of the Makefile:
+
+```makefile
+# --- Worktree cleanup ---
+worktree-cleanup:
+	@echo "\n=== Cleaning up merged worktrees ==="
+	@for wt in $$(git worktree list --porcelain | grep '^worktree' | awk '{print $$2}' | grep '.claude/worktrees'); do \
+		branch=$$(git worktree list --porcelain | grep -A2 "$$wt" | grep '^branch' | sed 's|branch refs/heads/||'); \
+		if [ -n "$$branch" ] && ! git rev-parse --verify "$$branch" >/dev/null 2>&1; then \
+			echo "  Removing stale worktree: $$wt (branch $$branch deleted)"; \
+			git worktree remove "$$wt" --force; \
+		fi; \
+	done
+	@git worktree prune
+	@echo "Done"
+```
+
+- [ ] **Step 3: Update .PHONY**
+
+Add `worktree-cleanup` to the `.PHONY` declaration at line 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .gitignore Makefile
+git commit -m "chore: add worktree exclusion and cleanup target"
+```
+
+---
+
+## Task 8: Write the ADR
+
+**Files:**
+- Create: `docs/adr/cicd-rebuild-qa-environment.md`
+- Modify: `docs/adr/cicd-pipeline.md` (mark as superseded)
+
+- [ ] **Step 1: Write the ADR**
+
+```markdown
+# CI/CD Pipeline Rebuild and QA Environment
+
+- **Date:** 2026-04-13
+- **Status:** Accepted
+- **Supersedes:** [CI/CD Pipeline](cicd-pipeline.md)
+
+## Context
+
+The portfolio project had three separate GitHub Actions workflows (`ci.yml`, `java-ci.yml`, `go-ci.yml`) and a staging branch. For a solo developer, the staging branch added no value — it re-ran the same checks that already passed on the feature branch, with no code review or manual gate in between. The multiple workflow files also made it harder to understand the full CI/CD picture.
+
+The project needed:
+1. A pre-production QA environment for visual inspection before shipping
+2. Automated agent workflow to reduce manual steps
+3. A simpler, unified CI/CD pipeline
+
+## Decision
+
+### Unified Workflow
+
+Consolidated all three workflow files into a single `ci.yml` with three triggers:
+- **PR to `qa`:** runs all quality checks (lint, test, security, K8s validation)
+- **Push to `qa`:** runs checks + builds all Docker images + deploys to QA namespaces + smoke tests
+- **Push to `main`:** runs checks + builds images + deploys to production + smoke tests
+
+The staging branch is retired. The `qa` branch replaces it.
+
+### QA Environment
+
+QA runs in the same Minikube cluster as production using separate namespaces (`ai-services-qa`, `java-tasks-qa`, `go-ecommerce-qa`). QA shares database instances with production but uses separate databases (`ecommercedb_qa`, `taskdb_qa`, `documents_qa` collection). This avoids duplicating infrastructure pods (PostgreSQL, MongoDB, Redis, RabbitMQ, Qdrant) saving ~1.3GB of memory on the single Minikube node.
+
+QA is publicly accessible:
+- Backend: `qa-api.kylebradshaw.dev` via Cloudflare Tunnel
+- Frontend: `qa.kylebradshaw.dev` via Vercel branch domain
+
+### Agent Workflow
+
+Agents create feature branches, implement changes in git worktrees, push, and create PRs targeting `qa`. After CI passes, Kyle reviews the PR, merges it, inspects the QA deployment, and tells Claude to ship it to main. Claude handles the merge, push, CI watch, and worktree cleanup.
+
+### Why Kyle Pushes Directly to Main
+
+This is a solo developer project. By the time code reaches `main`, it has already passed all quality checks (on the PR), been deployed to QA, and been visually inspected. Branch protection requiring a PR approval would be a single person approving their own PR — ceremony with no value. Kyle pushes directly to main (via Claude when told to "ship it") after reviewing QA.
+
+## Consequences
+
+**Positive:**
+- Single workflow file is easier to understand and maintain
+- QA environment catches visual and integration issues before production
+- Agent automation reduces manual steps from ~8 to ~2 (review PR, say "ship it")
+- Shared database instances keep Minikube resource usage manageable
+
+**Trade-offs:**
+- All quality checks run on every trigger (no path-based skipping). Slower but simpler and catches cross-stack issues.
+- QA and production share database instances. A runaway QA query could theoretically affect production, but this is a portfolio project with no real traffic.
+- QA is publicly accessible, which is intentional — it demonstrates the CI/CD pipeline as part of the portfolio.
+```
+
+- [ ] **Step 2: Mark the old ADR as superseded**
+
+Add to the top of `docs/adr/cicd-pipeline.md`, after the title line:
+
+```markdown
+> **Superseded** by [CI/CD Pipeline Rebuild and QA Environment](cicd-rebuild-qa-environment.md) (2026-04-13)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/cicd-rebuild-qa-environment.md docs/adr/cicd-pipeline.md
+git commit -m "docs: ADR for CI/CD rebuild and QA environment"
+```
+
+---
+
+## Task 9: Write the QA Workflow Guide
+
+**Files:**
+- Create: `docs/qa-workflow-guide.md`
+
+- [ ] **Step 1: Write the workflow guide**
+
+```markdown
+# QA Workflow Guide
+
+Step-by-step reference for reviewing and shipping changes through the QA pipeline.
+
+## Normal Flow: Agent Delivers a Feature
+
+1. **Agent notifies you:** "PR to `qa` is ready, CI passed. Review at [PR link]"
+2. **Review the PR diff** on GitHub — check the code changes make sense
+3. **Merge the PR** on GitHub — this triggers the QA build + deploy pipeline
+4. **Wait for deploy** — watch the Actions tab or wait for the pipeline to finish (~5-10 min)
+5. **Inspect QA** at [qa.kylebradshaw.dev](https://qa.kylebradshaw.dev) — click through the affected pages, verify the change works as expected
+6. **Ship to production** — tell Claude "ship it" and Claude will:
+   - Merge `qa` into `main`
+   - Push `main`
+   - Watch the production CI/deploy pipeline
+   - Debug any minor failures (lint, config)
+   - Clean up the worktree and delete the feature branch
+   - Report back when production is live
+
+## Tweaking QA
+
+If something needs adjustment after inspecting QA:
+
+1. `git checkout qa && git pull`
+2. For **frontend changes:** run `npm run dev` in `frontend/` with QA backend env vars:
+   ```bash
+   NEXT_PUBLIC_API_URL=https://qa-api.kylebradshaw.dev \
+   NEXT_PUBLIC_GATEWAY_URL=https://qa-api.kylebradshaw.dev \
+   NEXT_PUBLIC_INGESTION_API_URL=https://qa-api.kylebradshaw.dev/ingestion \
+   NEXT_PUBLIC_CHAT_API_URL=https://qa-api.kylebradshaw.dev/chat \
+   NEXT_PUBLIC_GO_AUTH_URL=https://qa-api.kylebradshaw.dev/go-auth \
+   NEXT_PUBLIC_GO_ECOMMERCE_URL=https://qa-api.kylebradshaw.dev/go-api \
+   NEXT_PUBLIC_AI_SERVICE_URL=https://qa-api.kylebradshaw.dev/ai-api \
+   npm run dev
+   ```
+3. Tell Claude what to fix
+4. **Ask Claude to push** — it will:
+   - Commit the fix
+   - Push to `qa`
+   - Watch CI and debug minor failures (lint, formatting, config issues)
+   - Stop and ask you before changing anything that affects app behavior
+5. Wait for QA to redeploy, inspect again
+6. When satisfied, tell Claude to ship it
+
+## Environments
+
+| Environment | Backend URL | Frontend URL |
+|-------------|-------------|--------------|
+| Production | api.kylebradshaw.dev | kylebradshaw.dev |
+| QA | qa-api.kylebradshaw.dev | qa.kylebradshaw.dev |
+| Local dev | localhost:8000 (via SSH tunnel) | localhost:3000 |
+
+## What Claude Can Fix Autonomously
+
+When watching CI on the `qa` branch:
+- **Go ahead:** lint errors, formatting issues, type errors, import ordering, config typos
+- **Stop and ask:** logic changes, API contract changes, data flow changes, new dependencies
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/qa-workflow-guide.md
+git commit -m "docs: add QA workflow guide for Kyle"
+```
+
+---
+
+## Task 10: Validation
+
+- [ ] **Step 1: Validate all Kustomize overlays build cleanly**
+
+```bash
+kubectl kustomize k8s/overlays/qa/ > /dev/null && echo "AI services QA: OK"
+kubectl kustomize java/k8s/overlays/qa/ > /dev/null && echo "Java QA: OK"
+kubectl kustomize go/k8s/overlays/qa/ > /dev/null && echo "Go QA: OK"
+```
+
+Expected: All three print OK with no errors.
+
+- [ ] **Step 2: Validate workflow YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml: OK')"
+```
+
+Expected: `ci.yml: OK`
+
+- [ ] **Step 3: Validate deploy.sh syntax**
+
+```bash
+bash -n k8s/deploy.sh && echo "deploy.sh: OK"
+```
+
+Expected: `deploy.sh: OK`
+
+- [ ] **Step 4: Run relevant preflight checks**
+
+```bash
+make grafana-sync-check
+```
+
+Expected: Pass (we didn't change Grafana config).
+
+- [ ] **Step 5: Verify .gitignore excludes worktrees**
+
+```bash
+mkdir -p .claude/worktrees/test-branch
+git status | grep -q 'worktrees' && echo "FAIL: worktrees showing in git status" || echo "OK: worktrees excluded"
+rmdir .claude/worktrees/test-branch
+```
+
+Expected: `OK: worktrees excluded`
+
+- [ ] **Step 6: Commit any fixes from validation**
+
+If any validation steps revealed issues, fix and commit before proceeding.

--- a/docs/superpowers/specs/2026-04-13-cicd-docs-maintenance-pages-design.md
+++ b/docs/superpowers/specs/2026-04-13-cicd-docs-maintenance-pages-design.md
@@ -1,0 +1,123 @@
+# CI/CD Documentation Page & Maintenance Pages
+
+## Context
+
+The portfolio project is about to go through a server migration from Windows to Debian 12. During this transition (and any future downtime), interactive demo pages that depend on backend APIs will break silently — users see errors or blank states instead of a professional maintenance message.
+
+Additionally, the CI/CD pipeline was recently rebuilt (unified workflow, QA environment, agent automation) and this work should be showcased on the portfolio site as a documentation page demonstrating DevOps skills.
+
+## Goals
+
+- Show a professional maintenance screen on interactive demo pages when the backend is down
+- Add a CI/CD pipeline documentation page that explains the pipeline and why it's designed for a solo developer
+- Reorder the site header navigation to match the homepage card order
+
+## Health-Check Maintenance Screen
+
+### HealthGate Component
+
+A shared client component at `frontend/src/components/health-gate.tsx` that wraps each interactive demo page.
+
+**Behavior:**
+1. On mount, fetches the given health endpoint with a 3-second timeout
+2. While checking: renders a minimal loading skeleton (matching page background) to avoid layout flash
+3. If healthy (200 response): renders children (the demo page)
+4. If unhealthy (fetch fails, timeout, non-200): renders the maintenance screen
+
+**Props:**
+- `endpoint` — health check URL (e.g., `https://api.kylebradshaw.dev/chat/health`)
+- `stack` — display name for the service (e.g., "Python AI Services")
+- `docsHref` — link back to the documentation page (e.g., `/ai`)
+- `children` — the demo content to render when healthy
+
+### Maintenance Screen Design
+
+Style A from brainstorming: informative with context.
+
+- Wrench icon (🔧)
+- "Server Maintenance" heading
+- Maintenance message from `NEXT_PUBLIC_MAINTENANCE_MESSAGE` env var. Fallback: "The backend services are currently offline for maintenance. Please check back later."
+- Context box explaining what's happening
+- Back link to the documentation page for that stack
+
+### Health Endpoints Per Page
+
+| Page | Health Endpoint | Stack Label | Docs Link |
+|------|----------------|-------------|-----------|
+| `/ai/rag` | `{API_URL}/chat/health` | Python AI Services | `/ai` |
+| `/ai/debug` | `{API_URL}/debug/health` | Python AI Services | `/ai` |
+| `/java/tasks` (+ sub-pages) | `{GATEWAY_URL}/actuator/health` | Java Task Management | `/java` |
+| `/java/dashboard` | `{GATEWAY_URL}/actuator/health` | Java Task Management | `/java` |
+| `/go/ecommerce` (+ sub-pages) | `{GO_ECOMMERCE_URL}/health` | Go Ecommerce | `/go` |
+| `/go/login` | `{GO_AUTH_URL}/health` | Go Ecommerce | `/go` |
+| `/go/register` | `{GO_AUTH_URL}/health` | Go Ecommerce | `/go` |
+
+The `API_URL`, `GATEWAY_URL`, `GO_ECOMMERCE_URL`, and `GO_AUTH_URL` values come from the existing `NEXT_PUBLIC_*` env vars already used by each page.
+
+For pages with layouts that wrap multiple sub-pages (`/java/tasks/layout.tsx`, `/go/ecommerce/layout.tsx`), the HealthGate wraps at the layout level so all child pages inherit the health check.
+
+### Maintenance Message Env Var
+
+`NEXT_PUBLIC_MAINTENANCE_MESSAGE` — set in Vercel. Initial value: "Migrating to Linux for improved performance and reliability."
+
+Updated via `vercel env` when the reason for downtime changes. Falls back to a generic message if not set.
+
+## CI/CD Pipeline Documentation Page
+
+### Route
+
+`/cicd` — new top-level page. Static content, no backend dependency, no HealthGate needed.
+
+### Navigation
+
+Added to `SiteHeader` after Infrastructure & Deployment. Full header reordered to match homepage card order:
+
+**New nav order:** Go, Infrastructure & Deployment, Java, AI, CI/CD
+
+### Content Sections
+
+1. **Overview** — what the pipeline does, diagram of the full flow (PR → quality checks → QA deploy → prod deploy)
+2. **Why a unified workflow** — rationale for consolidating 3 workflows into 1, why path filtering was removed for simplicity
+3. **Trigger matrix** — table showing what runs on PR-to-qa, push-to-qa, push-to-main
+4. **Quality gates** — list of all checks (lint, test, security, k8s validation) with brief descriptions
+5. **QA environment** — separate namespaces, Kustomize overlays, CORS scoping, how QA mirrors production
+6. **Image tagging strategy** — `:qa-<sha>` vs `:latest`, GHCR registry
+7. **Deploy mechanism** — SSH via Tailscale to Windows/Linux PC, kubectl apply, selective restarts
+8. **Why no branch protection** — solo developer, code already reviewed in QA, branch protection would be one person approving their own PR
+9. **Agent automation** — how Claude Code agents drive the spec-to-QA pipeline, worktree lifecycle, the "ship it" flow
+10. **Smoke tests** — health endpoint checks for QA, Playwright for production
+
+### Implementation
+
+Standard Next.js page component with shadcn/ui typography. Diagrams rendered as styled HTML/CSS (same approach as existing architecture diagrams on `/ai`, `/java`, `/go` overview pages). Code snippets in `<pre>` blocks showing YAML fragments and workflow configuration.
+
+## Files Changed
+
+| Action | File | Purpose |
+|---|---|---|
+| Create | `frontend/src/components/health-gate.tsx` | Shared health-check wrapper component + maintenance screen |
+| Create | `frontend/src/app/cicd/page.tsx` | CI/CD pipeline documentation page |
+| Modify | `frontend/src/components/site-header.tsx` | Add CI/CD link, reorder nav: Go, AWS, Java, AI, CI/CD |
+| Modify | `frontend/src/app/ai/rag/page.tsx` | Wrap content with HealthGate |
+| Modify | `frontend/src/app/ai/debug/page.tsx` | Wrap content with HealthGate |
+| Modify | `frontend/src/app/java/tasks/layout.tsx` | Wrap with HealthGate (covers tasks + sub-pages) |
+| Modify | `frontend/src/app/java/dashboard/page.tsx` | Wrap with HealthGate |
+| Modify | `frontend/src/app/go/ecommerce/layout.tsx` | Wrap with HealthGate (covers ecommerce + sub-pages) |
+| Modify | `frontend/src/app/go/login/page.tsx` | Wrap with HealthGate |
+| Modify | `frontend/src/app/go/register/page.tsx` | Wrap with HealthGate |
+
+**Vercel env var:** `NEXT_PUBLIC_MAINTENANCE_MESSAGE` — added to production environment.
+
+## Verification
+
+1. **HealthGate works when backend is up:** demo pages render normally
+2. **HealthGate works when backend is down:** maintenance screen appears with correct stack name, message, and back link
+3. **Maintenance message env var:** setting/unsetting `NEXT_PUBLIC_MAINTENANCE_MESSAGE` changes the displayed text
+4. **CI/CD page:** renders with all sections, diagrams display correctly, code snippets are readable
+5. **Navigation:** header order matches homepage card order, CI/CD link works
+6. **Preflight:** `make preflight-frontend` passes (lint, tsc, build)
+
+## Follow-up (Out of Scope)
+
+- Separate QA database instances (address during Debian 12 migration)
+- Live health status indicators on the CI/CD page (could show real-time stack health)

--- a/docs/superpowers/specs/2026-04-14-restore-e2e-prestaging-design.md
+++ b/docs/superpowers/specs/2026-04-14-restore-e2e-prestaging-design.md
@@ -1,0 +1,78 @@
+# Restore E2E Pre-Staging Checks
+
+**Date:** 2026-04-14
+**Status:** Draft
+
+## Context
+
+The CI/CD overhaul (commit `9cec1cc`, 2026-04-13) unified three workflow files into a single `ci.yml` and replaced the old `e2e-staging` Playwright job with deeper infrastructure checks (`compose-smoke`, `k8s-manifest-validation`, `go-migration-test`). However, the `e2e-staging` job — which ran the mocked Playwright E2E suite as a pre-merge gate — was removed entirely rather than being migrated to the new branch model.
+
+**Problem:** With multiple agents creating PRs to `qa`, a frontend regression merged by one agent can block testing for all others. The mocked E2E tests catch these regressions cheaply (no backend needed) and should gate PR merges.
+
+## Design
+
+### 1. New CI job: `e2e-mocked`
+
+Add a single job to `.github/workflows/ci.yml` that restores the mocked Playwright E2E tests as a pre-merge staging check.
+
+**Triggers:**
+- `pull_request` to `qa` (pre-merge gate)
+- `push` to `qa` (post-merge small tweaks)
+- Does NOT run on `push` to `main` (compose-smoke and smoke-prod cover that)
+
+**Dependencies:** `needs: [frontend-checks]` — ensures the build passes before running E2E.
+
+**Condition:** `if: github.event_name == 'pull_request' || github.ref == 'refs/heads/qa'` — skips on push to main.
+
+**Steps:**
+1. Checkout code
+2. Set up Node 20 with npm cache
+3. `npm ci` in `frontend/`
+4. `npx playwright install --with-deps chromium`
+5. `npx playwright test` (runs default config: `e2e/mocked/` suite)
+6. Upload `frontend/playwright-report/` artifact on failure
+
+**Estimated CI time:** ~2-3 minutes (Node install + Playwright install + mocked tests).
+
+### 2. Update CI/CD frontend page (`frontend/src/app/cicd/page.tsx`)
+
+**"Why a Unified Workflow" section:** Rewrite to reflect Kyle's actual experience — started with separate workflows which were helpful for refining individual checks, but as a solo developer rarely stopped between stages, so unified made more practical sense. Also easier for Claude agents to follow and debug a single pipeline. No need to rigorously defend staging since no one else is using it — Kyle pushes minor tweaks directly to qa without feature branches, which is fine because there's no one else to disrupt.
+
+**Add staging checks context:** Update the page to explain that mocked E2E tests now run as a pre-merge staging check on PRs to `qa`, catching frontend regressions before actually deploying to QA.
+
+**Rewrite "Agent Automation" section:**
+- Add justification for why agent-driven workflow makes sense: solo developer, no risk of disrupting others' deployments.
+- Highlight that Kyle rigorously reviews specs before anything gets implemented — this is a major time investment and a critical human checkpoint.
+- Split the current "Spec → Plan" step into two distinct steps:
+  1. **Spec:** Kyle and Claude brainstorm the design. Kyle reviews the spec thoroughly before approving.
+  2. **Plan:** Once the spec is approved, Claude writes an implementation plan to keep track of what it needs to do during execution.
+- Highlight the quality steps that the superpowers plugin adds throughout the workflow:
+  - **Spec self-review:** After writing a spec, Claude automatically checks for placeholders, internal contradictions, ambiguity, and scope issues before presenting it to Kyle.
+  - **Code review agent:** After completing a major implementation step, a dedicated code-review agent examines the work against the plan and coding standards.
+  - **Verification before completion:** Before claiming work is done, Claude runs verification commands and confirms output — evidence before assertions.
+- The rest of the workflow (implement, CI watch, QA deploy, ship) stays similar.
+
+**Update trigger matrix:** Add a row for "E2E staging checks" showing it runs on PR to qa and push to qa but not push to main.
+
+**Update pipeline flow diagram:** Add E2E staging checks to the PR subgraph.
+
+### What this does NOT change
+
+- `compose-smoke` continues to run on all pushes (deeper Python stack E2E)
+- `smoke-prod` continues to run after production deploys (real Playwright against prod)
+- All other quality checks remain unchanged
+- No new branches or branch protection rules needed
+
+## Files to Modify
+
+- `.github/workflows/ci.yml` — add `e2e-mocked` job after the `frontend-checks` job
+- `frontend/src/app/cicd/page.tsx` — rewrite "Why a Unified Workflow" section, add staging checks info, update trigger matrix and pipeline diagram
+
+## Verification
+
+1. Create a test PR to `qa` and confirm the `e2e-mocked` job appears and runs
+2. Verify it depends on `frontend-checks` completing first
+3. Verify the Playwright report artifact is uploaded
+4. Push to `qa` and confirm the job runs there too
+5. Push to `main` and confirm the job is skipped
+6. Run `npm run dev` in `frontend/` and verify the CI/CD page renders correctly with updated content

--- a/docs/windows-pc-recovery.md
+++ b/docs/windows-pc-recovery.md
@@ -1,0 +1,57 @@
+# Windows PC Recovery After Power Outage
+
+When the Windows PC (100.79.113.84) restarts after a power outage, most services auto-start but Minikube and its tunnel need manual intervention.
+
+## Quick recovery
+
+Open an **admin PowerShell** (right-click Terminal → Run as administrator) and run:
+
+```powershell
+restartservices
+```
+
+This runs `C:\Users\PC\Scripts\Restart-Services.ps1`, which:
+1. Verifies Ollama is responding
+2. Verifies Cloudflared tunnel service is running
+3. Starts Minikube if stopped
+4. Waits for all pods to become ready (up to 3 minutes)
+5. Starts `minikube tunnel` in a minimized window
+6. Runs a health check to confirm ingress is working
+
+**Leave the minikube tunnel window open** — closing it kills ingress routing.
+
+## What auto-starts on boot
+
+- **Ollama** — startup app, GPU-accelerated
+- **Cloudflared** — Windows service, reconnects the Cloudflare Tunnel automatically
+
+## What does NOT auto-start
+
+- **Minikube** — must be started manually (`minikube start`)
+- **Minikube tunnel** — must be started manually in an admin terminal (`minikube tunnel`)
+
+## Verification
+
+After recovery, these should all return HTTP 200:
+
+```
+curl http://localhost/go-api/health
+curl http://localhost/grafana/api/health
+curl http://localhost/chat/health
+```
+
+Once working, the production site (kylebradshaw.dev) is also functional since Cloudflared routes through the same localhost:80 ingress.
+
+## From the Mac
+
+Re-establish the SSH tunnel for local dev if needed:
+
+```
+ssh -f -N -L 8000:localhost:8000 PC@100.79.113.84
+```
+
+## Files
+
+- **Script:** `C:\Users\PC\Scripts\Restart-Services.ps1`
+- **Profile alias:** `C:\Users\PC\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+- **Execution policy:** `RemoteSigned` (CurrentUser scope)

--- a/frontend/src/app/ai/debug/page.tsx
+++ b/frontend/src/app/ai/debug/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { DebugForm } from "@/components/DebugForm";
 import { AgentTimeline, AgentEvent } from "@/components/AgentTimeline";
+import { HealthGate } from "@/components/HealthGate";
 
 export default function DebugPage() {
   const [events, setEvents] = useState<AgentEvent[]>([]);
@@ -13,6 +14,7 @@ export default function DebugPage() {
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
   const debugApiUrl = `${apiUrl}/debug`;
+  const debugHealthUrl = `${apiUrl}/debug/health`;
 
   // Auto-scroll timeline as events arrive
   useEffect(() => {
@@ -107,50 +109,52 @@ export default function DebugPage() {
   );
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto max-w-6xl px-6 py-12">
-        {/* Navigation */}
-        <Link
-          href="/ai"
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          &larr; Back
-        </Link>
+    <HealthGate endpoint={debugHealthUrl} stack="Python AI Services" docsHref="/ai">
+      <div className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto max-w-6xl px-6 py-12">
+          {/* Navigation */}
+          <Link
+            href="/ai"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            &larr; Back
+          </Link>
 
-        {/* Header */}
-        <h1 className="mt-8 text-3xl font-bold">Debug Assistant</h1>
-        <p className="mt-2 text-muted-foreground leading-relaxed">
-          Index a Python project, describe a bug, and let the agent search
-          through your code to diagnose the issue.
-        </p>
+          {/* Header */}
+          <h1 className="mt-8 text-3xl font-bold">Debug Assistant</h1>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            Index a Python project, describe a bug, and let the agent search
+            through your code to diagnose the issue.
+          </p>
 
-        {/* Error Banner */}
-        {error && (
-          <div className="mt-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {error}
-          </div>
-        )}
+          {/* Error Banner */}
+          {error && (
+            <div className="mt-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
 
-        {/* 2-column grid */}
-        <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
-          {/* Left: Form */}
-          <div>
-            <h2 className="mb-4 text-lg font-semibold">Configure Debug Session</h2>
-            <DebugForm onSubmit={handleSubmit} isLoading={isLoading} />
-          </div>
+          {/* 2-column grid */}
+          <div className="mt-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
+            {/* Left: Form */}
+            <div>
+              <h2 className="mb-4 text-lg font-semibold">Configure Debug Session</h2>
+              <DebugForm onSubmit={handleSubmit} isLoading={isLoading} />
+            </div>
 
-          {/* Right: Timeline */}
-          <div className="flex flex-col">
-            <h2 className="mb-4 text-lg font-semibold">Agent Timeline</h2>
-            <div
-              ref={timelineRef}
-              className="flex-1 overflow-y-auto rounded-xl border border-foreground/10 bg-card p-4 min-h-96 max-h-[60vh]"
-            >
-              <AgentTimeline events={events} />
+            {/* Right: Timeline */}
+            <div className="flex flex-col">
+              <h2 className="mb-4 text-lg font-semibold">Agent Timeline</h2>
+              <div
+                ref={timelineRef}
+                className="flex-1 overflow-y-auto rounded-xl border border-foreground/10 bg-card p-4 min-h-96 max-h-[60vh]"
+              >
+                <AgentTimeline events={events} />
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/ai/rag/page.tsx
+++ b/frontend/src/app/ai/rag/page.tsx
@@ -6,6 +6,7 @@ import { ChatWindow, Message, Source } from "@/components/ChatWindow";
 import { MessageInput } from "@/components/MessageInput";
 import { FileUpload } from "@/components/FileUpload";
 import { DocumentList, Document } from "@/components/DocumentList";
+import { HealthGate } from "@/components/HealthGate";
 
 export default function RagDemo() {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -14,6 +15,7 @@ export default function RagDemo() {
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
   const ingestionBaseUrl = `${apiUrl}/ingestion`;
+  const chatHealthUrl = `${apiUrl}/chat/health`;
 
   const fetchDocuments = useCallback(async () => {
     try {
@@ -153,31 +155,33 @@ export default function RagDemo() {
   );
 
   return (
-    <div className="flex h-screen flex-col bg-background text-foreground">
-      {/* Header */}
-      <header className="flex items-center justify-between border-b px-6 py-3">
-        <div className="flex items-center gap-4">
-          <Link
-            href="/ai"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            &larr; Back
-          </Link>
-          <h1 className="text-lg font-semibold">Document Q&A Assistant</h1>
-        </div>
-        <div className="flex items-center gap-4">
-          {documents?.length > 0 && (
-            <DocumentList documents={documents} onDelete={handleDelete} />
-          )}
-          <FileUpload onUploaded={handleUploaded} />
-        </div>
-      </header>
+    <HealthGate endpoint={chatHealthUrl} stack="Python AI Services" docsHref="/ai">
+      <div className="flex h-screen flex-col bg-background text-foreground">
+        {/* Header */}
+        <header className="flex items-center justify-between border-b px-6 py-3">
+          <div className="flex items-center gap-4">
+            <Link
+              href="/ai"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              &larr; Back
+            </Link>
+            <h1 className="text-lg font-semibold">Document Q&A Assistant</h1>
+          </div>
+          <div className="flex items-center gap-4">
+            {documents?.length > 0 && (
+              <DocumentList documents={documents} onDelete={handleDelete} />
+            )}
+            <FileUpload onUploaded={handleUploaded} />
+          </div>
+        </header>
 
-      {/* Chat */}
-      <ChatWindow messages={messages} />
+        {/* Chat */}
+        <ChatWindow messages={messages} />
 
-      {/* Input */}
-      <MessageInput onSend={handleSend} disabled={isStreaming} />
-    </div>
+        {/* Input */}
+        <MessageInput onSend={handleSend} disabled={isStreaming} />
+      </div>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/cicd/page.tsx
+++ b/frontend/src/app/cicd/page.tsx
@@ -4,7 +4,8 @@ const pipelineFlowDiagram = `flowchart LR
   subgraph PR["Pull Request to qa"]
     direction LR
     A[PR Created] --> B[Quality Checks]
-    B --> C{All Pass?}
+    B --> B2[E2E Staging Checks]
+    B2 --> C{All Pass?}
     C -->|Yes| D[Ready for Review]
     C -->|No| E[Fix & Push]
     E --> B
@@ -13,7 +14,8 @@ const pipelineFlowDiagram = `flowchart LR
   subgraph QA["Push to qa"]
     direction LR
     F[PR Merged] --> G[Quality Checks]
-    G --> H[Build Images]
+    G --> G2[E2E Staging Checks]
+    G2 --> H[Build Images]
     H --> I[Deploy to QA]
     I --> J[Smoke Tests]
   end
@@ -83,19 +85,28 @@ export default function CICDPage() {
         <section className="mt-12">
           <h2 className="text-xl font-semibold">Why a Unified Workflow</h2>
           <p className="mt-2 text-muted-foreground leading-relaxed">
-            The project originally had three separate workflow files — one per
-            language stack. Each ran its own lint, test, and build jobs. For a
-            solo developer, this created unnecessary complexity: three files to
-            maintain, three sets of CI status checks to monitor, and path-based
-            filtering that occasionally skipped checks when cross-stack changes
-            were made.
+            I started with separate workflow files for each language stack —
+            Python, Java, and Go each had their own CI pipeline. That was
+            helpful early on for refining the specific checks I wanted per
+            stack. But as a solo developer, I found that I very rarely stopped
+            between stages. The separate workflows added maintenance overhead
+            without adding real decision points.
           </p>
           <p className="mt-4 text-muted-foreground leading-relaxed">
-            Consolidating into a single workflow simplified everything. All
-            quality gates run unconditionally on every trigger — no path
-            filtering, no change detection for quality checks. This is slower
-            (every push runs all checks regardless of what changed) but simpler
-            and catches cross-stack issues that path filtering would miss.
+            Consolidating into a single workflow made the pipeline easier to
+            reason about — both for me and for the Claude Code agents that drive
+            most of the development. One file to maintain, one set of status
+            checks to watch, and a single place to debug when something fails.
+            All quality gates run unconditionally on every trigger, which is
+            slower but catches cross-stack issues that path filtering would
+            miss.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Since I&apos;m the only one working on this project, there&apos;s no
+            need to rigorously defend the QA branch. I push minor tweaks
+            directly to <code>qa</code> without feature branches — there&apos;s
+            no one else to disrupt. The E2E staging checks still run on those
+            direct pushes, so regressions get caught before deploy.
           </p>
         </section>
 
@@ -124,6 +135,12 @@ export default function CICDPage() {
                   <td className="py-2 px-4 text-center">✓</td>
                   <td className="py-2 px-4 text-center">✓</td>
                   <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">E2E staging checks</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">—</td>
                 </tr>
                 <tr className="border-b border-border/50">
                   <td className="py-2 pr-4">Build images</td>
@@ -298,34 +315,58 @@ ssh PC@100.79.113.84 \\
         <section className="mt-12">
           <h2 className="text-xl font-semibold">Agent Automation</h2>
           <p className="mt-2 text-muted-foreground leading-relaxed">
-            Claude Code agents drive the development workflow from spec to
-            production. The pipeline is designed so agents can operate
-            autonomously through the QA stage, with human review at two points:
-            PR approval and the &ldquo;ship it&rdquo; command.
+            Since I&apos;m the only developer on this project, there&apos;s no
+            risk to letting Claude Code agents drive the workflow from spec to
+            production. No one else&apos;s deployment gets disrupted, and I
+            review every spec thoroughly before any code gets written.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            The agents use a{" "}
+            <a
+              href="https://github.com/nichochar/claude-plugins-official/tree/main/superpowers"
+              className="underline underline-offset-2"
+            >
+              superpowers
+            </a>{" "}
+            plugin that adds built-in quality gates throughout the workflow —
+            automated spec self-review, code review agents, and
+            verification-before-completion checks that require evidence before
+            claiming work is done.
           </p>
           <div className="mt-4 rounded-lg border border-border p-4">
             <ol className="space-y-2 text-sm text-muted-foreground">
               <li>
-                <strong className="text-foreground">1. Spec &rarr; Plan:</strong>{" "}
-                Agent brainstorms design, writes implementation plan
+                <strong className="text-foreground">1. Spec:</strong> Kyle and
+                Claude brainstorm the design together. Claude writes a spec,
+                then self-reviews it for placeholders, contradictions, and
+                ambiguity before presenting it. Kyle reviews the spec
+                thoroughly — this is the main human checkpoint.
+              </li>
+              <li>
+                <strong className="text-foreground">2. Plan:</strong> Once the
+                spec is approved, Claude writes a detailed implementation plan
+                to keep track of what it needs to do during execution.
               </li>
               <li>
                 <strong className="text-foreground">
-                  2. Implement &rarr; PR:
+                  3. Implement &rarr; PR:
                 </strong>{" "}
-                Agent creates feature branch, implements, pushes, creates PR to{" "}
-                <code>qa</code>
+                Agent creates a feature branch, implements the plan, and pushes
+                a PR to <code>qa</code>. A code-review agent examines the work
+                against the plan before the PR is created.
               </li>
               <li>
-                <strong className="text-foreground">3. CI Watch:</strong> Agent
-                monitors CI, fixes lint/format/config failures autonomously
+                <strong className="text-foreground">4. CI Watch:</strong> Agent
+                monitors CI, fixes lint/format/config failures autonomously.
+                Verification checks confirm the fix before claiming
+                it&apos;s resolved.
               </li>
               <li>
-                <strong className="text-foreground">4. QA Deploy:</strong> Kyle
+                <strong className="text-foreground">5. QA Deploy:</strong> Kyle
                 reviews PR, merges. QA deploys automatically.
               </li>
               <li>
-                <strong className="text-foreground">5. Ship It:</strong> Kyle
+                <strong className="text-foreground">6. Ship It:</strong> Kyle
                 inspects QA, tells agent to ship. Agent merges to main, watches
                 prod deploy, cleans up.
               </li>

--- a/frontend/src/app/cicd/page.tsx
+++ b/frontend/src/app/cicd/page.tsx
@@ -1,0 +1,350 @@
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const pipelineFlowDiagram = `flowchart LR
+  subgraph PR["Pull Request to qa"]
+    direction LR
+    A[PR Created] --> B[Quality Checks]
+    B --> C{All Pass?}
+    C -->|Yes| D[Ready for Review]
+    C -->|No| E[Fix & Push]
+    E --> B
+  end
+
+  subgraph QA["Push to qa"]
+    direction LR
+    F[PR Merged] --> G[Quality Checks]
+    G --> H[Build Images]
+    H --> I[Deploy to QA]
+    I --> J[Smoke Tests]
+  end
+
+  subgraph Prod["Push to main"]
+    direction LR
+    K[Ship It] --> L[Quality Checks]
+    L --> M[Build Images]
+    M --> N[Deploy to Prod]
+    N --> O[Smoke Tests]
+  end
+`;
+
+const qaArchitectureDiagram = `flowchart TB
+  subgraph Minikube["Minikube Cluster"]
+    subgraph ProdNS["Production Namespaces"]
+      direction LR
+      P1[ai-services]
+      P2[java-tasks]
+      P3[go-ecommerce]
+      P4[monitoring]
+    end
+    subgraph QANS["QA Namespaces"]
+      direction LR
+      Q1[ai-services-qa]
+      Q2[java-tasks-qa]
+      Q3[go-ecommerce-qa]
+    end
+  end
+
+  CF1[api.kylebradshaw.dev] --> P1
+  CF2[qa-api.kylebradshaw.dev] --> Q1
+
+  QANS -.->|shared infra| ProdNS
+`;
+
+export default function CICDPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="mt-8 text-3xl font-bold">CI/CD Pipeline</h1>
+
+        {/* Overview */}
+        <section className="mt-8">
+          <p className="text-muted-foreground leading-relaxed">
+            A unified GitHub Actions pipeline built for a solo developer. One
+            workflow file handles all quality checks, image builds, and
+            deployments for three service stacks (Python, Java, Go) and a Next.js
+            frontend. Designed to automate everything from code push to production
+            deploy, with a QA environment for visual inspection before shipping.
+          </p>
+        </section>
+
+        {/* Pipeline Flow */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Pipeline Flow</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Three triggers, one workflow. Every code change follows the same path
+            through quality gates before reaching production.
+          </p>
+          <div className="mt-4">
+            <MermaidDiagram chart={pipelineFlowDiagram} />
+          </div>
+        </section>
+
+        {/* Why Unified */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Why a Unified Workflow</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            The project originally had three separate workflow files — one per
+            language stack. Each ran its own lint, test, and build jobs. For a
+            solo developer, this created unnecessary complexity: three files to
+            maintain, three sets of CI status checks to monitor, and path-based
+            filtering that occasionally skipped checks when cross-stack changes
+            were made.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Consolidating into a single workflow simplified everything. All
+            quality gates run unconditionally on every trigger — no path
+            filtering, no change detection for quality checks. This is slower
+            (every push runs all checks regardless of what changed) but simpler
+            and catches cross-stack issues that path filtering would miss.
+          </p>
+        </section>
+
+        {/* Trigger Matrix */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Trigger Matrix</h2>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-2 pr-4 text-left font-medium">Job</th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    PR to qa
+                  </th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    Push to qa
+                  </th>
+                  <th className="py-2 px-4 text-center font-medium">
+                    Push to main
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Quality checks</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Build images</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">Deploy</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">QA</td>
+                  <td className="py-2 px-4 text-center">Prod</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">Smoke tests</td>
+                  <td className="py-2 px-4 text-center">—</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                  <td className="py-2 px-4 text-center">✓</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Quality Gates */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Quality Gates</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            22 parallel jobs run on every trigger. All must pass before images are
+            built.
+          </p>
+          <div className="mt-4 grid gap-3">
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Python</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Ruff lint + format, pytest with coverage (ingestion, chat, debug),
+                Bandit SAST, pip-audit
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Java</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Checkstyle, unit tests (4 services), integration tests with
+                Testcontainers
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Go</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                golangci-lint, go test -race (3 services), migration pipeline test
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Frontend</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                ESLint, TypeScript type check, Next.js build, npm audit
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Security</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Gitleaks (secrets), Hadolint (Dockerfiles), CORS guardrail (no
+                wildcard origins)
+              </p>
+            </div>
+            <div className="rounded-lg border border-border p-4">
+              <h3 className="text-sm font-medium">Infrastructure</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                K8s manifest validation (kubeconform + kind dry-run), Grafana
+                dashboard sync, Compose smoke test
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* QA Environment */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">QA Environment</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            QA runs in the same Minikube cluster as production using separate
+            Kubernetes namespaces. Kustomize overlays patch the base manifests to
+            set QA-specific CORS origins, database names, and ingress hosts —
+            without duplicating the manifests themselves.
+          </p>
+          <div className="mt-4">
+            <MermaidDiagram chart={qaArchitectureDiagram} />
+          </div>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="py-2 pr-4 text-left font-medium">
+                    Production
+                  </th>
+                  <th className="py-2 px-4 text-left font-medium">QA</th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">ai-services</td>
+                  <td className="py-2 px-4">ai-services-qa</td>
+                </tr>
+                <tr className="border-b border-border/50">
+                  <td className="py-2 pr-4">java-tasks</td>
+                  <td className="py-2 px-4">java-tasks-qa</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">go-ecommerce</td>
+                  <td className="py-2 px-4">go-ecommerce-qa</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Image Tagging */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Image Tagging</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            All 10 service images are built in a single matrix job and pushed to
+            GitHub Container Registry. QA images use a commit-pinned tag for
+            traceability; production uses <code>:latest</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm">
+{`# QA (push to qa branch)
+ghcr.io/kabradshaw1/portfolio/ingestion:qa-abc1234
+
+# Production (push to main branch)
+ghcr.io/kabradshaw1/portfolio/ingestion:latest`}
+          </pre>
+        </section>
+
+        {/* Deploy Mechanism */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Deploy Mechanism</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            GitHub Actions joins a Tailscale VPN to reach the home server, then
+            deploys via SSH. Kustomize overlays are built on the runner and piped
+            to the server via <code>kubectl apply</code>.
+          </p>
+          <pre className="mt-4 overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-sm">
+{`# CI runner joins Tailscale VPN
+- uses: tailscale/github-action@v3
+
+# Build overlay locally, apply remotely
+kubectl kustomize k8s/overlays/qa/ | \\
+  ssh PC@100.79.113.84 "kubectl apply -f -"
+
+# Restart deployments to pull new images
+ssh PC@100.79.113.84 \\
+  "kubectl rollout restart deployment -n ai-services-qa"`}
+          </pre>
+        </section>
+
+        {/* No Branch Protection */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Why No Branch Protection</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            This is a solo developer project. By the time code reaches{" "}
+            <code>main</code>, it has passed all quality checks on the PR, been
+            deployed to QA, and been visually inspected. Branch protection
+            requiring PR approval would mean one person approving their own PR —
+            ceremony with no value.
+          </p>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            The real protection is the CI pipeline itself: 22 quality gates that
+            run on every push. If any fail, the deploy doesn&apos;t happen.
+          </p>
+        </section>
+
+        {/* Agent Automation */}
+        <section className="mt-12">
+          <h2 className="text-xl font-semibold">Agent Automation</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            Claude Code agents drive the development workflow from spec to
+            production. The pipeline is designed so agents can operate
+            autonomously through the QA stage, with human review at two points:
+            PR approval and the &ldquo;ship it&rdquo; command.
+          </p>
+          <div className="mt-4 rounded-lg border border-border p-4">
+            <ol className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                <strong className="text-foreground">1. Spec &rarr; Plan:</strong>{" "}
+                Agent brainstorms design, writes implementation plan
+              </li>
+              <li>
+                <strong className="text-foreground">
+                  2. Implement &rarr; PR:
+                </strong>{" "}
+                Agent creates feature branch, implements, pushes, creates PR to{" "}
+                <code>qa</code>
+              </li>
+              <li>
+                <strong className="text-foreground">3. CI Watch:</strong> Agent
+                monitors CI, fixes lint/format/config failures autonomously
+              </li>
+              <li>
+                <strong className="text-foreground">4. QA Deploy:</strong> Kyle
+                reviews PR, merges. QA deploys automatically.
+              </li>
+              <li>
+                <strong className="text-foreground">5. Ship It:</strong> Kyle
+                inspects QA, tells agent to ship. Agent merges to main, watches
+                prod deploy, cleans up.
+              </li>
+            </ol>
+          </div>
+        </section>
+
+        {/* Smoke Tests */}
+        <section className="mt-12 mb-16">
+          <h2 className="text-xl font-semibold">Smoke Tests</h2>
+          <p className="mt-2 text-muted-foreground leading-relaxed">
+            After every deployment, automated smoke tests verify the services are
+            healthy. QA runs health endpoint checks against{" "}
+            <code>qa-api.kylebradshaw.dev</code>. Production runs Playwright
+            tests against the live site — including an end-to-end RAG flow that
+            uploads a PDF, asks a question, and verifies a streamed response.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/go/ecommerce/layout.tsx
+++ b/frontend/src/app/go/ecommerce/layout.tsx
@@ -1,5 +1,11 @@
+"use client";
+
 import { GoSubHeader } from "@/components/go/GoSubHeader";
 import { AiAssistantDrawer } from "@/components/go/AiAssistantDrawer";
+import { HealthGate } from "@/components/HealthGate";
+
+const goEcommerceUrl =
+  process.env.NEXT_PUBLIC_GO_ECOMMERCE_URL || "http://localhost:8092";
 
 export default function GoEcommerceLayout({
   children,
@@ -7,10 +13,14 @@ export default function GoEcommerceLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <HealthGate
+      endpoint={`${goEcommerceUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
       <GoSubHeader />
       {children}
       <AiAssistantDrawer />
-    </>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/go/login/page.tsx
+++ b/frontend/src/app/go/login/page.tsx
@@ -6,12 +6,22 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { GoGoogleLoginButton } from "@/components/go/GoGoogleLoginButton";
 import { useGoAuth } from "@/components/go/GoAuthProvider";
+import { HealthGate } from "@/components/HealthGate";
+
+const goAuthUrl =
+  process.env.NEXT_PUBLIC_GO_AUTH_URL || "http://localhost:8091";
 
 export default function GoLoginPage() {
   return (
-    <Suspense fallback={<div className="mx-auto max-w-sm px-6 py-12">Loading…</div>}>
-      <GoLoginPageInner />
-    </Suspense>
+    <HealthGate
+      endpoint={`${goAuthUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <Suspense fallback={<div className="mx-auto max-w-sm px-6 py-12">Loading…</div>}>
+        <GoLoginPageInner />
+      </Suspense>
+    </HealthGate>
   );
 }
 

--- a/frontend/src/app/go/register/page.tsx
+++ b/frontend/src/app/go/register/page.tsx
@@ -6,6 +6,10 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { GoGoogleLoginButton } from "@/components/go/GoGoogleLoginButton";
 import { useGoAuth } from "@/components/go/GoAuthProvider";
+import { HealthGate } from "@/components/HealthGate";
+
+const goAuthUrl =
+  process.env.NEXT_PUBLIC_GO_AUTH_URL || "http://localhost:8091";
 
 export default function GoRegisterPage() {
   const router = useRouter();
@@ -34,58 +38,64 @@ export default function GoRegisterPage() {
   );
 
   return (
-    <div className="mx-auto max-w-sm px-6 py-12">
-      <h1 className="text-2xl font-bold">Create account</h1>
-      <form onSubmit={handleSubmit} className="mt-6 space-y-3">
-        <input
-          type="text"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-          disabled={busy}
-          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
-        />
-        <input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-          disabled={busy}
-          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
-        />
-        <input
-          type="password"
-          placeholder="Password (min 8 chars)"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-          minLength={8}
-          disabled={busy}
-          className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
-        />
-        <Button type="submit" disabled={busy} className="w-full">
-          {busy ? "Creating account…" : "Create account"}
-        </Button>
-      </form>
+    <HealthGate
+      endpoint={`${goAuthUrl}/health`}
+      stack="Go Ecommerce"
+      docsHref="/go"
+    >
+      <div className="mx-auto max-w-sm px-6 py-12">
+        <h1 className="text-2xl font-bold">Create account</h1>
+        <form onSubmit={handleSubmit} className="mt-6 space-y-3">
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            disabled={busy}
+            className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            disabled={busy}
+            className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
+          />
+          <input
+            type="password"
+            placeholder="Password (min 8 chars)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            minLength={8}
+            disabled={busy}
+            className="w-full rounded border border-foreground/20 bg-background px-3 py-2 text-sm"
+          />
+          <Button type="submit" disabled={busy} className="w-full">
+            {busy ? "Creating account…" : "Create account"}
+          </Button>
+        </form>
 
-      <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
-        <div className="h-px flex-1 bg-foreground/10" />
-        <span>or</span>
-        <div className="h-px flex-1 bg-foreground/10" />
+        <div className="my-6 flex items-center gap-3 text-xs text-muted-foreground">
+          <div className="h-px flex-1 bg-foreground/10" />
+          <span>or</span>
+          <div className="h-px flex-1 bg-foreground/10" />
+        </div>
+
+        <GoGoogleLoginButton />
+
+        {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link href="/go/login" className="underline hover:text-foreground">
+            Sign in
+          </Link>
+        </p>
       </div>
-
-      <GoGoogleLoginButton />
-
-      {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
-
-      <p className="mt-6 text-center text-sm text-muted-foreground">
-        Already have an account?{" "}
-        <Link href="/go/login" className="underline hover:text-foreground">
-          Sign in
-        </Link>
-      </p>
-    </div>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/java/dashboard/page.tsx
+++ b/frontend/src/app/java/dashboard/page.tsx
@@ -1,10 +1,26 @@
+"use client";
+
 import { Suspense } from "react";
+import { HealthGate } from "@/components/HealthGate";
 import { DashboardClient } from "./dashboard-client";
+
+const gatewayUrl =
+  process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:8080";
 
 export default function DashboardPage() {
   return (
-    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading…</div>}>
-      <DashboardClient />
-    </Suspense>
+    <HealthGate
+      endpoint={`${gatewayUrl}/actuator/health`}
+      stack="Java Task Management"
+      docsHref="/java"
+    >
+      <Suspense
+        fallback={
+          <div className="p-6 text-sm text-muted-foreground">Loading…</div>
+        }
+      >
+        <DashboardClient />
+      </Suspense>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/java/tasks/layout.tsx
+++ b/frontend/src/app/java/tasks/layout.tsx
@@ -1,4 +1,10 @@
+"use client";
+
 import { JavaSubHeader } from "@/components/java/JavaSubHeader";
+import { HealthGate } from "@/components/HealthGate";
+
+const gatewayUrl =
+  process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:8080";
 
 export default function JavaTasksLayout({
   children,
@@ -6,9 +12,13 @@ export default function JavaTasksLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
+    <HealthGate
+      endpoint={`${gatewayUrl}/actuator/health`}
+      stack="Java Task Management"
+      docsHref="/java"
+    >
       <JavaSubHeader />
       {children}
-    </>
+    </HealthGate>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -109,6 +109,24 @@ export default function Home() {
               </CardContent>
             </Card>
           </Link>
+          <Link href="/cicd" className="block">
+            <Card className="hover:ring-foreground/20 transition-all">
+              <CardHeader>
+                <CardTitle>CI/CD Pipeline</CardTitle>
+                <CardDescription>
+                  Unified GitHub Actions workflow with QA environment and agent
+                  automation
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-sm">
+                  A single workflow handles quality checks, image builds, and
+                  deployments for three service stacks — designed for a solo
+                  developer with automated spec-to-production delivery.
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/components/HealthGate.tsx
+++ b/frontend/src/components/HealthGate.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+interface HealthGateProps {
+  endpoint: string;
+  stack: string;
+  docsHref: string;
+  children: React.ReactNode;
+}
+
+export function HealthGate({ endpoint, stack, docsHref, children }: HealthGateProps) {
+  const [status, setStatus] = useState<"checking" | "healthy" | "unhealthy">("checking");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    fetch(endpoint, { signal: controller.signal })
+      .then((res) => {
+        setStatus(res.ok ? "healthy" : "unhealthy");
+      })
+      .catch(() => {
+        setStatus("unhealthy");
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+      });
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, [endpoint]);
+
+  if (status === "checking") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-background">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (status === "unhealthy") {
+    const message =
+      process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
+      "The backend services are currently offline for maintenance. Please check back later.";
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-background px-6">
+        <div className="max-w-md text-center">
+          <div className="text-5xl">🔧</div>
+          <h2 className="mt-4 text-2xl font-bold text-foreground">
+            Server Maintenance
+          </h2>
+          <p className="mt-3 text-muted-foreground">{message}</p>
+          <div className="mt-6 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
+            <strong className="text-foreground">{stack}</strong> is currently
+            unavailable.
+          </div>
+          <Link
+            href={docsHref}
+            className="mt-6 inline-block text-sm text-primary hover:underline"
+          >
+            &larr; View documentation instead
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -23,17 +23,20 @@ export function SiteHeader() {
             Kyle Bradshaw
           </Link>
           <nav className="flex items-center gap-4">
-            <Link href="/ai" className={navLinkClass("/ai")}>
-              AI
-            </Link>
-            <Link href="/java" className={navLinkClass("/java")}>
-              Java
-            </Link>
             <Link href="/go" className={navLinkClass("/go")}>
               Go
             </Link>
             <Link href="/aws" className={navLinkClass("/aws")}>
               AWS
+            </Link>
+            <Link href="/java" className={navLinkClass("/java")}>
+              Java
+            </Link>
+            <Link href="/ai" className={navLinkClass("/ai")}>
+              AI
+            </Link>
+            <Link href="/cicd" className={navLinkClass("/cicd")}>
+              CI/CD
             </Link>
           </nav>
         </div>

--- a/prompt.md
+++ b/prompt.md
@@ -1,2 +1,5 @@
-Command contains ambiguous syntax with command separators that could be misinterpreted
-Compound commands with cd and git require approval to prevent bare repository attacks
+want to rebuild my CI/CD pipeline.  This should be design to consider my team is currently only 1, and will likely not have more than 2 developers any time soon.  I wan to add a QA stop. I want to go to a single unified worflow for getting the changes into QA.  It should deploy a functionally idential set of services that are served with cors set to only be accessable from my 2 development machines.  I think this should be triggered by a pull request into the QA branch.   
+
+I also want to update my worflow.  I think I wan to make it as automatic as possible.  When we I crate a spec with the brainstorm skill, I want to try and automate it to go all the way to QA.  This means that agents should do all commit and pull requests, they should wait for the github actions, and debug any problems.  Agents should create a worktree in .claude.  Once they successfully get the changes into QA, they should prompt me to go inspect the changes.  I want to think about if we need to clean up the work tree first, or wait until it's decided if we want to keep the changes.  
+
+I can manually merge main and push it myself.  


### PR DESCRIPTION
## Summary
- Add `e2e-mocked` job to CI workflow — runs Playwright mocked E2E tests on PRs to `qa` and pushes to `qa` as a pre-merge staging gate
- Rewrite "Why a Unified Workflow" section on CI/CD page with solo-dev rationale
- Expand "Agent Automation" section to highlight superpowers quality gates (spec self-review, code review agent, verification-before-completion)
- Add E2E staging checks to trigger matrix and pipeline flow diagram
- Update CLAUDE.md push rules: don't ask before pushing or creating PRs on feature/qa branches

## Test plan
- [ ] Verify CI/CD page renders correctly with updated content (`npm run dev`, visit `/cicd`)
- [ ] Confirm `e2e-mocked` job appears in CI on this PR
- [ ] Confirm trigger matrix table shows E2E staging checks row
- [ ] Confirm pipeline diagram includes E2E staging checks nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)