### PR TITLE
fix: resolve QA deploy Kustomize namespace conflict

### DIFF
--- a/go/k8s/overlays/qa/kustomization.yaml
+++ b/go/k8s/overlays/qa/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../
-  - namespace.yml
 
 namespace: go-ecommerce-qa
 

--- a/java/k8s/overlays/qa/kustomization.yaml
+++ b/java/k8s/overlays/qa/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../
-  - namespace.yml
 
 namespace: java-tasks-qa
 

--- a/k8s/overlays/qa/kustomization.yaml
+++ b/k8s/overlays/qa/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 resources:
   - ../../ai-services
-  - namespace.yml
   - ollama.yml
 
 namespace: ai-services-qa


### PR DESCRIPTION
## Summary

- Remove duplicate `namespace.yml` from QA Kustomize overlays (ai-services, java-tasks, go-ecommerce)
- The base kustomizations already include a namespace resource which gets transformed by the `namespace:` directive — having a second one caused `namespace transformation produces ID conflict`
- Also includes the E2E health mock fix from the previous PR

## Test plan

- [ ] CI passes
- [ ] QA deploy succeeds (no Kustomize conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)