### PR TITLE
fix(gateway): forward cookie auth as Bearer to downstream services

### DIFF
--- a/docs/superpowers/plans/2026-04-16-debian-host-hardening.md
+++ b/docs/superpowers/plans/2026-04-16-debian-host-hardening.md
@@ -1,0 +1,916 @@
+# Debian 13 Host Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Take the Debian 13 production host (`debian` / `100.82.52.82`) from "works but partially exposed" to "internet-exposed-but-locked-down": Tailscale-only SSH, UFW with default-deny, narrow passwordless sudo for routine ops, auto-start for Minikube + ethernet, and baseline auditing (auditd, journald persistence, sysctl hardening, lynis report).
+
+**Architecture:** Three phases with explicit Kyle-approval gates between them. Phase 1 stages everything risky (UFW rules, snapshots) without enabling. Phase 2 enables in order: UFW → SSH lockdown → sudo narrowing, with verification after each. Phase 3 adds auditing/kernel hardening (low risk, no per-step gates). Every Phase 2 change is a *new* file (not an edit), so console rollback is always "delete one file, reload one service." Snapshots taken before Phase 2 and Phase 3.
+
+**Tech Stack:**
+- Debian 13.4, kernel 6.12.73, single user `kyle`
+- `systemd` (units, drop-ins, journald), `ufw`, `openssh-server`, `sudo`/`visudo`
+- `auditd`, `lynis`, `fail2ban`, AppArmor (Debian default)
+- Networking: `ifupdown` (`/etc/network/interfaces`) currently — fall back to `systemd-networkd` if needed
+- Remote ops via `ssh debian` from Mac (key-based, alias in `~/.ssh/config`)
+
+**Source spec:** `docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md`
+
+**Repo deliverables (committed on `main`, no push without Kyle approval):**
+- `docs/security/lynis-baseline-2026-04-16.log` — baseline audit report
+- `docs/adr/2026-04-16-debian-host-hardening.md` — short ADR capturing final state and key decisions
+
+---
+
+## Phase 1: Bootstrap & Quick Wins
+
+### Task 1: Bootstrap — grant agent temporary NOPASSWD ALL
+
+**Files:**
+- Create on `debian`: `/etc/sudoers.d/kyle-temp`
+
+This task requires Kyle to type the command (sudo password). Everything after this is unattended.
+
+- [ ] **Step 1: Show Kyle the bootstrap command**
+
+Output to chat:
+```
+! ssh -t debian 'sudo bash -c "
+  cat > /tmp/kyle-temp.sudoers <<EOF
+# Temporary unrestricted sudo for agent during host-hardening work.
+# This file is removed automatically in Phase 2 (replaced by kyle-ops).
+kyle ALL=(ALL) NOPASSWD: ALL
+EOF
+  visudo -c -f /tmp/kyle-temp.sudoers && \
+    install -m 0440 -o root -g root /tmp/kyle-temp.sudoers /etc/sudoers.d/kyle-temp && \
+    rm /tmp/kyle-temp.sudoers && \
+    echo BOOTSTRAP_OK
+"'
+```
+
+- [ ] **Step 2: Wait for Kyle to confirm `BOOTSTRAP_OK`**
+
+If Kyle reports anything other than `BOOTSTRAP_OK` (e.g., `visudo` parse error), STOP and debug before continuing.
+
+- [ ] **Step 3: Verify passwordless sudo works for the agent**
+
+```bash
+ssh debian 'sudo -n true && echo SUDO_OK'
+```
+Expected: `SUDO_OK`
+
+- [ ] **Step 4: No commit (remote-only change)**
+
+---
+
+### Task 2: Install minikube auto-start systemd units
+
+**Files:**
+- Create on `debian`: `/etc/systemd/system/minikube.service`
+- Replace on `debian`: `/etc/systemd/system/minikube-tunnel.service`
+
+- [ ] **Step 1: Stage `minikube.service` to `/tmp` on debian**
+
+```bash
+ssh debian 'cat > /tmp/minikube.service <<EOF
+[Unit]
+Description=Minikube Cluster
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=kyle
+Group=kyle
+Environment=HOME=/home/kyle
+Environment=MINIKUBE_HOME=/home/kyle/.minikube
+ExecStart=/usr/local/bin/minikube start
+ExecStop=/usr/local/bin/minikube stop
+TimeoutStartSec=600
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+```
+
+- [ ] **Step 2: Stage updated `minikube-tunnel.service` to `/tmp` on debian**
+
+```bash
+ssh debian 'cat > /tmp/minikube-tunnel.service <<EOF
+[Unit]
+Description=Minikube Tunnel
+After=minikube.service
+Requires=minikube.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/minikube tunnel --cleanup=true
+Environment=HOME=/home/kyle
+Environment=MINIKUBE_HOME=/home/kyle/.minikube
+User=kyle
+Group=kyle
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+```
+
+- [ ] **Step 3: Verify `which minikube` is `/usr/local/bin/minikube` (the path baked into the units)**
+
+```bash
+ssh debian 'which minikube'
+```
+Expected: `/usr/local/bin/minikube`. If different, edit the staged unit files in `/tmp` to match before installing.
+
+- [ ] **Step 4: Install both units, reload systemd, enable**
+
+```bash
+ssh debian 'sudo install -m 644 /tmp/minikube.service /etc/systemd/system/minikube.service && \
+            sudo install -m 644 /tmp/minikube-tunnel.service /etc/systemd/system/minikube-tunnel.service && \
+            sudo systemctl daemon-reload && \
+            sudo systemctl enable minikube.service minikube-tunnel.service && \
+            echo INSTALL_OK'
+```
+Expected: `INSTALL_OK` (plus `Created symlink` lines from `enable`).
+
+- [ ] **Step 5: Verify both units are enabled and active**
+
+```bash
+ssh debian 'systemctl is-enabled minikube.service minikube-tunnel.service && \
+            systemctl is-active minikube.service minikube-tunnel.service'
+```
+Expected: 4 lines, `enabled` `enabled` `active` `active`.
+
+- [ ] **Step 6: No commit (remote-only change)**
+
+---
+
+### Task 3: Install UFW with default-deny and allow rules (rules drafted, firewall NOT enabled)
+
+**Files:**
+- Install on `debian`: `ufw` package
+- Configure on `debian`: UFW rules (in-memory; written by `ufw allow` commands)
+
+- [ ] **Step 1: Install ufw**
+
+```bash
+ssh debian 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ufw && echo UFW_INSTALLED'
+```
+Expected: `UFW_INSTALLED`.
+
+- [ ] **Step 2: Set default policies**
+
+```bash
+ssh debian 'sudo ufw default deny incoming && sudo ufw default allow outgoing'
+```
+Expected: two `Default ... policy changed to ...` confirmations.
+
+- [ ] **Step 3: Add allow rules**
+
+```bash
+ssh debian '
+  sudo ufw allow proto tcp from 100.64.0.0/10 to any port 22 comment "ssh from tailnet" && \
+  sudo ufw allow proto tcp from 192.168.1.0/24 to any port 22 comment "ssh from LAN (removed in Phase 2)" && \
+  sudo ufw allow proto tcp from 172.17.0.0/16 to any port 11434 comment "ollama from docker bridge" && \
+  sudo ufw allow proto tcp from 100.64.0.0/10 to any port 11434 comment "ollama from tailnet"
+'
+```
+
+- [ ] **Step 4: Verify rules listed but UFW still inactive**
+
+```bash
+ssh debian 'sudo ufw status verbose'
+```
+Expected: `Status: inactive` followed by the four allow rules in the "Anywhere" section. **Do not enable here** — that's Phase 2.
+
+- [ ] **Step 5: No commit (remote-only change)**
+
+---
+
+### Task 4: Fix ethernet auto-connect
+
+**Files:**
+- Inspect on `debian`: `/etc/network/interfaces`
+- Possibly modify or replace on `debian`: `/etc/network/interfaces` OR `/etc/systemd/network/10-ethernet.network`
+
+The current config uses `ifupdown` (neither NetworkManager nor systemd-networkd is active). Two paths depending on what's already there: prefer fixing `ifupdown`, fall back to `systemd-networkd`.
+
+- [ ] **Step 1: Identify the ethernet interface name**
+
+```bash
+ssh debian 'ls /sys/class/net/ | grep -E "^en|^eth"'
+```
+Expected: typically one interface like `enp4s0` or `eno1`. Note the name (used below as `<IFACE>`).
+
+- [ ] **Step 2: Inspect `/etc/network/interfaces`**
+
+```bash
+ssh debian 'cat /etc/network/interfaces; echo ---; ls /etc/network/interfaces.d/ 2>/dev/null'
+```
+
+- [ ] **Step 3: Decision branch — `ifupdown` path**
+
+If the interface (`<IFACE>`) is mentioned in `/etc/network/interfaces` or `/etc/network/interfaces.d/` but lacks an `auto <IFACE>` line, append it (using `sudo tee -a` so the redirection runs as root):
+
+```bash
+ssh debian 'sudo tee -a /etc/network/interfaces > /dev/null <<EOF
+
+auto <IFACE>
+iface <IFACE> inet dhcp
+EOF'
+```
+
+(Adjust if it already has an `iface` block — append only the missing `auto <IFACE>` line.)
+
+- [ ] **Step 3 (alternative): Decision branch — `systemd-networkd` path**
+
+If `/etc/network/interfaces` is empty / does not mention the interface, install a minimal systemd-networkd config:
+
+```bash
+ssh debian 'sudo bash -c "cat > /etc/systemd/network/10-ethernet.network <<EOF
+[Match]
+Name=<IFACE>
+
+[Network]
+DHCP=yes
+EOF
+systemctl enable --now systemd-networkd systemd-resolved"'
+```
+
+- [ ] **Step 4: Test by toggling the link**
+
+```bash
+ssh debian 'sudo ip link set <IFACE> down && sleep 2 && sudo ip link set <IFACE> up && sleep 5 && ip -4 addr show <IFACE>'
+```
+Expected: an `inet 192.168.x.x/24` line within ~5s of bringing the interface back up.
+
+- [ ] **Step 5: No commit (remote-only change)**
+
+---
+
+### Task 5: Flag stale Tailscale node for Kyle
+
+**Files:** None — this is a Tailscale admin-console action.
+
+- [ ] **Step 1: Confirm `pc-master-race` is still in the tailnet**
+
+```bash
+ssh debian 'tailscale status | grep pc-master-race || echo NODE_GONE'
+```
+
+If `NODE_GONE`, skip the rest of this task.
+
+- [ ] **Step 2: Tell Kyle**
+
+> "Heads up — `pc-master-race` (the old Windows PC) is still in your tailnet (offline 2 days). It's safe to delete from the Tailscale admin console at https://login.tailscale.com/admin/machines. I can't do this from the host. Confirm when removed (or skip)."
+
+- [ ] **Step 3: Wait for Kyle's confirmation, then continue**
+
+---
+
+### Task 6: Phase 1 verification gate (reboot test)
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Tell Kyle Phase 1 is done and request a reboot**
+
+> "Phase 1 staged. Want to reboot now to confirm everything auto-starts cleanly? Run: `! ssh debian sudo reboot`. SSH will drop; reconnect in ~60s."
+
+- [ ] **Step 2: After Kyle confirms reboot, wait for SSH to recover**
+
+```bash
+ssh debian 'echo BACK; uptime'
+```
+
+- [ ] **Step 3: Verify all services are up**
+
+```bash
+ssh debian '
+  echo "=== systemd units ==="
+  systemctl is-active docker minikube minikube-tunnel ollama cloudflared fail2ban
+  echo "=== ethernet ==="
+  ip -4 addr show | grep inet | grep -v 127.0.0.1
+  echo "=== ufw (should be inactive) ==="
+  sudo ufw status | head -1
+  echo "=== minikube cluster ==="
+  kubectl get nodes
+'
+```
+Expected: 6 `active` lines, an `inet 192.168.x.x` line, `Status: inactive`, one `Ready` node.
+
+- [ ] **Step 4: Verify K8s pods are recovering**
+
+```bash
+ssh debian 'kubectl get pods -A | grep -vE "Running|Completed" | head -20'
+```
+Expected: empty (or only the pre-existing `jaeger` ImagePull issue).
+
+If any new pods are stuck, debug before proceeding.
+
+- [ ] **Step 5: Verify Ollama still reachable from a pod**
+
+```bash
+ssh debian 'kubectl -n ai-services exec deploy/chat -- curl -s --max-time 5 http://host.minikube.internal:11434/api/tags | head -c 80'
+```
+Expected: a JSON snippet starting `{"models":[`.
+
+- [ ] **Step 6: Verify Ollama still reachable from Mac over LAN (UFW still off)**
+
+```bash
+curl -s --max-time 5 http://<debian-lan-ip>:11434/api/tags | head -c 80
+```
+Expected: same JSON snippet.
+
+- [ ] **Step 7: Hand off to Kyle for Phase 2 approval**
+
+> "Phase 1 verified clean: minikube, tunnel, ollama, ethernet all auto-started, kubectl works, pods reach Ollama. Ready for Phase 2 (lockdown — UFW enable, SSH Tailscale-only, sudo narrow). Approve to proceed?"
+
+---
+
+## Phase 2: Lockdown
+
+### Task 7: Take pre-Phase-2 snapshots
+
+**Files:**
+- Create on `debian`: `/root/etc-ssh-backup-2026-04-16/`, `/root/sudoers-backup-2026-04-16/`
+
+- [ ] **Step 1: Snapshot `/etc/ssh` and `/etc/sudoers.d`**
+
+```bash
+ssh debian 'sudo cp -a /etc/ssh /root/etc-ssh-backup-2026-04-16/ && \
+            sudo cp -a /etc/sudoers.d /root/sudoers-backup-2026-04-16/ && \
+            ls -la /root/ | grep 2026-04-16'
+```
+Expected: two new directories listed.
+
+- [ ] **Step 2: No commit (remote-only)**
+
+---
+
+### Task 8: Enable UFW + verify
+
+**Files:** None — applies the rules drafted in Task 3.
+
+- [ ] **Step 1: Enable UFW**
+
+```bash
+ssh debian 'sudo ufw --force enable && sudo ufw status verbose'
+```
+Expected: `Status: active` plus the four allow rules. (`--force` skips the interactive "this may disconnect SSH" prompt — safe because Tailscale SSH is allowed.)
+
+- [ ] **Step 2: Verify SSH (current session) still alive**
+
+The current SSH session must not have dropped. If it did, that's a Tailscale routing issue — investigate immediately.
+
+- [ ] **Step 3: Verify K8s pods can still reach Ollama**
+
+```bash
+ssh debian 'kubectl -n ai-services exec deploy/chat -- curl -s --max-time 5 http://host.minikube.internal:11434/api/tags | head -c 80'
+```
+Expected: `{"models":[...` JSON snippet.
+
+- [ ] **Step 4: Verify LAN SSH still works (we kept the rule)**
+
+From Mac: `ssh kyle@<debian-lan-ip> 'echo LAN_SSH_OK'`
+Expected: `LAN_SSH_OK`. (LAN rule will be removed in Task 10.)
+
+- [ ] **Step 5: Confirm with Kyle**
+
+> "UFW enabled. SSH (Tailscale + LAN) still works, pods still reach Ollama. Proceed to SSH lockdown?"
+
+---
+
+### Task 9: Lock SSH to Tailscale-only
+
+**Files:**
+- Create on `debian`: `/etc/ssh/sshd_config.d/10-hardening.conf`
+
+- [ ] **Step 1: Stage the SSH hardening drop-in**
+
+```bash
+ssh debian 'cat > /tmp/10-hardening.conf <<EOF
+# SSH hardening — Tailscale-only listener, key-only auth.
+# Remove this file and reload sshd to revert.
+ListenAddress 100.82.52.82
+ListenAddress 127.0.0.1
+AllowUsers kyle
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+MaxAuthTries 3
+LoginGraceTime 20
+ClientAliveInterval 300
+ClientAliveCountMax 2
+EOF
+sudo sshd -t -f /etc/ssh/sshd_config && echo BASE_CONFIG_VALID'
+```
+Expected: `BASE_CONFIG_VALID` (validates the existing config still parses; the drop-in will be checked on install).
+
+- [ ] **Step 2: Install the drop-in and validate full config**
+
+```bash
+ssh debian 'sudo install -m 644 /tmp/10-hardening.conf /etc/ssh/sshd_config.d/10-hardening.conf && \
+            sudo sshd -t && echo SSHD_CONFIG_VALID'
+```
+Expected: `SSHD_CONFIG_VALID`. If this fails, `sudo rm /etc/ssh/sshd_config.d/10-hardening.conf` and debug.
+
+- [ ] **Step 3: Reload sshd (does not drop existing sessions)**
+
+```bash
+ssh debian 'sudo systemctl reload ssh && echo RELOADED'
+```
+Expected: `RELOADED`. The current SSH session must remain alive.
+
+- [ ] **Step 4: Verify SSH binds only on Tailscale IP + loopback**
+
+```bash
+ssh debian 'sudo ss -tlnp | grep :22'
+```
+Expected: lines containing `100.82.52.82:22` and `127.0.0.1:22` — and **no** `0.0.0.0:22` line.
+
+- [ ] **Step 5: Open a fresh SSH session to confirm Tailscale SSH works**
+
+From Mac (NEW terminal): `ssh debian 'echo TAILSCALE_SSH_OK'`
+Expected: `TAILSCALE_SSH_OK`.
+
+- [ ] **Step 6: Verify LAN SSH is now refused**
+
+From Mac: `ssh -o ConnectTimeout=5 kyle@<debian-lan-ip> 'echo LAN_REACHED' 2>&1 | tail -3`
+Expected: `Connection refused` or `Connection timed out`. (Either means success.)
+
+If LAN SSH still works, the `ListenAddress` lines didn't take effect — debug `sshd -T | grep -i listen`.
+
+- [ ] **Step 7: Remove now-unneeded LAN-SSH UFW rule**
+
+```bash
+ssh debian 'sudo ufw delete allow proto tcp from 192.168.1.0/24 to any port 22 && \
+            sudo ufw status verbose | grep -A1 "Anywhere"'
+```
+Expected: rule deletion confirmation; LAN-SSH rule no longer listed.
+
+- [ ] **Step 8: Confirm with Kyle**
+
+> "SSH locked to Tailscale-only. Listener is `100.82.52.82:22` + loopback only. LAN SSH refused. Fresh tailnet SSH works. Proceed to sudo narrowing?"
+
+---
+
+### Task 10: Narrow sudo to routine-ops allowlist
+
+**Files:**
+- Create on `debian`: `/etc/sudoers.d/kyle-ops`
+- Delete on `debian`: `/etc/sudoers.d/kyle-temp`
+
+- [ ] **Step 1: Identify exact paths for binaries in the allowlist**
+
+```bash
+ssh debian 'for b in systemctl journalctl apt apt-get dpkg kubectl minikube docker ufw lynis; do printf "%-12s -> %s\n" "$b" "$(which $b 2>/dev/null || echo MISSING)"; done'
+```
+Expected: every binary except `lynis` resolves (lynis is installed in Phase 3 — that's fine, the sudoers entry is path-based and works once installed). If anything else is `MISSING`, adjust the staged sudoers in Step 2 to use the actual path.
+
+- [ ] **Step 2: Stage `/etc/sudoers.d/kyle-ops`**
+
+```bash
+ssh debian 'cat > /tmp/kyle-ops <<EOF
+# Routine ops for the agent — passwordless.
+# Anything not listed here still requires kyles password.
+
+kyle ALL=(root) NOPASSWD: /usr/bin/systemctl, \\
+                          /usr/bin/journalctl, \\
+                          /usr/bin/apt, \\
+                          /usr/bin/apt-get, \\
+                          /usr/bin/dpkg, \\
+                          /usr/local/bin/kubectl, \\
+                          /usr/local/bin/minikube, \\
+                          /usr/bin/docker, \\
+                          /usr/sbin/ufw status, \\
+                          /usr/sbin/ufw status verbose, \\
+                          /usr/bin/lynis audit system
+
+# Privilege-changing actions still require password
+kyle ALL=(ALL) ALL
+EOF
+sudo visudo -c -f /tmp/kyle-ops && echo SUDOERS_VALID'
+```
+Expected: `/tmp/kyle-ops: parsed OK` plus `SUDOERS_VALID`.
+
+- [ ] **Step 3: Install kyle-ops, then delete kyle-temp**
+
+```bash
+ssh debian 'sudo install -m 0440 -o root -g root /tmp/kyle-ops /etc/sudoers.d/kyle-ops && \
+            sudo rm /etc/sudoers.d/kyle-temp && \
+            sudo visudo -c && \
+            ls /etc/sudoers.d/'
+```
+Expected: `/etc/sudoers.d/kyle-ops: parsed OK`, `/etc/sudoers.d/README: parsed OK`, listing shows `README kyle-ops`.
+
+- [ ] **Step 4: Verify routine ops still work without password**
+
+```bash
+ssh debian 'sudo -n systemctl is-active sshd && \
+            sudo -n journalctl --since "5 min ago" -u ssh | tail -3 > /dev/null && \
+            sudo -n ufw status | head -1 && \
+            echo PASSWORDLESS_OPS_OK'
+```
+Expected: `active`, then ufw status line, then `PASSWORDLESS_OPS_OK`.
+
+- [ ] **Step 5: Verify privilege-changing ops are gated**
+
+```bash
+ssh debian 'sudo -n useradd testuser 2>&1 | tail -1; sudo -n ufw disable 2>&1 | tail -1'
+```
+Expected: both lines say `sudo: a password is required`. (No actual user added; no firewall change.)
+
+- [ ] **Step 6: Confirm with Kyle**
+
+> "Sudo narrowed. Passwordless for systemctl/journalctl/apt/kubectl/minikube/docker/ufw-status/lynis. Anything privilege-changing (useradd, ufw disable, etc.) still needs your password. Phase 2 complete. Proceed to Phase 3 (auditing & kernel hardening)?"
+
+---
+
+## Phase 3: Auditing & Kernel Hardening
+
+### Task 11: Pre-Phase-3 snapshot
+
+**Files:**
+- Create on `debian`: `/root/sysctl.conf.bak-2026-04-16`
+
+- [ ] **Step 1: Snapshot `/etc/sysctl.conf`**
+
+```bash
+ssh debian 'sudo cp /etc/sysctl.conf /root/sysctl.conf.bak-2026-04-16 && ls -la /root/sysctl.conf.bak-2026-04-16'
+```
+Expected: file listed.
+
+- [ ] **Step 2: No commit**
+
+---
+
+### Task 12: Install auditd with baseline rules and log rotation
+
+**Files:**
+- Install on `debian`: `auditd` package
+- Create on `debian`: `/etc/audit/rules.d/10-baseline.rules`
+- Modify on `debian`: `/etc/audit/auditd.conf`
+
+- [ ] **Step 1: Install auditd**
+
+```bash
+ssh debian 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y auditd && echo AUDITD_INSTALLED'
+```
+Expected: `AUDITD_INSTALLED`.
+
+- [ ] **Step 2: Stage baseline rules**
+
+```bash
+ssh debian 'sudo tee /etc/audit/rules.d/10-baseline.rules > /dev/null <<EOF
+# Identity changes
+-w /etc/passwd -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/group -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+
+# Sudo + sshd config
+-w /etc/sudoers -p wa -k sudoers
+-w /etc/sudoers.d/ -p wa -k sudoers
+-w /etc/ssh/sshd_config -p wa -k sshd
+-w /etc/ssh/sshd_config.d/ -p wa -k sshd
+
+# Privilege escalation invocations
+-w /usr/bin/sudo -p x -k sudo_exec
+-w /usr/bin/su -p x -k su_exec
+
+# Cron + scheduled-task tampering
+-w /etc/crontab -p wa -k cron
+-w /etc/cron.d/ -p wa -k cron
+-w /etc/cron.daily/ -p wa -k cron
+-w /etc/cron.hourly/ -p wa -k cron
+
+# Make rules immutable until reboot (last line)
+-e 2
+EOF
+echo RULES_STAGED'
+```
+Expected: `RULES_STAGED`.
+
+- [ ] **Step 3: Set log rotation in `auditd.conf`**
+
+```bash
+ssh debian 'sudo sed -i \
+  -e "s/^max_log_file *=.*/max_log_file = 50/" \
+  -e "s/^num_logs *=.*/num_logs = 4/" \
+  /etc/audit/auditd.conf && \
+  grep -E "^max_log_file|^num_logs" /etc/audit/auditd.conf'
+```
+Expected: `max_log_file = 50` and `num_logs = 4` printed.
+
+- [ ] **Step 4: Reload rules + restart auditd**
+
+```bash
+ssh debian 'sudo augenrules --load && sudo systemctl restart auditd && sudo auditctl -l | head -20'
+```
+Expected: rule list (matches what we wrote) printed.
+
+- [ ] **Step 5: No commit**
+
+---
+
+### Task 13: Enable journald persistence + retention caps
+
+**Files:**
+- Create on `debian`: `/var/log/journal/` directory
+- Create on `debian`: `/etc/systemd/journald.conf.d/retention.conf`
+
+- [ ] **Step 1: Create journal dir + drop-in config**
+
+```bash
+ssh debian 'sudo mkdir -p /var/log/journal /etc/systemd/journald.conf.d && \
+            sudo tee /etc/systemd/journald.conf.d/retention.conf > /dev/null <<EOF
+[Journal]
+Storage=persistent
+SystemMaxUse=2G
+SystemKeepFree=1G
+MaxRetentionSec=30day
+EOF
+echo JOURNALD_CONFIG_OK'
+```
+Expected: `JOURNALD_CONFIG_OK`.
+
+- [ ] **Step 2: Restart journald**
+
+```bash
+ssh debian 'sudo systemctl restart systemd-journald && journalctl --disk-usage'
+```
+Expected: a line like `Archived and active journals take up 0B in the file system.` initially, growing over time.
+
+- [ ] **Step 3: No commit**
+
+---
+
+### Task 14: Apply sysctl kernel hardening
+
+**Files:**
+- Create on `debian`: `/etc/sysctl.d/99-hardening.conf`
+
+- [ ] **Step 1: Stage and install hardening sysctls**
+
+```bash
+ssh debian 'sudo tee /etc/sysctl.d/99-hardening.conf > /dev/null <<EOF
+# Kernel
+kernel.kptr_restrict=2
+kernel.dmesg_restrict=1
+kernel.yama.ptrace_scope=1
+kernel.unprivileged_bpf_disabled=1
+
+# Network
+net.ipv4.conf.all.rp_filter=1
+net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.accept_source_route=0
+net.ipv4.conf.all.accept_redirects=0
+net.ipv4.conf.all.send_redirects=0
+net.ipv6.conf.all.accept_redirects=0
+net.ipv4.tcp_syncookies=1
+net.ipv4.icmp_echo_ignore_broadcasts=1
+
+# Filesystem
+fs.protected_hardlinks=1
+fs.protected_symlinks=1
+EOF
+sudo sysctl --system 2>&1 | grep -E "99-hardening|error|invalid"'
+```
+Expected: lines like `* Applying /etc/sysctl.d/99-hardening.conf ...` followed by the assignments echoed back. No `error` / `invalid` lines.
+
+- [ ] **Step 2: Verify a couple of values took effect**
+
+```bash
+ssh debian 'sysctl kernel.kptr_restrict kernel.yama.ptrace_scope net.ipv4.tcp_syncookies'
+```
+Expected: `kernel.kptr_restrict = 2`, `kernel.yama.ptrace_scope = 1`, `net.ipv4.tcp_syncookies = 1`.
+
+- [ ] **Step 3: No commit**
+
+---
+
+### Task 15: Verify AppArmor is enforcing + tune fail2ban
+
+**Files:**
+- Possibly modify on `debian`: `/etc/fail2ban/jail.local`
+
+- [ ] **Step 1: Check AppArmor status**
+
+```bash
+ssh debian 'sudo aa-status | head -20'
+```
+Expected: `apparmor module is loaded.` and `N profiles are in enforce mode.` (N ≥ 0). If any profiles are in `complain` mode that should be enforcing, escalate to Kyle before flipping.
+
+- [ ] **Step 2: Inspect existing fail2ban config**
+
+```bash
+ssh debian 'sudo fail2ban-client status sshd; ls /etc/fail2ban/jail.local 2>&1'
+```
+
+- [ ] **Step 3: Tune sshd jail (create or update `jail.local`)**
+
+If `/etc/fail2ban/jail.local` doesn't exist, create it:
+```bash
+ssh debian 'sudo tee /etc/fail2ban/jail.local > /dev/null <<EOF
+[sshd]
+enabled = true
+bantime = 1h
+maxretry = 3
+EOF
+sudo systemctl reload fail2ban && sudo fail2ban-client status sshd'
+```
+Expected: status with the new bantime/maxretry visible.
+
+If it already exists, update only the `bantime` and `maxretry` keys in the `[sshd]` section using `sudo sed -i` (verify the section exists first; if not, append the block above).
+
+- [ ] **Step 4: No commit**
+
+---
+
+### Task 16: Install lynis and run baseline audit
+
+**Files:**
+- Install on `debian`: `lynis` package
+- Create on `debian`: `/var/log/lynis-baseline-2026-04-16.log`
+
+- [ ] **Step 1: Install lynis**
+
+```bash
+ssh debian 'sudo DEBIAN_FRONTEND=noninteractive apt-get install -y lynis && lynis --version'
+```
+Expected: a version string (Lynis 3.x).
+
+- [ ] **Step 2: Run the audit and save the report**
+
+```bash
+ssh debian 'sudo lynis audit system --quiet --no-colors 2>&1 | sudo tee /var/log/lynis-baseline-2026-04-16.log > /dev/null && \
+            sudo grep -E "Hardening index|Tests performed" /var/log/lynis-baseline-2026-04-16.log'
+```
+Expected: a line like `Hardening index : 75` (or higher).
+
+If score < 75: print the warnings/suggestions section (`sudo grep -A2 "Warning\|Suggestion" /var/log/lynis-baseline-2026-04-16.log | head -60`) and discuss with Kyle which to address now vs defer.
+
+- [ ] **Step 3: Pull the report locally for the repo commit (Task 18)**
+
+```bash
+mkdir -p docs/security
+scp debian:/var/log/lynis-baseline-2026-04-16.log docs/security/lynis-baseline-2026-04-16.log
+```
+Expected: file copied locally.
+
+- [ ] **Step 4: No commit yet (commit happens in Task 18 with the ADR)**
+
+---
+
+### Task 17: Final reboot test
+
+**Files:** None — verification only.
+
+- [ ] **Step 1: Tell Kyle**
+
+> "Phase 3 changes applied. Final reboot test? Run: `! ssh debian sudo reboot`."
+
+- [ ] **Step 2: After reconnect, full health check**
+
+```bash
+ssh debian '
+  echo "=== units ===";        systemctl is-active docker minikube minikube-tunnel ollama cloudflared fail2ban auditd
+  echo "=== ufw ===";          sudo ufw status | head -1
+  echo "=== sshd binding ==="; sudo ss -tlnp | grep :22
+  echo "=== sysctl key ===";   sysctl kernel.kptr_restrict kernel.yama.ptrace_scope
+  echo "=== auditd rules ==="; sudo auditctl -l | wc -l
+  echo "=== journald ===";     journalctl --disk-usage
+  echo "=== pods ===";         kubectl get pods -A | grep -vE "Running|Completed" | grep -v NAMESPACE | wc -l
+'
+```
+Expected:
+- 7 `active` lines
+- `Status: active`
+- only Tailscale + loopback :22 lines
+- `kernel.kptr_restrict = 2`, `kernel.yama.ptrace_scope = 1`
+- non-zero rule count
+- a disk-usage line
+- pod-not-ready count = 0 or 1 (jaeger only)
+
+- [ ] **Step 3: Re-run lynis to confirm score holds across reboot**
+
+```bash
+ssh debian 'sudo lynis audit system --quiet --no-colors 2>&1 | grep "Hardening index"'
+```
+Expected: ≥ 75, ideally same as Task 16.
+
+---
+
+### Task 18: Commit lynis baseline + write ADR + open PR (or push)
+
+**Files:**
+- Already created: `docs/security/lynis-baseline-2026-04-16.log` (from Task 16, Step 3)
+- Create: `docs/adr/2026-04-16-debian-host-hardening.md`
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/adr/2026-04-16-debian-host-hardening.md` with this content:
+
+```markdown
+# ADR: Debian 13 Host Hardening (2026-04-16)
+
+## Status
+Accepted
+
+## Context
+The production Debian 13 host (`100.82.52.82`) was migrated from a Windows PC. The migration spec deferred most OS hardening, and a 2026-04-15 power outage revealed that Minikube and ethernet didn't auto-restart. This ADR records the final hardened state and the key decisions.
+
+## Decisions
+
+### SSH binds only to Tailscale + loopback
+`/etc/ssh/sshd_config.d/10-hardening.conf` sets `ListenAddress 100.82.52.82` and `ListenAddress 127.0.0.1`. Public SSH is gone. Recovery if Tailscale is down: physical console.
+
+### Ollama is fenced by firewall, not by bind address
+Ollama keeps `OLLAMA_HOST=0.0.0.0:11434` because Minikube reaches it via `host.minikube.internal` (docker bridge IP), not loopback. UFW restricts reach to `172.17.0.0/16` (docker bridge) and `100.64.0.0/10` (Tailscale). Single-bind alternatives don't cleanly support both consumers.
+
+### Sudo: narrow allowlist, not NOPASSWD ALL
+`/etc/sudoers.d/kyle-ops` grants passwordless sudo for `systemctl`, `journalctl`, `apt`, `kubectl`, `minikube`, `docker`, `ufw status`, and `lynis audit system`. Privilege-changing actions (useradd, ufw enable/disable, sshd config edits) still require Kyle's password. The defense-in-depth gain is small once SSH is Tailscale-only, but the friction cost is also small.
+
+### Auditd, journald-persistent, sysctl drop-in, lynis
+Standard defense-in-depth posture. Baseline lynis report saved at `docs/security/lynis-baseline-2026-04-16.log` for future comparison.
+
+### Minikube auto-start via systemd oneshot
+`minikube.service` (`Type=oneshot RemainAfterExit=yes`) runs `minikube start` as `kyle` after `docker.service`. `minikube-tunnel.service` now `Requires=minikube.service` so the tunnel doesn't start before the cluster.
+
+### Out of scope (not done, intentional)
+- File-integrity monitoring (AIDE), rkhunter — high maintenance cost, low marginal value for single-tenant home box.
+- Docker `userns-remap` — risk of breaking Minikube outweighs gain.
+- SSH cert-based auth — raw keys are fine for a single user / single trusted client.
+- Backups / DR — separate concern, separate spec.
+
+## References
+- Spec: `docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md`
+- Plan: `docs/superpowers/plans/2026-04-16-debian-host-hardening.md`
+- Baseline lynis report: `docs/security/lynis-baseline-2026-04-16.log`
+```
+
+- [ ] **Step 2: Stage both files and run preflight (no per-language checks for docs)**
+
+```bash
+git add docs/security/lynis-baseline-2026-04-16.log docs/adr/2026-04-16-debian-host-hardening.md
+git status
+```
+Expected: both files in "Changes to be committed".
+
+- [ ] **Step 3: Ask Kyle whether to commit on `main` or branch + PR**
+
+> "Phase 3 done. Two files to commit: the lynis baseline and the ADR. Both are docs only. Want me to:
+> (a) commit straight to `main` (don't push — you push when ready), or
+> (b) create a feature branch + worktree and open a PR to `qa` per the standard flow?"
+
+Default to (a) — these are doc-only and the spec was committed on `main`.
+
+- [ ] **Step 4: Commit per Kyle's choice**
+
+If (a):
+```bash
+git commit -m "$(cat <<'EOF'
+docs: add Debian 13 host hardening ADR + lynis baseline
+
+Captures the final hardened state of the production host after the
+2026-04-16 hardening spec: Tailscale-only SSH, narrow passwordless
+sudo, UFW default-deny, auditd + journald + sysctl + lynis baseline.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If (b): follow the feature-branch/worktree flow from CLAUDE.md (create `agent/feat-debian-host-hardening-docs` worktree, commit there, push, open PR to `qa`).
+
+- [ ] **Step 5: Mark plan complete and report final state to Kyle**
+
+> "Hardening complete. End state:
+> - Public attack surface: zero (SSH Tailscale-only, Ollama firewall-fenced, no other listeners)
+> - Auto-start: minikube + tunnel + ollama + cloudflared + ethernet + auditd all start on boot
+> - Sudo: passwordless for routine ops, password for privilege-changing
+> - Lynis baseline: <score>
+> - Spec, plan, ADR, baseline report all in repo"
+
+---
+
+## Rollback Quick Reference
+
+If anything breaks during execution:
+
+| Phase | Symptom | Recovery |
+|---|---|---|
+| Phase 1 | Service won't start | `sudo rm /etc/systemd/system/minikube.service && sudo systemctl daemon-reload` |
+| Phase 2 - UFW | Lost connectivity from Mac | (from console) `sudo ufw disable` |
+| Phase 2 - SSH | Can't open new SSH session | (from console) `sudo rm /etc/ssh/sshd_config.d/10-hardening.conf && sudo systemctl reload ssh` |
+| Phase 2 - sudo | Can't run any sudo | (from console) `sudo cp /root/sudoers-backup-2026-04-16/kyle-temp /etc/sudoers.d/` (kyle-temp survives in the snapshot) |
+| Phase 3 - sysctl | Network weirdness | `sudo rm /etc/sysctl.d/99-hardening.conf && sudo sysctl -p /etc/sysctl.conf` |
+| Phase 3 - auditd | Disk filling | `sudo systemctl stop auditd && sudo apt purge auditd` |
+
+Snapshots are at `/root/etc-ssh-backup-2026-04-16/`, `/root/sudoers-backup-2026-04-16/`, `/root/sysctl.conf.bak-2026-04-16`.

--- a/docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md
@@ -1,0 +1,354 @@
+# Debian 13 Host Hardening & Production-Readiness
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Approach:** Three-phase implementation with verification gates between phases.
+
+## Context
+
+The production Debian 13 host (`100.82.52.82`, alias `debian`) was migrated from a Windows PC per `2026-04-15-debian-server-migration-design.md`. That migration's "Phase 1: OS Hardening" section was aspirational — UFW, sudo policy, and SSH lockdown were never applied. A power outage on 2026-04-15 also revealed that Minikube does not auto-start on boot (only `minikube-tunnel.service` was installed, with no `minikube.service` underneath it), and the ethernet interface requires a manual command to come up.
+
+This spec finishes the Phase 1 hardening from the migration plan, fixes the auto-start gaps surfaced by the outage, and establishes a sudo policy that lets the agent perform routine ops without password prompts while keeping privilege-changing actions gated.
+
+## Goals
+
+1. Public attack surface = zero (Cloudflare Tunnel is outbound-only; no listening ports reachable from the internet).
+2. SSH is reachable only over Tailscale (key-based, `kyle` only).
+3. Power-cycle the box → Minikube, the tunnel, Ollama, cloudflared, and ethernet all come back unaided.
+4. Ollama (port 11434) is reachable from the Minikube cluster and from Kyle's tailnet, but not from the public internet or the LAN.
+5. The agent can run routine ops (`systemctl`, `journalctl`, `apt`, `kubectl`, `docker`, `minikube`) without prompting for a password. Anything else still requires Kyle's password.
+6. `lynis audit system` baseline score ≥ 75.
+
+## Non-Goals
+
+- Backups / disaster recovery (separate spec).
+- Kubernetes / application-layer hardening (covered by `2026-04-15-security-audit-hardening-design.md`).
+- Docker `userns-remap` and other deep container hardening (deferred — risk of breaking Minikube outweighs marginal gain on a single-tenant box).
+- File-integrity monitoring (AIDE), `rkhunter`, SSH cert-based auth (deferred — high maintenance cost relative to threat model).
+- Targeted-attacker / supply-chain threat models.
+
+## Threat Model
+
+**In scope:**
+- Opportunistic internet scanners hitting public IPs (SSH probes, exposed-service probes).
+- Compromise of one layer (e.g., Cloudflare misroute, app-level RCE) attempting to escalate to the host.
+- Host coming back from power loss without manual intervention.
+
+**Out of scope:**
+- Targeted attacker with physical house access.
+- Attacker who already has Kyle's SSH key *and* tailnet access (no realistic mitigation).
+
+## Current State (2026-04-16)
+
+- Debian 13.4, kernel 6.12.73, single user `kyle` (uid 1000, in `sudo` and `docker` groups).
+- SSH: key-only, root login disabled, password auth disabled. Listens on `0.0.0.0:22`.
+- `fail2ban` and `unattended-upgrades` active.
+- No UFW / nftables rules in place; firewall effectively absent.
+- Ollama listens on `*:11434` — exposed on every interface.
+- No `NetworkManager` and no `systemd-networkd` — networking is via `ifupdown` (`/etc/network/interfaces`).
+- `/etc/sudoers.d/` contains only the default `README` — no `kyle` drop-in.
+- `minikube.service` does not exist; `minikube-tunnel.service` is installed but waits on a cluster nothing starts.
+- Tailnet contains stale `pc-master-race` node (offline 2 days, the old Windows PC).
+
+## Final State
+
+- UFW enabled, default deny incoming, allow outgoing. Specific allow rules listed in Phase 2.
+- SSH binds to `100.82.52.82` (Tailscale) and `127.0.0.1` only. `AllowUsers kyle`. `0.0.0.0:22` is gone.
+- Ollama still binds `0.0.0.0:11434` but UFW restricts reach to loopback, docker bridge (`172.17.0.0/16`), and Tailscale (`100.64.0.0/10`). Direct binding to multiple interfaces is not Ollama-supported; the firewall is the fence.
+- `minikube.service` (Type=oneshot, `ExecStart=minikube start`, runs as `kyle`) installed and enabled. `minikube-tunnel.service` updated with `Requires=minikube.service`.
+- Ethernet auto-connects on boot via `ifupdown` `auto` directive (or systemd-networkd if `ifupdown` config is absent / wrong).
+- `/etc/sudoers.d/kyle-ops`: passwordless for the routine-ops binary list (Section "Phase 2 → C.3"); typed-password for everything else.
+- `auditd` running with baseline rule set; `journald` persistent with retention caps; sysctl hardening drop-in applied; AppArmor confirmed enforcing; `lynis` installed and baseline report saved.
+- Stale `pc-master-race` node removed from Tailscale admin (Kyle handles via web console).
+
+## Phase 1: Bootstrap & Quick Wins
+
+### Bootstrap (one Kyle-typed sudo command)
+
+Kyle runs (with `! ssh -t debian sudo ...`) a single command that:
+- Writes `/etc/sudoers.d/kyle-temp` containing `kyle ALL=(ALL) NOPASSWD: ALL`, mode 0440.
+- Validates with `visudo -c`.
+
+This grants the agent unrestricted sudo for the duration of Phase 1 and Phase 2. Phase 2's last step (C.3) replaces it with the narrow allowlist.
+
+### B.1 — Minikube auto-start
+
+- Install `/etc/systemd/system/minikube.service`:
+  ```ini
+  [Unit]
+  Description=Minikube Cluster
+  After=docker.service network-online.target
+  Requires=docker.service
+  Wants=network-online.target
+
+  [Service]
+  Type=oneshot
+  RemainAfterExit=yes
+  User=kyle
+  Group=kyle
+  Environment=HOME=/home/kyle
+  Environment=MINIKUBE_HOME=/home/kyle/.minikube
+  ExecStart=/usr/local/bin/minikube start
+  ExecStop=/usr/local/bin/minikube stop
+  TimeoutStartSec=600
+  Restart=on-failure
+  RestartSec=30
+
+  [Install]
+  WantedBy=multi-user.target
+  ```
+- Replace `/etc/systemd/system/minikube-tunnel.service` so its `[Unit]` block has `After=minikube.service` and `Requires=minikube.service`.
+- `systemctl daemon-reload && systemctl enable minikube.service minikube-tunnel.service`.
+
+### B.2 — Bind Ollama safely (defer the actual binding to the firewall)
+
+Ollama keeps `OLLAMA_HOST=0.0.0.0:11434` because Minikube reaches it via `host.minikube.internal` → docker bridge IP, not loopback. The firewall (B.3 + Phase 2) constrains reachability.
+
+No Ollama config change in Phase 1; the work is the firewall draft in B.3.
+
+### B.3 — Install UFW with rules drafted but disabled
+
+- `apt install ufw`
+- Default policies: `deny incoming`, `allow outgoing`.
+- Allow rules drafted (not yet enabled):
+  - `22/tcp` from `100.64.0.0/10` (Tailscale)
+  - `22/tcp` from `192.168.1.0/24` (LAN — kept until Phase 2 confirms tailnet works, then removed)
+  - `11434/tcp` from `172.17.0.0/16` (docker bridge → Ollama for K8s)
+  - `11434/tcp` from `100.64.0.0/10` (Tailscale → Ollama for Mac access)
+- `ufw` left disabled at end of Phase 1. Phase 2 enables it.
+
+### B.4 — Ethernet auto-connect
+
+- Inspect `/etc/network/interfaces`. If the ethernet interface lacks an `auto <iface>` line, add it.
+- If the file is missing or unusable, install a minimal `systemd-networkd` `.network` file:
+  ```ini
+  [Match]
+  Name=en*
+
+  [Network]
+  DHCP=yes
+  ```
+  Enable `systemd-networkd` and `systemd-resolved`.
+- Verify by toggling the link down/up; confirm DHCP lease.
+
+### B.5 — Tailnet hygiene (Kyle action)
+
+Agent flags the offline `pc-master-race` node. Kyle removes it from the Tailscale admin console (control-plane action; not doable from the host).
+
+### Phase 1 Verification Gate
+
+- Reboot the box.
+- Confirm SSH, ethernet, minikube, ollama, cloudflared all come up unaided (`systemctl status` for each).
+- `kubectl get pods -A` — no Error states beyond the pre-existing `jaeger` ImagePull issue.
+- From a Minikube pod: `curl host.minikube.internal:11434/api/tags` succeeds.
+- From Kyle's Mac (over LAN): `curl <debian-lan-ip>:11434/api/tags` succeeds (UFW not on yet).
+
+Kyle approves before Phase 2.
+
+## Phase 2: Lockdown
+
+This is the only phase with lockout risk. Each step is followed by a verification before the next.
+
+### C.1 — Enable UFW
+
+- `ufw enable` (allow rules from B.3 take effect).
+- Verify:
+  - From inside cluster: K8s pods still reach Ollama.
+  - From Mac over Tailscale: `ssh debian` works.
+  - From Mac over LAN: `ssh kyle@192.168.1.x` works (LAN rule still present).
+
+Kyle confirms before C.2.
+
+### C.2 — Lock SSH to Tailscale-only
+
+Install `/etc/ssh/sshd_config.d/10-hardening.conf`:
+```
+ListenAddress 100.82.52.82
+ListenAddress 127.0.0.1
+AllowUsers kyle
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+MaxAuthTries 3
+LoginGraceTime 20
+ClientAliveInterval 300
+ClientAliveCountMax 2
+```
+
+- `systemctl reload ssh` (not `restart` — reload preserves existing sessions if config is broken, leaving Kyle a live shell to recover).
+- Update UFW: delete the `192.168.1.0/24 → 22/tcp` rule (LAN SSH no longer needed since SSH no longer binds the LAN interface).
+
+Verify:
+- `ss -tlnp | grep :22` shows listener on `100.82.52.82:22` and `127.0.0.1:22` only — **not** `0.0.0.0:22`.
+- Open a *new* terminal on Mac, `ssh debian` succeeds.
+- From LAN: `ssh kyle@192.168.1.x` returns "connection refused" (success signal).
+
+Kyle confirms before C.3.
+
+### C.3 — Narrow sudo
+
+Install `/etc/sudoers.d/kyle-ops`:
+```
+# Routine ops — passwordless
+kyle ALL=(root) NOPASSWD: /usr/bin/systemctl, \
+                          /usr/bin/journalctl, \
+                          /usr/bin/apt, \
+                          /usr/bin/apt-get, \
+                          /usr/bin/dpkg, \
+                          /usr/local/bin/kubectl, \
+                          /usr/local/bin/minikube, \
+                          /usr/bin/docker, \
+                          /usr/sbin/ufw status, \
+                          /usr/sbin/ufw status verbose, \
+                          /usr/bin/lynis audit system
+
+# Everything else still requires password
+kyle ALL=(ALL) ALL
+```
+
+- `visudo -c` validates before installing.
+- Delete `/etc/sudoers.d/kyle-temp`.
+
+**Excluded from passwordless** (intentional — these change privilege/security state and should be Kyle-confirmed):
+- `ufw enable/disable/allow/delete`
+- `useradd`, `usermod`, `passwd`
+- `chmod`, `chown` (outside `/home/kyle`)
+- `mount`, `cryptsetup`
+- Any direct edit of `/etc/...` config
+
+### Phase 2 Verification Gate
+
+- Agent runs `sudo systemctl status sshd` (succeeds without password).
+- Agent runs `sudo ufw disable` (prompts for password — denied successfully).
+- Kyle confirms ssh, kubectl, and Ollama-from-pod all still work.
+
+## Phase 3: Auditing & Kernel Hardening
+
+Low-risk; mostly observability and defense-in-depth. No verification gates within the phase — bundled together.
+
+### D.1 — auditd
+
+- `apt install auditd`
+- Install `/etc/audit/rules.d/10-baseline.rules`:
+  - `-w /etc/passwd -p wa -k identity`
+  - `-w /etc/shadow -p wa -k identity`
+  - `-w /etc/group -p wa -k identity`
+  - `-w /etc/sudoers -p wa -k sudoers`
+  - `-w /etc/sudoers.d/ -p wa -k sudoers`
+  - `-w /etc/ssh/sshd_config -p wa -k sshd`
+  - `-w /etc/ssh/sshd_config.d/ -p wa -k sshd`
+  - `-w /usr/bin/sudo -p x -k sudo_exec`
+  - `-w /usr/bin/su -p x -k su_exec`
+  - `-w /etc/crontab -p wa -k cron`
+  - `-w /etc/cron.d/ -p wa -k cron`
+- `augenrules --load`.
+- Configure log rotation: `max_log_file = 50`, `num_logs = 4` in `/etc/audit/auditd.conf` (caps at ~200MB).
+
+### D.2 — journald persistence
+
+- `mkdir -p /var/log/journal` (triggers persistence).
+- `/etc/systemd/journald.conf.d/retention.conf`:
+  ```ini
+  [Journal]
+  Storage=persistent
+  SystemMaxUse=2G
+  SystemKeepFree=1G
+  MaxRetentionSec=30day
+  ```
+- `systemctl restart systemd-journald`.
+
+### D.3 — sysctl kernel hardening
+
+Install `/etc/sysctl.d/99-hardening.conf`:
+```
+kernel.kptr_restrict=2
+kernel.dmesg_restrict=1
+kernel.yama.ptrace_scope=1
+kernel.unprivileged_bpf_disabled=1
+net.ipv4.conf.all.rp_filter=1
+net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.accept_source_route=0
+net.ipv4.conf.all.accept_redirects=0
+net.ipv4.conf.all.send_redirects=0
+net.ipv6.conf.all.accept_redirects=0
+net.ipv4.tcp_syncookies=1
+net.ipv4.icmp_echo_ignore_broadcasts=1
+fs.protected_hardlinks=1
+fs.protected_symlinks=1
+```
+
+- `sysctl --system` to apply.
+- **Not set:** `net.ipv4.ip_forward` — Docker/Minikube need forwarding=1; leave as-is.
+
+### D.4 — AppArmor verification
+
+- Run `aa-status`.
+- Confirm AppArmor is enforcing the Debian default profile set.
+- If any default profiles are in `complain` mode, flip them to `enforce` with `aa-enforce`.
+- No new custom profiles authored.
+
+### D.5 — fail2ban tuning
+
+- Confirm `sshd` jail is enabled (`fail2ban-client status sshd`).
+- Verify the log path matches actual SSH logging (journald vs `/var/log/auth.log`); adjust if needed.
+- Bump `bantime = 1h`, `maxretry = 3` in `/etc/fail2ban/jail.local`.
+- `systemctl reload fail2ban`.
+
+### D.6 — Lynis baseline
+
+- `apt install lynis`.
+- `lynis audit system | tee /var/log/lynis-baseline-2026-04-16.log`.
+- Copy the report to `docs/security/lynis-baseline-2026-04-16.log` in the repo (commit it; future runs compare against this baseline).
+
+### Phase 3 Verification Gate
+
+- `lynis audit system` score ≥ 75.
+- `auditctl -l` lists baseline rules.
+- `journalctl --disk-usage` shows persistent storage.
+- `sysctl kernel.kptr_restrict` returns `2`.
+- Reboot once. All services come back unaided.
+
+## Rollback
+
+Each change is a discrete file `install`. Rollback per phase:
+
+- **Phase 1:** `rm` the unit file or config drop-in, `systemctl daemon-reload`. UFW not yet enabled, no network risk.
+- **Phase 2 — UFW:** `ufw disable`. Drops all rules immediately.
+- **Phase 2 — SSH:** `rm /etc/ssh/sshd_config.d/10-hardening.conf && systemctl reload ssh`. Reverts to prior config. Existing sessions survive `reload`, so a broken config doesn't immediately disconnect.
+- **Phase 2 — sudo:** Restore `kyle-temp` from `/root/sudoers-backup-2026-04-16/`.
+- **Phase 3:** Each piece independent. `apt purge auditd lynis`, `rm /etc/sysctl.d/99-hardening.conf`, `sysctl -p /etc/sysctl.conf`.
+
+## Lockout Recovery
+
+If after C.2 SSH fails over both Tailscale and LAN:
+1. Plug keyboard + monitor into the box.
+2. Log in as `kyle` at console.
+3. `sudo systemctl status sshd` — usually shows the config error.
+4. `sudo rm /etc/ssh/sshd_config.d/10-hardening.conf && sudo systemctl reload ssh` — SSH back to pre-Phase-2 state.
+5. `sudo ufw disable` if firewall is the cause.
+
+Every Phase 2 change is a *new* file (never an edit of an existing config). Console recovery is always "delete one file, reload one service."
+
+## Snapshots Taken
+
+Before Phase 2:
+```
+cp -a /etc/ssh /root/etc-ssh-backup-2026-04-16/
+cp -a /etc/sudoers.d /root/sudoers-backup-2026-04-16/
+```
+
+Before Phase 3:
+```
+cp /etc/sysctl.conf /root/sysctl.conf.bak-2026-04-16
+```
+
+## Done Criteria
+
+- All Goals (Section "Goals") pass verification.
+- `docs/security/lynis-baseline-2026-04-16.log` committed.
+- A short ADR added under `docs/adr/` capturing the final state and decisions (Tailscale-only SSH, narrow sudo allowlist, Ollama-by-firewall pattern) so the rationale is recoverable later.
+
+## Open Questions
+
+None at spec-write time — all clarifying questions answered during brainstorming.

--- a/java/gateway-service/src/main/java/dev/kylebradshaw/gateway/config/GraphQlInterceptor.java
+++ b/java/gateway-service/src/main/java/dev/kylebradshaw/gateway/config/GraphQlInterceptor.java
@@ -10,6 +10,8 @@ import reactor.core.publisher.Mono;
 @Component
 public class GraphQlInterceptor implements WebGraphQlInterceptor {
 
+    private static final String ACCESS_TOKEN_COOKIE_PREFIX = "access_token=";
+
     @Override
     public Mono<WebGraphQlResponse> intercept(WebGraphQlRequest request, Chain chain) {
         String userId = null;
@@ -20,10 +22,14 @@ public class GraphQlInterceptor implements WebGraphQlInterceptor {
             userId = principal;
         }
 
-        // Extract raw Authorization header for forwarding to downstream services
+        // Extract the Authorization header so downstream REST calls can forward it.
+        // Fall back to the access_token cookie (httpOnly cookie auth flow) by
+        // synthesizing "Bearer <token>" — downstream services accept either form.
         var authHeaders = request.getHeaders().get("Authorization");
         if (authHeaders != null && !authHeaders.isEmpty()) {
             authorizationHeader = authHeaders.getFirst();
+        } else {
+            authorizationHeader = bearerFromCookie(request);
         }
 
         if (userId != null) {
@@ -39,5 +45,24 @@ public class GraphQlInterceptor implements WebGraphQlInterceptor {
         }
 
         return chain.next(request);
+    }
+
+    private static String bearerFromCookie(WebGraphQlRequest request) {
+        var cookieHeaders = request.getHeaders().get("Cookie");
+        if (cookieHeaders == null) {
+            return null;
+        }
+        for (String header : cookieHeaders) {
+            for (String part : header.split(";")) {
+                String trimmed = part.trim();
+                if (trimmed.startsWith(ACCESS_TOKEN_COOKIE_PREFIX)) {
+                    String token = trimmed.substring(ACCESS_TOKEN_COOKIE_PREFIX.length());
+                    if (!token.isEmpty()) {
+                        return "Bearer " + token;
+                    }
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

Completes the cookie-auth plumbing that PR #63 started. That PR taught \`JwtAuthenticationFilter\` to accept the \`access_token\` cookie for the gateway's own auth check, and it worked: the prod Go smoke test went green, and the 403-loop that was timing out the Java smoke test is gone.

But the Java smoke test on main still fails. The Playwright trace (now uploaded as a CI artifact thanks to the same PR) shows the gateway returning HTTP 200s on \`/graphql\`, but the GraphQL response bodies carry \`INTERNAL_ERROR\` for every resolver:

\`\`\`
POST /graphql 200  {"errors":[{"message":"INTERNAL_ERROR for 0f367beb-…","path":["createProject"]}]}
\`\`\`

Root cause: the gateway is a proxy. \`GraphQlInterceptor\` reads the incoming request's \`Authorization\` header and stashes it in the GraphQL context; every resolver pulls it back out and forwards it to TaskServiceClient/ActivityServiceClient/NotificationServiceClient. With cookie auth, no \`Authorization\` header arrives, so the downstream call lands unauthenticated → task-service 401s → gateway wraps the 401 as \`INTERNAL_ERROR\` (Spring GraphQL's standard error shim).

## Change

\`java/gateway-service/.../config/GraphQlInterceptor.java\`: when no \`Authorization\` header is present, read the \`access_token\` cookie and synthesize \`Bearer <token>\` for downstream forwarding. Downstream services already accept either the Bearer header or the cookie, so this restores the full proxy chain for cookie-authed requests.

## Out of scope

- The underlying design (every resolver passing \`authHeader\` through to a REST client) is awkward — a cleaner architecture would propagate auth via the \`SecurityContext\` on a reactive thread or use ServiceAccount-style internal tokens. Not today; that's a bigger refactor.

## Test plan

- [x] Java preflight: checkstyle + unit tests across activity/gateway/notification/task services pass locally
- [ ] Full PR quality checks (this run)
- [ ] After merge to qa: deploys to QA
- [ ] After qa→main ship: prod deploy → Production Smoke Tests finally green (Java project-create works end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)