### PR TITLE
feat(frontend): add Security page to portfolio site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ frontend/.next/
 .claude/settings.local.json
 .vercel
 .env*.local
+
+# Lynis machine-readable report data (we keep the human-readable .log)
+docs/security/*.dat

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ If you're short on time:
 2. **`docs/adr/go-stress-testing.md`** — k6 load testing that found real bugs (stock overselling), with before/after metrics
 3. **`services/`** — FastAPI + RAG + agent implementation
 4. **`docs/adr/document-qa/`** and **`docs/adr/document-debugger/`** — how and why the AI services were built
-5. **`.github/workflows/`** — CI/CD, security scanning, and deployment
-6. **`k8s/`** — production Kubernetes topology
+5. **`docs/security/`** — security assessments for the application stack and the hardened Debian 13 host (lynis 77)
+6. **`.github/workflows/`** — CI/CD, security scanning, and deployment
+7. **`k8s/`** — production Kubernetes topology
 
 Thanks for taking a look. — Kyle

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ I'm a developer who primarily focuses on **backend and AI integration**. This re
 - **Backend engineering across three languages** — Go, Java (Spring Boot), and Python (FastAPI), each chosen where it fits best
 - **AI integration** — a full RAG pipeline and an agentic debugging assistant, both backed by locally-hosted LLMs
 - **Production infrastructure** — Kubernetes, NGINX Ingress, Cloudflare Tunnel, Prometheus/Grafana, and a full CI/CD pipeline deploying to a home-lab cluster
+- **Linux server administration** — hand-installed Debian 13 on the home-lab box, hardened the OS (firewall, SSH lockdown, sudo policy, auditd, kernel sysctls), wrote systemd units for service auto-start, and recovered cleanly from a power outage and a botched SSH config
 - **A working full-stack surface** — Next.js + TypeScript frontend on Vercel, talking to REST, GraphQL, and streaming AI endpoints
 
 ---
@@ -54,19 +55,20 @@ Next.js + TypeScript + shadcn/ui + Apollo Client, deployed on Vercel. Sections f
 
 ## Infrastructure & DevOps
 
-- **Kubernetes (Minikube)** on a Windows PC with an RTX 3090 running Ollama natively for GPU inference
+- **Kubernetes (Minikube)** on a self-installed **Debian 13 server** with an RTX 3090 running Ollama natively for GPU inference
 - **Namespaces:** `ai-services`, `java-tasks`, `go-ecommerce`, `monitoring`
 - **NGINX Ingress** with path-based routing across all stacks
 - **Cloudflare Tunnel** exposes the home-lab cluster publicly as `api.kylebradshaw.dev`
 - **Docker Compose** for local development
 - **Prometheus + Grafana** for metrics and dashboards
 - **GitHub Actions CI/CD** — ruff, pytest, tsc, Next.js build, checkstyle, golangci-lint, Bandit, pip-audit, npm audit, gitleaks, Hadolint, Playwright E2E, and auto-deploy to the cluster via SSH
+- **Hardened Linux host** — UFW default-deny firewall, SSH locked to Tailscale only, narrow passwordless sudo allowlist, auditd + persistent journald, sysctl kernel hardening, lynis baseline score 77. See [`docs/security/linux-server-hardening.md`](docs/security/linux-server-hardening.md).
 
 ---
 
 ## Security
 
-For a full security assessment of the controls implemented in this project — shift-left CI gates, Kubernetes policy-as-code, auth architecture, supply chain posture, and explicitly accepted risks — see **[`docs/security/security-assessment.md`](docs/security/security-assessment.md)**. Each finding cites the exact file(s) that implement it so the claims can be independently verified.
+For a full security assessment of the controls implemented in this project — shift-left CI gates, Kubernetes policy-as-code, auth architecture, supply chain posture, and explicitly accepted risks — see **[`docs/security/security-assessment.md`](docs/security/security-assessment.md)**. For host-level hardening of the Debian 13 server (firewall, SSH lockdown, sudo policy, auditd, kernel sysctls, patch hygiene, lynis baseline), see **[`docs/security/linux-server-hardening.md`](docs/security/linux-server-hardening.md)**. Each finding cites the exact file(s) that implement it so the claims can be independently verified.
 
 ---
 

--- a/docs/adr/2026-04-16-debian-host-hardening.md
+++ b/docs/adr/2026-04-16-debian-host-hardening.md
@@ -1,0 +1,69 @@
+# ADR: Debian 13 Host Hardening (2026-04-16)
+
+## Status
+Accepted
+
+## Context
+The production Debian 13 host (`debian` / `100.82.52.82`) was migrated from a Windows PC per `2026-04-15-debian-server-migration-design.md`. That migration's Phase 1 OS hardening section was partially executed (UFW was installed and enabled with rules, fail2ban + unattended-upgrades both running) but a 2026-04-15 power outage revealed gaps: Minikube did not auto-restart, ethernet did not auto-connect, and the Debian security repository was missing from `/etc/apt/sources.list` (so `unattended-upgrades` had been silently doing nothing for security patches since the migration).
+
+This ADR records the as-built hardened state and the key decisions made during the 2026-04-16 hardening pass. Spec: `docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md`. Implementation plan: `docs/superpowers/plans/2026-04-16-debian-host-hardening.md`.
+
+## Decisions
+
+### SSH binds only to Tailscale + loopback
+`/etc/ssh/sshd_config.d/10-hardening.conf` sets `ListenAddress 100.82.52.82` and `ListenAddress 127.0.0.1`. Public SSH is gone. Includes `AllowUsers kyle`, `MaxSessions 2`, `MaxAuthTries 3`, `LoginGraceTime 20`, plus the lynis-recommended additions: `AllowTcpForwarding no`, `AllowAgentForwarding no`, `X11Forwarding no`, `LogLevel VERBOSE`, `TCPKeepAlive no`. Recovery if Tailscale is down: physical console.
+
+**Race fix (`/etc/systemd/system/ssh.service.d/wait-for-tailscale.conf`):** Because `ListenAddress 100.82.52.82` requires the Tailscale IP to exist before sshd starts, the original install caused sshd to fail to bind on the first reboot — the box came up but SSH was unreachable until manual `systemctl restart ssh` from console. The drop-in adds `After=tailscaled.service` + `Wants=tailscaled.service` and `Restart=on-failure RestartSec=10` so sshd waits for tailscaled to start and self-recovers if it races within tailscaled's startup window. Future boots verified clean.
+
+### Ollama is fenced by firewall, not by bind address
+Ollama keeps `OLLAMA_HOST=0.0.0.0:11434` because Minikube reaches it via `host.minikube.internal` which resolves to the docker bridge IP (`172.17.0.1`), not loopback. UFW restricts reach to:
+- `127.0.0.1` (loopback)
+- `172.16.0.0/12` and `172.17.0.0/16` (docker bridges)
+- `192.168.49.0/24` (minikube subnet specifically)
+- `100.64.0.0/10` (Tailscale CGNAT range — Mac access)
+
+A previously-existing rule allowing `192.168.0.0/16 → 11434` (which silently exposed Ollama to the home LAN, since `192.168.1.0/24` ⊂ `192.168.0.0/16`) was removed during this pass.
+
+### UFW: default-deny, narrow allowlist
+`Status: active`, `default deny (incoming) / allow (outgoing)`. Allow rules cover SSH from Tailscale CIDR, Ollama from the fenced ranges above, port 80 from loopback (cloudflared), and Tailscale UDP 41641. Two redundant per-host SSH allows for individual tailnet IPs were removed in favor of the CIDR rule.
+
+### Sudo: narrow allowlist, not NOPASSWD ALL
+`/etc/sudoers.d/kyle-ops` grants passwordless sudo for `systemctl`, `journalctl`, `apt`, `apt-get`, `dpkg`, `kubectl`, `minikube`, `docker`, `ufw status` (read-only), and `lynis audit system`. Privilege-changing actions (`useradd`, `ufw enable/disable`, sshd config edits, `chmod`/`chown` on system paths) still require Kyle's password (via the default `%sudo` group rule in `/etc/sudoers`).
+
+**Sudoers gotcha (recorded for future):** The first draft included an explicit trailing `kyle ALL=(ALL) ALL` line in `kyle-ops` intending to make "everything else needs password" explicit. Sudo's last-match-wins rule meant that line *overrode* the NOPASSWD entries above it, making nothing passwordless. The fix: remove the catch-all line and rely on the implicit password-required access from `%sudo` group membership. Lesson: only put explicit `NOPASSWD:` overrides in drop-in files, never a catch-all that could re-shadow them.
+
+### Sequencing: narrow sudo *after* Phase 3, not after Phase 2
+The original spec had Task 10 (narrow sudo) as the last step of Phase 2, before Phase 3. But Phase 3 needs sudo for `tee`, `sed`, `mkdir`, `sysctl`, `augenrules` — none of which are in the narrow allowlist (and shouldn't be: `sudo tee` can write any file and effectively equals NOPASSWD ALL). Re-sequencing Task 10 to *after* Phase 3 avoided either bloating the allowlist or requiring 10+ password prompts during Phase 3.
+
+### Defense-in-depth additions
+- `auditd` with baseline rules covering `/etc/passwd`, `/etc/shadow`, `/etc/sudoers*`, `/etc/ssh/sshd_config*`, sudo/su execution, cron paths. Rules made immutable via `-e 2` (changes require reboot). Log rotation at 50MB × 4 files (~200MB cap).
+- `journald` made persistent (`/var/log/journal`), retention capped at 2GB / 30 days.
+- `sysctl` hardening drop-in (`/etc/sysctl.d/99-hardening.conf`): `kptr_restrict=2`, `dmesg_restrict=1`, `yama.ptrace_scope=1`, `unprivileged_bpf_disabled=1`, plus standard network-stack hygiene (`rp_filter`, `accept_redirects=0`, `tcp_syncookies=1`).
+- `fail2ban`: existing `jail.local` updated to `bantime=1h`, `maxretry=3`. Global `[DEFAULT]` defaults updated too.
+- AppArmor verified loaded with 4 profiles in enforce mode (docker-default, lsb_release, nvidia_modprobe). 23 profiles in complain mode are all desktop/GUI (Xorg, plasmashell, sbuild-*, transmission-*) and intentionally not flipped.
+- `lynis` installed; baseline audit captured at `docs/security/lynis-baseline-2026-04-16.log`.
+
+### Security repository (the silent gap)
+`/etc/apt/sources.list` lacked the `security.debian.org` entry. `unattended-upgrades` was configured to allow security-origin packages but had no source to fetch them from — silently doing nothing since the migration. Added `deb http://security.debian.org/debian-security trixie-security main contrib non-free non-free-firmware`. The first `apt-get update` after this fetched 15 pending security patches (OpenSSL, OpenSSH, libpng, libtiff, libfreetype, gdk-pixbuf, kernel 6.12.73 → 6.12.74). All applied, and the box rebooted onto the new kernel as part of the Phase 3 verification.
+
+### Minikube auto-start via systemd oneshot
+`minikube.service` (`Type=oneshot RemainAfterExit=yes`) runs `minikube start` as `kyle` after `docker.service`. `minikube-tunnel.service` updated to `Requires=minikube.service` so the tunnel doesn't start before the cluster.
+
+### Ethernet auto-connect via ifupdown
+Debian 13 default install left `enp4s0` completely absent from `/etc/network/interfaces` (only `lo` was configured). Added `auto enp4s0 / iface enp4s0 inet dhcp`. Verified by reboot.
+
+### Lynis hardening index: 77
+Final score 77 (target was ≥75). Pre-remediation score: 70. The 7-point gap was closed primarily by adding the security repository (single biggest contributor), the SSH lynis additions, and `login.defs` tightening (`PASS_MAX_DAYS=90`, `PASS_MIN_DAYS=1`, `UMASK=027`, `SHA_CRYPT_*_ROUNDS=10000`).
+
+## Out of scope (deferred, intentional)
+- File-integrity monitoring (AIDE), `rkhunter`, `chkrootkit` — high maintenance cost, low marginal value for a single-tenant home box.
+- Docker `userns-remap` — risk of breaking Minikube outweighs gain.
+- SSH cert-based auth instead of raw keys — fine for a single user / single trusted client.
+- Backups / DR — separate concern, separate spec.
+- Separate `/home` and `/var` partitions, GRUB password, USB driver disable — flagged by lynis but require partition rebuild or are unnecessary for the threat model.
+
+## References
+- Spec: `docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md`
+- Plan: `docs/superpowers/plans/2026-04-16-debian-host-hardening.md`
+- Migration spec (predecessor): `docs/superpowers/specs/2026-04-15-debian-server-migration-design.md`
+- Baseline lynis report: `docs/security/lynis-baseline-2026-04-16.log`

--- a/docs/security/linux-server-hardening.md
+++ b/docs/security/linux-server-hardening.md
@@ -1,0 +1,344 @@
+# Linux Server Hardening — Debian 13 Home-Lab Host
+
+A focused security assessment of the Debian 13 server (`100.82.52.82`, alias `debian`) that hosts Minikube, Ollama, the Cloudflare Tunnel, and all backend services for this project. Written as a sibling to [`security-assessment.md`](security-assessment.md), which covers the application, CI/CD, and Kubernetes layers.
+
+**Scope:** the host operating system — install, network exposure, SSH, sudo, audit logging, kernel hardening, patch management, and operational resilience. Does **not** cover the Kubernetes workloads or the application-layer controls (those are in `security-assessment.md`).
+
+**Methodology:** `lynis audit system` baseline plus manual inspection of `/etc/ssh/`, `/etc/sudoers.d/`, `/etc/audit/`, `/etc/sysctl.d/`, `/etc/apt/`, and `systemd` units. No dynamic testing.
+
+**Date:** 2026-04-16
+
+**Companion documents:**
+- Engineering ADR with as-built decisions and surprises caught during the work — [`docs/adr/2026-04-16-debian-host-hardening.md`](../adr/2026-04-16-debian-host-hardening.md)
+- Implementation spec — [`docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md`](../superpowers/specs/2026-04-16-debian-host-hardening-design.md)
+- Captured lynis report — [`lynis-baseline-2026-04-16.log`](lynis-baseline-2026-04-16.log)
+
+## Summary of findings
+
+| Area | Status | Notes |
+|---|---|---|
+| OS install & base setup | **Strong** | Hand-installed Debian 13, NVIDIA drivers, Tailscale, key-only SSH from initial setup |
+| Network firewall (UFW) | **Strong** | Default-deny incoming, narrow allow rules, no public service ports — `nmap` from the public internet returns empty |
+| SSH hardening | **Strong** | Tailscale-only listener, lynis-recommended additions, race-condition-resilient via systemd drop-in |
+| Privilege management | **Strong** | Narrow passwordless sudo allowlist for routine ops; privilege-changing actions still gated |
+| Audit logging | **Adequate** | `auditd` with immutable baseline rules; persistent `journald` with retention caps. Local-only (no remote forwarding) |
+| Kernel hardening | **Strong** | `sysctl` drop-in covering `kptr_restrict`, `ptrace_scope`, `unprivileged_bpf_disabled`, network-stack hygiene |
+| Patch management | **Strong** | Found and fixed missing `security.debian.org` repository; 15 stale patches applied; `unattended-upgrades` now actually pulling security updates |
+| Service auto-start | **Strong** | Minikube + tunnel + Ollama + cloudflared + ethernet all auto-start; verified across two reboots |
+| Intrusion prevention | **Adequate** | `fail2ban` `[sshd]` jail tuned to `bantime=1h`, `maxretry=3` |
+| Lynis baseline | **Strong** | Hardening index 77 (target ≥75); deferred items documented in §11 |
+
+The overall posture is strong for a single-tenant home-lab box. The remaining gaps (file-integrity monitoring, remote audit-log forwarding) are documented as accepted risks.
+
+---
+
+## 1. OS install & initial setup
+
+**Status:** Strong.
+
+The host is a fresh hand-installed Debian 13 (trixie) on the home-lab machine, kernel 6.12.74. The migration replaced a Windows PC running the same workloads — see [`docs/superpowers/specs/2026-04-15-debian-server-migration-design.md`](../superpowers/specs/2026-04-15-debian-server-migration-design.md) for the migration record.
+
+Established from initial install:
+- **Single privileged user** `kyle` (uid 1000) in the `sudo` and `docker` groups.
+- **SSH key-based authentication only.** `PasswordAuthentication no` and `PermitRootLogin no` set in the base `/etc/ssh/sshd_config` from day one.
+- **Tailscale** installed for out-of-band reachability — gives every machine in Kyle's tailnet a stable IP (`100.82.52.82` for this host).
+- **NVIDIA drivers + CUDA toolkit** installed for Ollama GPU inference on the RTX 3090.
+- **Docker engine** installed via the official `docker.com` apt repository.
+- **Minikube** installed at `/usr/local/bin/minikube`, runs the Kubernetes control plane in a Docker container.
+
+---
+
+## 2. Network firewall (UFW)
+
+**Status:** Strong.
+
+Default policies: `deny (incoming)`, `allow (outgoing)`. Allow rules:
+
+| Source | Port | Purpose |
+|---|---|---|
+| `100.64.0.0/10` (Tailscale CGNAT range) | `22/tcp` | SSH from any tailnet member |
+| `127.0.0.1` | `80/tcp` | Cloudflare Tunnel inbound (loopback only — the tunnel daemon is the only listener) |
+| `127.0.0.1` | `11434/tcp` | Ollama localhost |
+| `172.16.0.0/12` | `11434/tcp` | Ollama from Docker bridge networks |
+| `172.17.0.0/16` | `11434/tcp` | Ollama from default Docker bridge specifically |
+| `192.168.49.0/24` | `11434/tcp` | Ollama from Minikube bridge |
+| `100.64.0.0/10` | `11434/tcp` | Ollama from any tailnet member |
+| Anywhere | `41641/udp` | Tailscale WireGuard control plane |
+
+**Note on Ollama exposure:** Ollama itself binds `0.0.0.0:11434` (required because Minikube reaches it via `host.minikube.internal` which resolves to the Docker bridge IP, not loopback). The firewall is the fence — it constrains who can reach the open port.
+
+**Operational discovery, 2026-04-16:** A previously-existing rule `192.168.0.0/16 → 11434/tcp` silently exposed Ollama to the home LAN (since `192.168.1.0/24` ⊂ `192.168.0.0/16`). The rule was removed during the hardening pass; the per-bridge rules above cover all legitimate paths.
+
+**Verification:** `nmap` from outside the tailnet against the host's public IP returns no open ports — Cloudflare Tunnel is outbound-only and exposes nothing inbound.
+
+---
+
+## 3. SSH hardening
+
+**Status:** Strong.
+
+`/etc/ssh/sshd_config.d/10-hardening.conf`:
+
+```
+ListenAddress 100.82.52.82
+ListenAddress 127.0.0.1
+AllowUsers kyle
+PermitRootLogin no
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+MaxAuthTries 3
+LoginGraceTime 20
+ClientAliveInterval 300
+ClientAliveCountMax 2
+
+# Lynis-recommended additions (safe because SSH is Tailscale-only)
+AllowTcpForwarding no
+AllowAgentForwarding no
+X11Forwarding no
+LogLevel VERBOSE
+MaxSessions 2
+TCPKeepAlive no
+```
+
+`sshd` listens only on the Tailscale IP and loopback — never `0.0.0.0:22`. The base `/etc/ssh/sshd_config` is unchanged; the drop-in is a pure overlay so console rollback is "delete one file, reload one service."
+
+**Race-condition fix:** `/etc/systemd/system/ssh.service.d/wait-for-tailscale.conf`
+
+```ini
+[Unit]
+After=tailscaled.service network-online.target
+Wants=tailscaled.service network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=10
+```
+
+Without this, the first reboot after enabling the hardening drop-in caused `sshd` to race ahead of `tailscaled`, fail to bind `100.82.52.82:22`, and leave the host SSH-unreachable until manual `systemctl restart ssh` from console. The drop-in fixes the ordering and adds a 10-second auto-retry safety net for the brief window where `tailscaled` is "active" but the IP isn't yet on the interface.
+
+---
+
+## 4. Privilege management (sudo)
+
+**Status:** Strong.
+
+`/etc/sudoers.d/kyle-ops`:
+
+```
+kyle ALL=(root) NOPASSWD: /usr/bin/systemctl, \
+                          /usr/bin/journalctl, \
+                          /usr/bin/apt, \
+                          /usr/bin/apt-get, \
+                          /usr/bin/dpkg, \
+                          /usr/local/bin/kubectl, \
+                          /usr/local/bin/minikube, \
+                          /usr/bin/docker, \
+                          /usr/sbin/ufw status, \
+                          /usr/sbin/ufw status verbose, \
+                          /usr/bin/lynis audit system
+```
+
+Routine operations (service management, log inspection, package updates, container/cluster management, firewall status checks, security audits) are passwordless. Privilege-changing operations (`useradd`, `ufw enable/disable`, edits to `/etc/...`, `chmod` on system paths, `mount`) still require Kyle's password via the default `%sudo` group rule in `/etc/sudoers`.
+
+**Lesson recorded:** an earlier draft included a trailing explicit `kyle ALL=(ALL) ALL` line in `kyle-ops` to make "everything else needs password" obvious. Sudo's last-match-wins evaluation meant this line *overrode* the NOPASSWD entries above it, making nothing passwordless. Removing the explicit catch-all and relying on the implicit `%sudo` group membership fixed it. Captured in the ADR as a reusable lesson.
+
+---
+
+## 5. Audit logging
+
+**Status:** Adequate.
+
+`/etc/audit/rules.d/10-baseline.rules`:
+
+```
+# Identity changes
+-w /etc/passwd -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/group -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+
+# Sudo + sshd config
+-w /etc/sudoers -p wa -k sudoers
+-w /etc/sudoers.d/ -p wa -k sudoers
+-w /etc/ssh/sshd_config -p wa -k sshd
+-w /etc/ssh/sshd_config.d/ -p wa -k sshd
+
+# Privilege escalation invocations
+-w /usr/bin/sudo -p x -k sudo_exec
+-w /usr/bin/su -p x -k su_exec
+
+# Cron + scheduled-task tampering
+-w /etc/crontab -p wa -k cron
+-w /etc/cron.d/ -p wa -k cron
+-w /etc/cron.daily/ -p wa -k cron
+-w /etc/cron.hourly/ -p wa -k cron
+
+-e 2
+```
+
+The trailing `-e 2` makes the rule set immutable until the next reboot — an attacker who gains root cannot remove or alter the rules without a power cycle. Log rotation: `max_log_file = 50` MB, `num_logs = 4` — caps disk use at ~200 MB.
+
+`journald` made persistent at `/var/log/journal/`, retention capped at 2 GB / 30 days via `/etc/systemd/journald.conf.d/retention.conf`. Logs survive reboots, which they didn't before.
+
+**Accepted limitation:** logs are local-only. A remote forwarder (Loki, journald-remote, syslog → SIEM) would harden the chain against a host compromise that wipes audit logs. Listed in §11.
+
+---
+
+## 6. Kernel hardening
+
+**Status:** Strong.
+
+`/etc/sysctl.d/99-hardening.conf`:
+
+```
+# Kernel
+kernel.kptr_restrict=2
+kernel.dmesg_restrict=1
+kernel.yama.ptrace_scope=1
+kernel.unprivileged_bpf_disabled=1
+
+# Network
+net.ipv4.conf.all.rp_filter=1
+net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.accept_source_route=0
+net.ipv4.conf.all.accept_redirects=0
+net.ipv4.conf.all.send_redirects=0
+net.ipv6.conf.all.accept_redirects=0
+net.ipv4.tcp_syncookies=1
+net.ipv4.icmp_echo_ignore_broadcasts=1
+
+# Filesystem
+fs.protected_hardlinks=1
+fs.protected_symlinks=1
+```
+
+Standard server-hardening profile: hide kernel pointers from `/proc`, restrict `dmesg` and `ptrace` to root and parent processes, block unprivileged eBPF, tighten the network stack against spoofing/redirects, enforce SYN cookies, protect against hardlink/symlink TOCTOU attacks.
+
+**Deliberate non-change:** `net.ipv4.ip_forward` stays at `1` — Docker and Minikube both require it.
+
+---
+
+## 7. Patch management
+
+**Status:** Strong.
+
+The most consequential operational finding of the 2026-04-16 hardening pass: `unattended-upgrades` was active and configured to allow security-origin packages, but `/etc/apt/sources.list` was missing the `security.debian.org` repository entry. The migration to Debian 13 had silently broken automatic security updates.
+
+Fix: appended to `/etc/apt/sources.list`:
+
+```
+deb http://security.debian.org/debian-security trixie-security main contrib non-free non-free-firmware
+```
+
+The first `apt-get update` after this fetched 15 stale patches: `openssh-server`, `openssh-client`, `openssl`, `libssl3t64`, `libpng16-16t64`, `libtiff6`, `libfreetype6`, `libgdk-pixbuf-2.0-0` (and related), `linux-image-amd64` (kernel `6.12.73 → 6.12.74`), `linux-libc-dev`. All applied via `apt-get -o Dpkg::Options::="--force-confold" dist-upgrade -y`; the kernel update landed via reboot.
+
+`unattended-upgrades` is now both enabled **and** has a security source to pull from. Verified by reading `/var/log/unattended-upgrades/unattended-upgrades.log` — the daemon now logs allowed origins including `Debian-Security`.
+
+---
+
+## 8. Service auto-start (operational resilience)
+
+**Status:** Strong.
+
+A 2026-04-15 power outage revealed that nothing on the box auto-restarted cleanly: Minikube did not come back, ethernet stayed down until manually `ifup`'d. Both fixed during the 2026-04-16 hardening:
+
+- **`/etc/systemd/system/minikube.service`** (new) — `Type=oneshot`, `RemainAfterExit=yes`, runs `/usr/local/bin/minikube start` as `kyle` after `docker.service`. `Restart=on-failure`, `TimeoutStartSec=600`.
+- **`/etc/systemd/system/minikube-tunnel.service`** (modified) — now `Requires=minikube.service`, so the LoadBalancer tunnel can't start before the cluster is up.
+- **`/etc/network/interfaces`** — added `auto enp4s0 / iface enp4s0 inet dhcp`. The Debian 13 default install had `lo` only.
+
+The stock `cloudflared.service` and `ollama.service` are enabled and confirmed to come back on boot. `fail2ban`, `auditd`, `ssh` (with the wait-for-tailscale drop-in from §3), and the new `minikube.service` round out the always-on set.
+
+**Verified across two reboots** during the 2026-04-16 hardening: from cold boot, every service comes back without intervention, ethernet auto-attaches, the cluster reports `Ready` within ~60 seconds.
+
+---
+
+## 9. Intrusion prevention
+
+**Status:** Adequate.
+
+`fail2ban` `[sshd]` jail tuned in `/etc/fail2ban/jail.local`:
+
+```
+[DEFAULT]
+bantime = 1h
+maxretry = 3
+
+[sshd]
+enabled = true
+bantime = 1h
+maxretry = 3
+```
+
+Three failed SSH attempts within `findtime` (default 10m) → 1-hour ban. Effective practical limit, even though SSH is Tailscale-only and brute-force is essentially infeasible from outside the tailnet.
+
+---
+
+## 10. Lynis baseline
+
+**Status:** Strong.
+
+`lynis audit system` final hardening index: **77** (target was ≥75). Pre-remediation score: 70.
+
+The 7-point gap was closed primarily by:
+- Adding the `security.debian.org` repository (single largest contributor)
+- The lynis-recommended SSH additions in §3 (`AllowTcpForwarding no`, `LogLevel VERBOSE`, etc.)
+- `login.defs` tightening: `PASS_MAX_DAYS=90`, `PASS_MIN_DAYS=1`, `UMASK=027`, `SHA_CRYPT_MIN_ROUNDS=10000`, `SHA_CRYPT_MAX_ROUNDS=10000`
+
+Full report captured at [`lynis-baseline-2026-04-16.log`](lynis-baseline-2026-04-16.log) (32 KB) for diffing against future runs.
+
+---
+
+## 11. Recovery posture
+
+**Status:** Strong.
+
+Every Phase-2 lockdown change (SSH binding, sudo narrowing, UFW rule changes) was implemented as a **new file**, never an edit of an existing config. This means console recovery is always "delete one file, reload one service" — not "remember what the original `/etc/ssh/sshd_config` said and undo your edit."
+
+Snapshots taken before risky changes:
+- `/root/etc-ssh-backup-2026-04-16/` — full `/etc/ssh` directory
+- `/root/sudoers-backup-2026-04-16/` — full `/etc/sudoers.d` directory (including the bootstrap `kyle-temp` file)
+- `/root/sysctl.conf.bak-2026-04-16` — `/etc/sysctl.conf` (turned out to be absent on Debian 13 default; snapshot is a placeholder)
+
+Console fallback (keyboard + monitor at the box) was used once during the work — the wait-for-tailscale race took out SSH on the first reboot of the new config, and recovery via console (`systemctl restart ssh`) took under a minute.
+
+---
+
+## Recommended next steps
+
+Ordered by impact-to-effort ratio:
+
+1. **Remote audit log forwarding.** `auditd` and `journald` are local-only. A remote sink (Loki via `journald-remote`, or a SIEM) means logs survive a host compromise. Medium effort, high value for incident response.
+2. **AIDE (Advanced Intrusion Detection Environment).** File-integrity monitoring with a daily scheduled scan against a baseline. Catches root-kit-style file tampering. Deferred during the 2026-04-16 work because tuning false positives is a real ongoing cost — worth doing if the box ever leaves single-tenant home use.
+3. **GRUB password.** Prevents an attacker with physical access from boot-time recovery shell. Marginal value — physical access already implies game-over, but lynis flags it.
+4. **SSH certificate-based authentication.** Replaces raw key trust with a CA-signed model. Worth it if more than one trusted client device exists.
+5. **`/home` and `/var` on separate partitions.** Lynis suggestion. Requires a partition rebuild — defer to next OS reinstall, not worth a forced rebuild.
+6. **`kernel` modules signing & `lockdown` mode.** Higher-effort hardening for a host that's not running custom kernel modules anyway. Defer.
+
+---
+
+## Evidence index
+
+**Host paths:**
+- `/etc/ssh/sshd_config.d/10-hardening.conf` — SSH hardening drop-in
+- `/etc/systemd/system/ssh.service.d/wait-for-tailscale.conf` — sshd-vs-tailscaled race fix
+- `/etc/sudoers.d/kyle-ops` — narrow sudo allowlist
+- `/etc/audit/rules.d/10-baseline.rules` — auditd baseline
+- `/etc/audit/auditd.conf` — log rotation (max_log_file=50, num_logs=4)
+- `/etc/systemd/journald.conf.d/retention.conf` — journald persistence + retention
+- `/etc/sysctl.d/99-hardening.conf` — kernel sysctl hardening
+- `/etc/fail2ban/jail.local` — fail2ban tuning
+- `/etc/apt/sources.list` — security repository addition
+- `/etc/login.defs` — password aging + umask + SHA crypt rounds
+- `/etc/systemd/system/minikube.service` — Minikube auto-start
+- `/etc/systemd/system/minikube-tunnel.service` — tunnel auto-start (depends on minikube)
+- `/etc/network/interfaces` — ethernet auto-connect
+- `/var/log/lynis.log` — full lynis output
+
+**Repo paths:**
+- [`docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md`](../superpowers/specs/2026-04-16-debian-host-hardening-design.md) — design spec
+- [`docs/superpowers/plans/2026-04-16-debian-host-hardening.md`](../superpowers/plans/2026-04-16-debian-host-hardening.md) — implementation plan
+- [`docs/adr/2026-04-16-debian-host-hardening.md`](../adr/2026-04-16-debian-host-hardening.md) — engineering ADR with as-built decisions and surprises
+- [`docs/superpowers/specs/2026-04-15-debian-server-migration-design.md`](../superpowers/specs/2026-04-15-debian-server-migration-design.md) — predecessor migration spec
+- [`docs/security/lynis-baseline-2026-04-16.log`](lynis-baseline-2026-04-16.log) — captured lynis baseline report
+- [`docs/security/security-assessment.md`](security-assessment.md) — application/CI/K8s security assessment (sibling)

--- a/docs/security/lynis-baseline-2026-04-16.log
+++ b/docs/security/lynis-baseline-2026-04-16.log
@@ -1,0 +1,766 @@
+
+[ Lynis 3.1.4 ]
+
+################################################################################
+  Lynis comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+  welcome to redistribute it under the terms of the GNU General Public License.
+  See the LICENSE file for details about using this software.
+
+  2007-2024, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+################################################################################
+
+
+[+] Initializing program
+------------------------------------
+[2C- Detecting OS... [41C [ DONE ]
+[2C- Checking profiles...[37C [ DONE ]
+
+  ---------------------------------------------------
+  Program version:           3.1.4
+  Operating system:          Linux
+  Operating system name:     Debian
+  Operating system version:  13
+  Kernel version:            6.12.74+deb13+1
+  Hardware platform:         x86_64
+  Hostname:                  debian
+  ---------------------------------------------------
+  Profiles:                  /etc/lynis/default.prf
+  Log file:                  /var/log/lynis.log
+  Report file:               /var/log/lynis-report.dat
+  Report version:            1.0
+  Plugin directory:          /etc/lynis/plugins
+  ---------------------------------------------------
+  Auditor:                   [Not Specified]
+  Language:                  en
+  Test category:             all
+  Test group:                all
+  ---------------------------------------------------
+[2C- Program update status... [32C [ NO UPDATE ]
+
+[+] System tools
+------------------------------------
+[2C- Scanning available tools...[30C
+[2C- Checking system binaries...[30C
+
+[+] Plugins (phase 1)
+------------------------------------
+[0CNote: plugins have more extensive tests and may take several minutes to complete[0C
+[0C [0C
+[2C- Plugin: debian[43C
+    [
+[+] Debian Tests
+------------------------------------
+[2C- Checking for system binaries that are required by Debian Tests...[0C
+[4C- Checking /bin... [38C [ FOUND ]
+[4C- Checking /sbin... [37C [ FOUND ]
+[4C- Checking /usr/bin... [34C [ FOUND ]
+[4C- Checking /usr/sbin... [33C [ FOUND ]
+[4C- Checking /usr/local/bin... [28C [ FOUND ]
+[4C- Checking /usr/local/sbin... [27C [ FOUND ]
+[2C- Authentication:[42C
+[4C- PAM (Pluggable Authentication Modules):[16C
+[6C- libpam-tmpdir[40C [ Not Installed ]
+[2C- File System Checks:[38C
+[4C- DM-Crypt, Cryptsetup & Cryptmount:[21C
+[2C- Software:[48C
+[4C- apt-listbugs[43C [ Not Installed ]
+[4C- apt-listchanges[40C [ Installed and enabled for apt ]
+[4C- needrestart[44C [ Not Installed ]
+[4C- fail2ban[47C [ Installed with jail.local ]
+]
+
+[+] Boot and services
+------------------------------------
+[2C- Service Manager[42C [ systemd ]
+[2C- Checking UEFI boot[39C [ ENABLED ]
+[2C- Checking Secure Boot[37C [ DISABLED ]
+[2C- Checking presence GRUB2[34C [ FOUND ]
+[4C- Checking for password protection[23C [ NONE ]
+[2C- Check running services (systemctl)[23C [ DONE ]
+[8CResult: found 18 running services[20C
+[2C- Check enabled services at boot (systemctl)[15C [ DONE ]
+[8CResult: found 28 enabled services[20C
+[2C- Check startup files (permissions)[24C [ OK ]
+[2C- Running 'systemd-analyze security'[23C
+[6CUnit name (exposure value) and predicate[15C
+[6C--------------------------------[23C
+[4C- auditd.service (value=8.9)[29C [ EXPOSED ]
+[4C- cloudflared.service (value=9.6)[24C [ UNSAFE ]
+[4C- containerd.service (value=9.6)[25C [ UNSAFE ]
+[4C- cron.service (value=9.6)[31C [ UNSAFE ]
+[4C- dbus.service (value=9.3)[31C [ UNSAFE ]
+[4C- docker.service (value=9.6)[29C [ UNSAFE ]
+[4C- emergency.service (value=9.5)[26C [ UNSAFE ]
+[4C- fail2ban.service (value=9.6)[27C [ UNSAFE ]
+[4C- getty@tty1.service (value=9.6)[25C [ UNSAFE ]
+[4C- lynis.service (value=9.6)[30C [ UNSAFE ]
+[4C- minikube-tunnel.service (value=9.2)[20C [ UNSAFE ]
+[4C- nvidia-persistenced.service (value=9.6)[16C [ UNSAFE ]
+[4C- ollama.service (value=9.2)[29C [ UNSAFE ]
+[4C- rc-local.service (value=9.6)[27C [ UNSAFE ]
+[4C- rescue.service (value=9.5)[29C [ UNSAFE ]
+[4C- ssh.service (value=9.6)[32C [ UNSAFE ]
+[4C- sshd@sshd-keygen.service (value=9.6)[19C [ UNSAFE ]
+[4C- systemd-ask-password-console.service (value=9.4)[7C [ UNSAFE ]
+[4C- systemd-ask-password-wall.service (value=9.4)[10C [ UNSAFE ]
+[4C- systemd-bsod.service (value=9.5)[23C [ UNSAFE ]
+[4C- systemd-hostnamed.service (value=1.7)[18C [ PROTECTED ]
+[4C- systemd-initctl.service (value=9.4)[20C [ UNSAFE ]
+[4C- systemd-journald.service (value=4.9)[19C [ PROTECTED ]
+[4C- systemd-logind.service (value=2.8)[21C [ PROTECTED ]
+[4C- systemd-networkd.service (value=2.9)[19C [ PROTECTED ]
+[4C- systemd-rfkill.service (value=9.4)[21C [ UNSAFE ]
+[4C- systemd-timesyncd.service (value=2.1)[18C [ PROTECTED ]
+[4C- systemd-udevd.service (value=7.1)[22C [ MEDIUM ]
+[4C- tailscaled.service (value=9.6)[25C [ UNSAFE ]
+[4C- unattended-upgrades.service (value=9.6)[16C [ UNSAFE ]
+[4C- user@1000.service (value=9.4)[26C [ UNSAFE ]
+
+[+] Kernel
+------------------------------------
+[2C- Checking default runlevel[32C [ runlevel 5 ]
+[2C- Checking CPU support (NX/PAE)[28C
+[4CCPU support: PAE and/or NoeXecute supported[14C [ FOUND ]
+[2C- Checking kernel version and release[22C [ DONE ]
+[2C- Checking kernel type[37C [ DONE ]
+[2C- Checking loaded kernel modules[27C [ DONE ]
+[6CFound 165 active modules[31C
+[2C- Checking Linux kernel configuration file[17C [ FOUND ]
+[2C- Checking default I/O kernel scheduler[20C [ NOT FOUND ]
+[2C- Checking for available kernel update[21C [ OK ]
+[2C- Checking core dumps configuration[24C
+[4C- configuration in systemd conf files[20C [ DEFAULT ]
+[4C- configuration in /etc/profile[26C [ DEFAULT ]
+[4C- 'hard' configuration in /etc/security/limits.conf[6C [ ENABLED ]
+[4C- 'soft' configuration in /etc/security/limits.conf[6C [ DISABLED ]
+[4C- Checking setuid core dumps configuration[15C [ DISABLED ]
+[2C- Check if reboot is needed[32C [ NO ]
+
+[+] Memory and Processes
+------------------------------------
+[2C- Checking /proc/meminfo[35C [ FOUND ]
+[2C- Searching for dead/zombie processes[22C [ NOT FOUND ]
+[2C- Searching for IO waiting processes[23C [ NOT FOUND ]
+[2C- Search prelink tooling[35C [ NOT FOUND ]
+
+[+] Users, Groups and Authentication
+------------------------------------
+[2C- Administrator accounts[35C [ OK ]
+[2C- Unique UIDs[46C [ OK ]
+[2C- Consistency of group files (grpck)[23C [ OK ]
+[2C- Unique group IDs[41C [ OK ]
+[2C- Unique group names[39C [ OK ]
+[2C- Password file consistency[32C [ OK ]
+[2C- Password hashing methods[33C [ OK ]
+[2C- Password hashing rounds (minimum)[24C [ CONFIGURED ]
+[2C- Query system users (non daemons)[25C [ DONE ]
+[2C- NIS+ authentication support[30C [ NOT ENABLED ]
+[2C- NIS authentication support[31C [ NOT ENABLED ]
+[2C- Sudoers file(s)[42C [ FOUND ]
+[4C- Permissions for directory: /etc/sudoers.d[14C [ WARNING ]
+[4C- Permissions for: /etc/sudoers[26C [ OK ]
+[4C- Permissions for: /etc/sudoers.d/kyle-temp[14C [ OK ]
+[4C- Permissions for: /etc/sudoers.d/README[17C [ OK ]
+[2C- PAM password strength tools[30C [ SUGGESTION ]
+[2C- PAM configuration files (pam.conf)[23C [ FOUND ]
+[2C- PAM configuration files (pam.d)[26C [ FOUND ]
+[2C- PAM modules[46C [ FOUND ]
+[2C- LDAP module in PAM[39C [ NOT FOUND ]
+[2C- Accounts without expire date[29C [ SUGGESTION ]
+[2C- Accounts without password[32C [ OK ]
+[2C- Locked accounts[42C [ OK ]
+[2C- User password aging (minimum)[28C [ CONFIGURED ]
+[2C- User password aging (maximum)[28C [ CONFIGURED ]
+[2C- Checking expired passwords[31C [ OK ]
+[2C- Checking Linux single user mode authentication[11C [ OK ]
+[2C- Determining default umask[32C
+[4C- umask (/etc/profile)[35C [ NOT FOUND ]
+[4C- umask (/etc/login.defs)[32C [ OK ]
+[2C- LDAP authentication support[30C [ NOT ENABLED ]
+[2C- Logging failed login attempts[28C [ DISABLED ]
+
+[+] Kerberos
+------------------------------------
+[2C- Check for Kerberos KDC and principals[20C [ NOT FOUND ]
+
+[+] Shells
+------------------------------------
+[2C- Checking shells from /etc/shells[25C
+[4CResult: found 7 shells (valid shells: 7).[16C
+[4C- Session timeout settings/tools[25C [ NONE ]
+[2C- Checking default umask values[28C
+[4C- Checking default umask in /etc/bash.bashrc[13C [ NONE ]
+[4C- Checking default umask in /etc/profile[17C [ NONE ]
+
+[+] File systems
+------------------------------------
+[2C- Checking mount points[36C
+[4C- Checking /home mount point[29C [ SUGGESTION ]
+[4C- Checking /tmp mount point[30C [ OK ]
+[4C- Checking /var mount point[30C [ SUGGESTION ]
+[2C- Query swap partitions (fstab)[28C [ OK ]
+[2C- Testing swap partitions[34C [ OK ]
+[2C- Testing /proc mount (hidepid)[28C [ SUGGESTION ]
+[2C- Checking for old files in /tmp[27C [ OK ]
+[2C- Checking /tmp sticky bit[33C [ OK ]
+[2C- Checking /var/tmp sticky bit[29C [ OK ]
+[2C- ACL support root file system[29C [ ENABLED ]
+[2C- Mount options of /[39C [ NON DEFAULT ]
+[2C- Mount options of /dev[36C [ PARTIALLY HARDENED ]
+[2C- Mount options of /dev/shm[32C [ PARTIALLY HARDENED ]
+[2C- Mount options of /run[36C [ HARDENED ]
+[2C- Mount options of /tmp[36C [ PARTIALLY HARDENED ]
+[2C- Total without nodev:7 noexec:10 nosuid:5 ro or noexec (W^X): 10 of total 28[0C
+[2C- Disable kernel support of some filesystems[15C
+
+[+] USB Devices
+------------------------------------
+[2C- Checking usb-storage driver (modprobe config)[12C [ NOT DISABLED ]
+[2C- Checking USB devices authorization[23C [ ENABLED ]
+[2C- Checking USBGuard[40C [ NOT FOUND ]
+
+[+] Storage
+------------------------------------
+[2C- Checking firewire ohci driver (modprobe config)[10C [ NOT DISABLED ]
+
+[+] NFS
+------------------------------------
+[2C- Check running NFS daemon[33C [ NOT FOUND ]
+
+[+] Name services
+------------------------------------
+[2C- Checking search domains[34C [ FOUND ]
+[2C- Searching DNS domain name[32C [ UNKNOWN ]
+[2C- Checking /etc/hosts[38C
+[4C- Duplicate entries in hosts file[24C [ NONE ]
+[4C- Presence of configured hostname in /etc/hosts[10C [ FOUND ]
+[4C- Hostname mapped to localhost[27C [ NOT FOUND ]
+[4C- Localhost mapping to IP address[24C [ OK ]
+
+[+] Ports and packages
+------------------------------------
+[2C- Searching package managers[31C
+[4C- Searching dpkg package manager[25C [ FOUND ]
+[6C- Querying package manager[29C
+[4C- Query unpurged packages[32C [ NONE ]
+[2C- Checking security repository in sources.list file[8C [ OK ]
+[2C- Checking APT package database[28C [ OK ]
+W: Failed to fetch https://pkgconfig.tailscale.com/stable/debian/dists/trixie/InRelease  Could not resolve 'pkgconfig.tailscale.com'
+W: Some index files failed to download. They have been ignored, or old ones used instead.
+[2C- Checking vulnerable packages (apt-get only)[14C [ DONE ]
+[2C- Checking upgradeable packages[28C [ SKIPPED ]
+[2C- Checking package audit tool[30C [ INSTALLED ]
+[4CFound: apt-get[43C
+[2C- Toolkit for automatic upgrades (unattended-upgrade)[6C [ FOUND ]
+
+[+] Networking
+------------------------------------
+[2C- Checking IPv6 configuration[30C [ ENABLED ]
+[6CConfiguration method[35C [ AUTO ]
+[6CIPv6 only[46C [ NO ]
+[2C- Checking configured nameservers[26C
+[4C- Testing nameservers[36C
+[6CNameserver: 100.100.100.100[28C [ SKIPPED ]
+[6CNameserver: fd7a:115c:a1e0::53[25C [ SKIPPED ]
+[4C- Minimal of 2 responsive nameservers[20C [ SKIPPED ]
+[2C- Getting listening ports (TCP/UDP)[24C [ DONE ]
+[2C- Checking promiscuous interfaces[26C [ OK ]
+[2C- Checking status DHCP client[30C [ RUNNING ]
+[2C- Checking for ARP monitoring software[21C [ NOT FOUND ]
+[2C- Uncommon network protocols[31C [ 0 ]
+
+[+] Printers and Spools
+------------------------------------
+[2C- Checking cups daemon[37C [ NOT FOUND ]
+[2C- Checking lp daemon[39C [ NOT RUNNING ]
+
+[+] Software: e-mail and messaging
+------------------------------------
+
+[+] Software: firewalls
+------------------------------------
+[2C- Checking iptables kernel module[26C [ FOUND ]
+[4C- Checking iptables policies of chains[19C [ FOUND ]
+[6C- Chain INPUT (table: filter, target: DROP)[12C [ DROP ]
+[6C- Chain INPUT (table: security, target: ACCEPT)[8C [ ACCEPT ]
+[4C- Checking for empty ruleset[29C [ OK ]
+[4C- Checking for unused rules[30C [ FOUND ]
+[2C- Checking host based firewall[29C [ ACTIVE ]
+
+[+] Software: webserver
+------------------------------------
+[2C- Checking Apache[42C [ NOT FOUND ]
+[2C- Checking nginx[43C [ FOUND ]
+[2C- Searching nginx configuration file[23C [ NOT FOUND ]
+
+[+] SSH Support
+------------------------------------
+[2C- Checking running SSH daemon[30C [ FOUND ]
+[4C- Searching SSH configuration[28C [ FOUND ]
+[4C- OpenSSH option: AllowTcpForwarding[21C [ OK ]
+[4C- OpenSSH option: ClientAliveCountMax[20C [ OK ]
+[4C- OpenSSH option: ClientAliveInterval[20C [ OK ]
+[4C- OpenSSH option: FingerprintHash[24C [ OK ]
+[4C- OpenSSH option: GatewayPorts[27C [ OK ]
+[4C- OpenSSH option: IgnoreRhosts[27C [ OK ]
+[4C- OpenSSH option: LoginGraceTime[25C [ OK ]
+[4C- OpenSSH option: LogLevel[31C [ OK ]
+[4C- OpenSSH option: MaxAuthTries[27C [ OK ]
+[4C- OpenSSH option: MaxSessions[28C [ OK ]
+[4C- OpenSSH option: PermitRootLogin[24C [ OK ]
+[4C- OpenSSH option: PermitUserEnvironment[18C [ OK ]
+[4C- OpenSSH option: PermitTunnel[27C [ OK ]
+[4C- OpenSSH option: Port[35C [ SUGGESTION ]
+[4C- OpenSSH option: PrintLastLog[27C [ OK ]
+[4C- OpenSSH option: StrictModes[28C [ OK ]
+[4C- OpenSSH option: TCPKeepAlive[27C [ OK ]
+[4C- OpenSSH option: UseDNS[33C [ OK ]
+[4C- OpenSSH option: X11Forwarding[26C [ OK ]
+[4C- OpenSSH option: AllowAgentForwarding[19C [ OK ]
+[4C- OpenSSH option: AllowUsers[29C [ FOUND ]
+[4C- OpenSSH option: AllowGroups[28C [ NOT FOUND ]
+
+[+] SNMP Support
+------------------------------------
+[2C- Checking running SNMP daemon[29C [ NOT FOUND ]
+
+[+] Databases
+------------------------------------
+[2C- MongoDB status[43C [ FOUND ]
+[4C- Checking MongoDB authorization[25C [ DISABLED ]
+[2C- PostgreSQL processes status[30C [ FOUND ]
+[2C- Redis (server) status[36C [ FOUND ]
+
+=================================================================
+
+  Exception found!
+
+  Function/test:  [DBS-1882]
+  Message:        Found Redis, but no configuration file. Report this if you know where it is located on your system.
+
+  Help improving the Lynis community with your feedback!
+
+  Steps:
+  - Ensure you are running the latest version (/usr/sbin/lynis update check)
+  - If so, create a GitHub issue at https://github.com/CISOfy/lynis
+  - Include relevant parts of the log file or configuration file
+
+  Thanks!
+
+=================================================================
+
+
+[+] LDAP Services
+------------------------------------
+[2C- Checking OpenLDAP instance[31C [ NOT FOUND ]
+
+[+] PHP
+------------------------------------
+[2C- Checking PHP[45C [ NOT FOUND ]
+
+[+] Squid Support
+------------------------------------
+[2C- Checking running Squid daemon[28C [ NOT FOUND ]
+
+[+] Logging and files
+------------------------------------
+[2C- Checking for a running log daemon[24C [ OK ]
+[4C- Checking Syslog-NG status[30C [ NOT FOUND ]
+[4C- Checking systemd journal status[24C [ FOUND ]
+[4C- Checking Metalog status[32C [ NOT FOUND ]
+[4C- Checking RSyslog status[32C [ NOT FOUND ]
+[4C- Checking RFC 3195 daemon status[24C [ NOT FOUND ]
+[4C- Checking minilogd instances[28C [ NOT FOUND ]
+[4C- Checking wazuh-agent daemon status[21C [ NOT FOUND ]
+[2C- Checking logrotate presence[30C [ OK ]
+[2C- Checking remote logging[34C [ NOT ENABLED ]
+[2C- Checking log directories (static list)[19C [ DONE ]
+[2C- Checking open log files[34C [ SKIPPED ]
+
+[+] Insecure services
+------------------------------------
+[2C- Installed inetd package[34C [ NOT FOUND ]
+[2C- Installed xinetd package[33C [ OK ]
+[4C- xinetd status[42C [ NOT ACTIVE ]
+[2C- Installed rsh client package[29C [ OK ]
+[2C- Installed rsh server package[29C [ OK ]
+[2C- Installed telnet client package[26C [ OK ]
+[2C- Installed telnet server package[26C [ NOT FOUND ]
+[2C- Checking NIS client installation[25C [ OK ]
+[2C- Checking NIS server installation[25C [ OK ]
+[2C- Checking TFTP client installation[24C [ OK ]
+[2C- Checking TFTP server installation[24C [ OK ]
+
+[+] Banners and identification
+------------------------------------
+[2C- /etc/issue[47C [ FOUND ]
+[4C- /etc/issue contents[36C [ WEAK ]
+[2C- /etc/issue.net[43C [ FOUND ]
+[4C- /etc/issue.net contents[32C [ WEAK ]
+
+[+] Scheduled tasks
+------------------------------------
+[2C- Checking crontab and cronjob files[23C [ DONE ]
+
+[+] Accounting
+------------------------------------
+[2C- Checking accounting information[26C [ NOT FOUND ]
+[2C- Checking sysstat accounting data[25C [ NOT FOUND ]
+[2C- Checking auditd[42C [ ENABLED ]
+[4C- Checking audit rules[35C [ OK ]
+[4C- Checking audit configuration file[22C [ OK ]
+[4C- Checking auditd log file[31C [ FOUND ]
+
+[+] Time and Synchronization
+------------------------------------
+[2C- NTP daemon found: systemd (timesyncd)[20C [ FOUND ]
+[2C- Checking for a running NTP daemon or client[14C [ OK ]
+[2C- Last time synchronization[32C [ 446s ]
+
+[+] Cryptography
+------------------------------------
+[2C- Checking for expired SSL certificates [0/151][12C [ NONE ]
+[2C- Kernel entropy is sufficient[29C [ YES ]
+[2C- HW RNG & rngd[44C [ NO ]
+[2C- SW prng[50C [ NO ]
+[2CMOR-bit set[48C [ YES ]
+
+[+] Virtualization
+------------------------------------
+
+[+] Containers
+------------------------------------
+[4C- Docker[49C
+[6C- Docker daemon[40C [ RUNNING ]
+[8C- Docker info output (warnings)[22C [ NONE ]
+[6C- Containers[43C
+[8C- Total containers[35C [ 1 ]
+[10C- Running containers[31C [ 1 ]
+[8C- Unused containers[34C [ 0 ]
+[4C- File permissions[39C [ OK ]
+
+[+] Security frameworks
+------------------------------------
+[2C- Checking presence AppArmor[31C [ FOUND ]
+[4C- Checking AppArmor status[31C [ ENABLED ]
+[8CFound 135 unconfined processes[23C
+[2C- Checking presence SELinux[32C [ NOT FOUND ]
+[2C- Checking presence TOMOYO Linux[27C [ NOT FOUND ]
+[2C- Checking presence grsecurity[29C [ NOT FOUND ]
+[2C- Checking for implemented MAC framework[19C [ OK ]
+
+[+] Software: file integrity
+------------------------------------
+[2C- Checking file integrity tools[28C
+[2C- Checking presence integrity tool[25C [ NOT FOUND ]
+
+[+] Software: System tooling
+------------------------------------
+[2C- Checking automation tooling[30C
+[2C- Automation tooling[39C [ NOT FOUND ]
+[2C- Checking presence of Fail2ban[28C [ FOUND ]
+[4C- Checking Fail2ban jails[32C [ ENABLED ]
+[2C- Checking for IDS/IPS tooling[29C [ FOUND ]
+
+[+] Software: Malware
+------------------------------------
+[2C- Malware software components[30C [ NOT FOUND ]
+
+[+] File Permissions
+------------------------------------
+[2C- Starting file permissions check[26C
+[4CFile: /boot/grub/grub.cfg[32C [ OK ]
+[4CFile: /etc/crontab[39C [ SUGGESTION ]
+[4CFile: /etc/group[41C [ OK ]
+[4CFile: /etc/group-[40C [ OK ]
+[4CFile: /etc/hosts.allow[35C [ OK ]
+[4CFile: /etc/hosts.deny[36C [ OK ]
+[4CFile: /etc/issue[41C [ OK ]
+[4CFile: /etc/issue.net[37C [ OK ]
+[4CFile: /etc/motd[42C [ OK ]
+[4CFile: /etc/passwd[40C [ OK ]
+[4CFile: /etc/passwd-[39C [ OK ]
+[4CFile: /etc/ssh/sshd_config[31C [ SUGGESTION ]
+[4CDirectory: /root/.ssh[36C [ OK ]
+[4CDirectory: /etc/cron.d[35C [ SUGGESTION ]
+[4CDirectory: /etc/cron.daily[31C [ SUGGESTION ]
+[4CDirectory: /etc/cron.hourly[30C [ SUGGESTION ]
+[4CDirectory: /etc/cron.weekly[30C [ SUGGESTION ]
+[4CDirectory: /etc/cron.monthly[29C [ SUGGESTION ]
+
+[+] Home directories
+------------------------------------
+[2C- Permissions of home directories[26C [ OK ]
+[2C- Ownership of home directories[28C [ OK ]
+[2C- Checking shell history files[29C [ OK ]
+
+[+] Kernel Hardening
+------------------------------------
+[2C- Comparing sysctl key pairs with scan profile[13C
+[4C- dev.tty.ldisc_autoload (exp: 0)[24C [ DIFFERENT ]
+[4C- fs.protected_fifos (exp: 2)[28C [ DIFFERENT ]
+[4C- fs.protected_hardlinks (exp: 1)[24C [ OK ]
+[4C- fs.protected_regular (exp: 2)[26C [ OK ]
+[4C- fs.protected_symlinks (exp: 1)[25C [ OK ]
+[4C- fs.suid_dumpable (exp: 0)[30C [ OK ]
+[4C- kernel.core_uses_pid (exp: 1)[26C [ OK ]
+[4C- kernel.ctrl-alt-del (exp: 0)[27C [ OK ]
+[4C- kernel.dmesg_restrict (exp: 1)[25C [ OK ]
+[4C- kernel.kptr_restrict (exp: 2)[26C [ OK ]
+[4C- kernel.modules_disabled (exp: 1)[23C [ DIFFERENT ]
+[4C- kernel.perf_event_paranoid (exp: 2 3 4)[16C [ OK ]
+[4C- kernel.randomize_va_space (exp: 2)[21C [ OK ]
+[4C- kernel.sysrq (exp: 0)[34C [ DIFFERENT ]
+[4C- kernel.unprivileged_bpf_disabled (exp: 1)[14C [ OK ]
+[4C- kernel.yama.ptrace_scope (exp: 1 2 3)[18C [ OK ]
+[4C- net.core.bpf_jit_harden (exp: 2)[23C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv4.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv4.conf.all.bootp_relay (exp: 0)[17C [ OK ]
+[4C- net.ipv4.conf.all.forwarding (exp: 0)[18C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.log_martians (exp: 1)[16C [ DIFFERENT ]
+[4C- net.ipv4.conf.all.mc_forwarding (exp: 0)[15C [ OK ]
+[4C- net.ipv4.conf.all.proxy_arp (exp: 0)[19C [ OK ]
+[4C- net.ipv4.conf.all.rp_filter (exp: 1)[19C [ OK ]
+[4C- net.ipv4.conf.all.send_redirects (exp: 0)[14C [ OK ]
+[4C- net.ipv4.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv4.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+[4C- net.ipv4.conf.default.log_martians (exp: 1)[12C [ DIFFERENT ]
+[4C- net.ipv4.icmp_echo_ignore_broadcasts (exp: 1)[10C [ OK ]
+[4C- net.ipv4.icmp_ignore_bogus_error_responses (exp: 1)[4C [ OK ]
+[4C- net.ipv4.tcp_syncookies (exp: 1)[23C [ OK ]
+[4C- net.ipv4.tcp_timestamps (exp: 0 1)[21C [ OK ]
+[4C- net.ipv6.conf.all.accept_redirects (exp: 0)[12C [ OK ]
+[4C- net.ipv6.conf.all.accept_source_route (exp: 0)[9C [ OK ]
+[4C- net.ipv6.conf.default.accept_redirects (exp: 0)[8C [ OK ]
+[4C- net.ipv6.conf.default.accept_source_route (exp: 0)[5C [ OK ]
+
+[+] Hardening
+------------------------------------
+[4C- Installed compiler(s)[34C [ FOUND ]
+[4C- Installed malware scanner[30C [ NOT FOUND ]
+[4C- Non-native binary formats[30C [ FOUND ]
+
+[+] Custom tests
+------------------------------------
+[2C- Running custom tests... [33C [ NONE ]
+
+[+] Plugins (phase 2)
+------------------------------------
+
+================================================================================
+
+  -[ Lynis 3.1.4 Results ]-
+
+  Warnings (1):
+  ----------------------------
+  ! MongoDB instance allows any user to access databases [DBS-1820] 
+      https://cisofy.com/lynis/controls/DBS-1820/
+
+  Suggestions (33):
+  ----------------------------
+  * This release is more than 4 months old. Check the website or GitHub to see if there is an update available. [LYNIS] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/LYNIS/
+
+  * Install libpam-tmpdir to set $TMP and $TMPDIR for PAM sessions [DEB-0280] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/DEB-0280/
+
+  * Install apt-listbugs to display a list of critical bugs prior to each APT installation. [DEB-0810] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/DEB-0810/
+
+  * Install needrestart, alternatively to debian-goodies, so that you can run needrestart after upgrades to determine which daemons are using old versions of libraries and need restarting. [DEB-0831] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/DEB-0831/
+
+  * Set a password on GRUB boot loader to prevent altering boot configuration (e.g. boot in single user mode without password) [BOOT-5122] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/BOOT-5122/
+
+  * Determine runlevel and services at startup [BOOT-5180] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/BOOT-5180/
+
+  * Consider hardening system services [BOOT-5264] 
+    - Details  : Run '/usr/bin/systemd-analyze security SERVICE' for each service
+    - Related resources
+      * Article: Systemd features to secure service files: https://linux-audit.com/systemd/systemd-features-to-secure-units-and-services/
+      * Website: https://cisofy.com/lynis/controls/BOOT-5264/
+
+  * Install a PAM module for password strength testing like pam_cracklib or pam_passwdqc or libpam-passwdqc [AUTH-9262] 
+    - Related resources
+      * Article: Configure minimum password length for Linux systems: https://linux-audit.com/configure-the-minimum-password-length-on-linux-systems/
+      * Website: https://cisofy.com/lynis/controls/AUTH-9262/
+
+  * When possible set expire dates for all password protected accounts [AUTH-9282] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/AUTH-9282/
+
+  * To decrease the impact of a full /home file system, place /home on a separate partition [FILE-6310] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/FILE-6310/
+
+  * To decrease the impact of a full /var file system, place /var on a separate partition [FILE-6310] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/FILE-6310/
+
+  * Disable drivers like USB storage when not used, to prevent unauthorized storage or data theft [USB-1000] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/USB-1000/
+
+  * Disable drivers like firewire storage when not used, to prevent unauthorized storage or data theft [STRG-1846] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/STRG-1846/
+
+  * Check DNS configuration for the dns domain name [NAME-4028] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/NAME-4028/
+
+  * Install debsums utility for the verification of packages with known good database. [PKGS-7370] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/PKGS-7370/
+
+  * Install package apt-show-versions for patch management purposes [PKGS-7394] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/PKGS-7394/
+
+  * Determine if protocol 'dccp' is really needed on this system [NETW-3200] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/NETW-3200/
+
+  * Determine if protocol 'sctp' is really needed on this system [NETW-3200] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/NETW-3200/
+
+  * Determine if protocol 'rds' is really needed on this system [NETW-3200] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/NETW-3200/
+
+  * Determine if protocol 'tipc' is really needed on this system [NETW-3200] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/NETW-3200/
+
+  * Check iptables rules to see which rules are currently not used [FIRE-4513] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/FIRE-4513/
+
+  * Consider hardening SSH configuration [SSH-7408] 
+    - Details  : Port (set 22 to )
+    - Related resources
+      * Article: OpenSSH security and hardening: https://linux-audit.com/ssh/audit-and-harden-your-ssh-configuration/
+      * Website: https://cisofy.com/lynis/controls/SSH-7408/
+
+  * Enable logging to an external logging host for archiving purposes and additional protection [LOGG-2154] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/LOGG-2154/
+
+  * Add a legal banner to /etc/issue, to warn unauthorized users [BANN-7126] 
+    - Related resources
+      * Article: The real purpose of login banners: https://linux-audit.com/the-real-purpose-of-login-banners-on-linux/
+      * Website: https://cisofy.com/lynis/controls/BANN-7126/
+
+  * Add legal banner to /etc/issue.net, to warn unauthorized users [BANN-7130] 
+    - Related resources
+      * Article: The real purpose of login banners: https://linux-audit.com/the-real-purpose-of-login-banners-on-linux/
+      * Website: https://cisofy.com/lynis/controls/BANN-7130/
+
+  * Enable process accounting [ACCT-9622] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/ACCT-9622/
+
+  * Enable sysstat to collect accounting (no results) [ACCT-9626] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/ACCT-9626/
+
+  * Install a file integrity tool to monitor changes to critical and sensitive files [FINT-4350] 
+    - Related resources
+      * Article: Monitoring Linux file access, changes and data modifications: https://linux-audit.com/monitoring-linux-file-access-changes-and-modifications/
+      * Article: Monitor for file changes on Linux: https://linux-audit.com/monitor-for-file-system-changes-on-linux/
+      * Website: https://cisofy.com/lynis/controls/FINT-4350/
+
+  * Determine if automation tools are present for system management [TOOL-5002] 
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/TOOL-5002/
+
+  * Consider restricting file permissions [FILE-7524] 
+    - Details  : See screen output or log file
+    - Solution : Use chmod to change file permissions
+    - Related resources
+      * Website: https://cisofy.com/lynis/controls/FILE-7524/
+
+  * One or more sysctl values differ from the scan profile and could be tweaked [KRNL-6000] 
+    - Solution : Change sysctl value or disable test (skip-test=KRNL-6000:<sysctl-key>)
+    - Related resources
+      * Article: Linux hardening with sysctl settings: https://linux-audit.com/linux-hardening-with-sysctl/
+      * Article: Overview of sysctl options and values: https://linux-audit.com/kernel/sysctl/
+      * Website: https://cisofy.com/lynis/controls/KRNL-6000/
+
+  * Harden compilers like restricting access to root user only [HRDN-7222] 
+    - Related resources
+      * Article: Why remove compilers from your system?: https://linux-audit.com/software/why-remove-compilers-from-your-system/
+      * Website: https://cisofy.com/lynis/controls/HRDN-7222/
+
+  * Harden the system by installing at least one malware scanner, to perform periodic file system scans [HRDN-7230] 
+    - Solution : Install a tool like rkhunter, chkrootkit, OSSEC, Wazuh
+    - Related resources
+      * Article: Antivirus for Linux: is it really needed?: https://linux-audit.com/malware/antivirus-for-linux-really-needed/
+      * Article: Monitoring Linux Systems for Rootkits: https://linux-audit.com/monitoring-linux-systems-for-rootkits/
+      * Website: https://cisofy.com/lynis/controls/HRDN-7230/
+
+  Follow-up:
+  ----------------------------
+  - Show details of a test (lynis show details TEST-ID)
+  - Check the logfile for all details (less /var/log/lynis.log)
+  - Read security controls texts (https://cisofy.com)
+  - Use --upload to upload data to central system (Lynis Enterprise users)
+
+================================================================================
+
+  Lynis security scan details:
+
+  Hardening index : 77 [###############     ]
+  Tests performed : 265
+  Plugins enabled : 1
+
+  Components:
+  - Firewall               [V]
+  - Malware scanner        [X]
+
+  Scan mode:
+  Normal [V]  Forensics [ ]  Integration [ ]  Pentest [ ]
+
+  Lynis modules:
+  - Compliance status      [?]
+  - Security audit         [V]
+  - Vulnerability scan     [V]
+
+  Files:
+  - Test and debug information      : /var/log/lynis.log
+  - Report data                     : /var/log/lynis-report.dat
+
+================================================================================
+
+  Exceptions found
+  Some exceptional events or information was found!
+
+  What to do:
+  You can help by providing your log file (/var/log/lynis.log).
+  Go to https://cisofy.com/contact/ and send your file to the e-mail address listed
+
+================================================================================
+
+  Lynis 3.1.4
+
+  Auditing, system hardening, and compliance for UNIX-based systems
+  (Linux, macOS, BSD, and others)
+
+  2007-2024, CISOfy - https://cisofy.com/lynis/
+  Enterprise support available (compliance, plugins, interface and tools)
+
+================================================================================
+
+  [TIP]: Enhance Lynis audits by adding your settings to custom.prf (see /etc/lynis/default.prf for all settings)
+

--- a/docs/security/security-assessment.md
+++ b/docs/security/security-assessment.md
@@ -6,7 +6,8 @@ An evaluation of the security and DevSecOps controls currently implemented in th
 
 **Methodology:** source-code review of `.github/workflows/`, Dockerfiles, Kubernetes manifests, application auth code, and operational scripts. No dynamic testing was performed.
 
-**Date:** 2026-04-08
+**Originally written:** 2026-04-08
+**Last updated:** 2026-04-16 — incorporates the application-layer security audit (`docs/superpowers/specs/2026-04-15-security-audit-hardening-design.md`) and adds a §11 pointer to the new host-OS hardening assessment ([`linux-server-hardening.md`](linux-server-hardening.md)).
 
 ## Summary of findings
 
@@ -16,14 +17,15 @@ An evaluation of the security and DevSecOps controls currently implemented in th
 | Infrastructure-as-Code validation | **Strong** | `kubeconform`, `kind` server-side dry-run, and a custom policy-as-code script |
 | Supply chain | **Adequate for portfolio** | Multi-stage non-root builds and a private registry; no image signing |
 | Secrets management | **Strong** | Gitignored files, full-history secret scanning, and k8s-native `secretKeyRef` injection |
-| Application AuthN/AuthZ | **Strong** | JWT + bcrypt + Google OAuth 2.0, gateway-validated tokens with trusted header forwarding |
+| Application AuthN/AuthZ | **Strong** | JWT + bcrypt + Google OAuth 2.0, httpOnly cookies, JWT propagated and independently validated downstream, Redis denylist for token revocation |
 | Transport security | **Adequate** | TLS terminated at Cloudflare; no direct internet exposure of the backend |
 | Developer guardrails | **Strong** | Pre-commit hooks, preflight Makefile targets, and a structured branch workflow |
 | Post-deploy verification | **Strong** | Production Playwright smoke tests plus a new pre-deploy compose-smoke job |
-| Kubernetes runtime posture | **Weak** | No `NetworkPolicy`, `PodSecurityContext`, or `readOnlyRootFilesystem` — see accepted risks |
+| Kubernetes runtime posture | **Adequate** | Pod security contexts (`runAsNonRoot`, `readOnlyRootFilesystem`, `capabilities.drop:[ALL]`) on every Deployment; `NetworkPolicy` and namespace-level PSS still gaps |
 | Observability | **Foundation only** | Metrics and dashboards exist; no security monitoring or alerting |
+| Host / OS hardening | **Strong** | Debian 13 host hardened per [`linux-server-hardening.md`](linux-server-hardening.md) — UFW, SSH-Tailscale-only, narrow sudo, auditd, sysctl, lynis baseline 77 |
 
-The overall posture is strong for a portfolio-scale project. The most notable gap is Kubernetes-level runtime security (NetworkPolicy, PSS), which is documented as an accepted risk below.
+The overall posture is strong for a portfolio-scale project. The most notable remaining gaps are at the Kubernetes runtime layer (`NetworkPolicy` and namespace-level Pod Security Standards), documented as accepted risks below.
 
 ---
 
@@ -99,16 +101,25 @@ This layer was built in response to a real production incident on 2026-04-08, wh
 
 ## 5. Application AuthN/AuthZ
 
-**Status:** Strong. The Go and Java stacks independently implement the same patterns, which demonstrates the patterns rather than the framework choices.
+**Status:** Strong. The Go and Java stacks independently implement the same patterns, which demonstrates the patterns rather than the framework choices. The Python AI services share an auth module so all three independently validate JWTs at the edge.
 
-- **JWT + bcrypt.** 15-minute access tokens and 7-day refresh tokens, HMAC-SHA256 signed, with bcrypt `DefaultCost` password hashes. Evidence: `go/auth-service/internal/service/auth.go`, `java/task-service/src/main/java/.../SecurityConfig.java:71-73`.
-- **Google OAuth 2.0.** Federated authentication with server-side code exchange. Both password and OAuth flows return the same JWT envelope so the frontend is agnostic. Evidence: `go/auth-service/internal/handler/auth.go:74-91`, `docs/adr/password-authentication.md`.
-- **Gateway-validated JWTs with `X-User-Id` header forwarding** on the Java side. Only the gateway and `task-service` validate tokens; `activity-service` and `notification-service` trust the forwarded header. This reduces the auth attack surface but introduces a trust boundary that must be enforced at the network layer (see accepted risks). Evidence: `java/gateway-service/src/main/java/.../SecurityConfig.java:33-51`, `docs/adr/java-task-management/03_authentication_and_security.md`.
-- **Strict CORS.** Environment-driven allowlists with no wildcards. Runtime-enforced in `go/auth-service/internal/middleware/cors.go:1-33` and `java/gateway-service/src/main/java/.../SecurityConfig.java:54-64`. Also enforced at CI time via the CORS guardrail (§1), so a wildcard cannot be committed.
-- **Security headers.** Spring Security sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and HSTS `max-age=31536000; includeSubDomains`. Evidence: `java/gateway-service/src/main/java/.../SecurityConfig.java:38-43`.
+- **JWT + bcrypt.** 15-minute access tokens and 7-day refresh tokens, HMAC-SHA256 signed, with bcrypt password hashes. Evidence: `go/auth-service/internal/service/auth.go`, `java/task-service/src/main/java/.../SecurityConfig.java`.
+- **JWT signing-method validation.** Both Go services explicitly check `t.Method.(*jwt.SigningMethodHMAC)` before validating signatures, defending against the "alg=none" and key-confusion attack class. Evidence: `go/auth-service/internal/service/auth.go:74`, `go/ecommerce-service/internal/middleware/auth.go:27`.
+- **Token revocation via Redis denylist.** On `POST /auth/logout`, the auth-service hashes the token (SHA-256) and writes it to Redis under `auth:denied:<hash>` with TTL matching the access-token expiration. Auth middleware checks the denylist before accepting any token. Evidence: `go/auth-service/internal/handler/auth.go:152-165` (`Logout`), `go/auth-service/internal/service/token_denylist.go:25-31` (`Revoke`).
+- **httpOnly cookies for both stacks.** `access_token` and `refresh_token` are set with `HttpOnly: true`, `Secure: true`, `SameSite=Lax` on both Go and Java. The frontend never touches the JWT in JavaScript, removing a whole class of XSS-token-theft attacks. Evidence: `go/auth-service/internal/handler/auth.go:50-54` (Go cookies), `java/task-service/.../controller/AuthController.java:56-82` (Java cookies), `java/task-service/.../security/JwtAuthenticationFilter.java:30-60` (Java filter that reads the cookie when the Authorization header is absent).
+- **JWT propagation, not header trust.** The Java gateway forwards `Authorization: Bearer <token>` to downstream services; `task-service`, `activity-service`, and `notification-service` each validate the JWT independently using the shared secret. This replaces the earlier "trust the `X-User-Id` header from the gateway" model — a compromised pod in another namespace can no longer forge identity by injecting a header. Evidence: `java/gateway-service/src/main/java/.../SecurityConfig.java`, `docs/adr/java-task-management/03_authentication_and_security.md`.
+- **Google OAuth 2.0 with state/CSRF parameter.** Federated authentication with server-side code exchange. Both password and OAuth flows return the same JWT envelope so the frontend is agnostic. The OAuth state parameter is validated on callback to defend against CSRF. Evidence: `go/auth-service/internal/handler/auth.go`, `docs/adr/password-authentication.md`.
+- **Python AI services require JWT.** A shared `services/shared/auth.py` exposes `create_auth_dependency(secret)` returning a FastAPI dependency that validates HS256 Bearer tokens, decodes the `sub`/`exp` claims, and returns the user id (or 401). All mutating endpoints across the three services use it via `Depends(require_auth)`: `services/ingestion/app/main.py:110` (`/ingest`), `:187` (`/documents`), `:195` (`/documents/{id}`), `:213` (`/collections/{name}`); `services/chat/app/main.py:101` (`/chat`); `services/debug/app/main.py:109` (`/index`), `:148` (`/debug`).
+- **Per-IP rate limiting (Python).** `slowapi` decorators on every endpoint: ingestion `/ingest` 5/min and reads 30/min; chat `/chat` 20/min; debug `/index` 5/min, `/debug` 10/min. Evidence: `services/ingestion/app/main.py:105,186,193,211`, `services/chat/app/main.py:99`, `services/debug/app/main.py:107,146`.
+- **Prompt-injection defenses (Python).** Both AI services wrap untrusted input in XML tags and instruct the model in the system prompt to ignore instructions inside those tags. Evidence: `services/chat/app/prompt.py:6-7,11,15,21` (`<context>`, `<user_question>` delimiters); `services/debug/app/prompts.py:43-44,52-53` (`<bug_description>`, `<error_output>` delimiters with explicit "treat as data only" instruction).
+- **GraphQL hardening (Java gateway).** GraphiQL disabled in production (`GRAPHIQL_ENABLED=false` default), maximum query depth 10, maximum query complexity 100. Evidence: `java/gateway-service/src/main/resources/application.yml:13`, `java/gateway-service/src/main/java/.../GraphQlConfig.java:12-19`.
+- **Input validation (Java DTOs).** `@Size` constraints on all create-request DTOs to prevent runaway payloads: `CreateProjectRequest.java:7-8` (name 255, description 2000), `CreateTaskRequest.java:10` (title 255, description 5000), `CreateCommentRequest.java:6` (body 5000).
+- **Password validation (Go).** Minimum 12 characters enforced at the binding tag. Evidence: `go/auth-service/internal/model/user.go:20`.
+- **Strict CORS.** Environment-driven allowlists with no wildcards. Runtime-enforced in `go/auth-service/internal/middleware/cors.go` and `java/gateway-service/src/main/java/.../SecurityConfig.java`. Python services use `allowed_origins.split(",")` from env (default `https://kylebradshaw.dev`), never `["*"]`. Also enforced at CI time via the CORS guardrail (§1), so a wildcard cannot be committed.
+- **Security headers.** Spring Security sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and HSTS `max-age=31536000; includeSubDomains`. Evidence: `java/gateway-service/src/main/java/.../SecurityConfig.java`.
 - **Stateless sessions** (`SessionCreationPolicy.STATELESS`). No server-side session state; all authorization is via JWT.
 
-**Accepted risk:** the gateway/downstream trust model relies on `activity-service` and `notification-service` only being reachable from inside the cluster. With no `NetworkPolicy` in place (§9), this boundary is not enforced at the network layer — a compromised pod in another namespace could in principle forge `X-User-Id`. Acceptable for portfolio, not acceptable for production.
+**Note on previous "accepted risk":** the earlier draft of this document called out a gateway/downstream trust risk based on `X-User-Id` header forwarding. That model has been replaced by JWT propagation (each service independently validates the token), so the risk no longer applies.
 
 ---
 
@@ -116,7 +127,7 @@ This layer was built in response to a real production incident on 2026-04-08, wh
 
 **Status:** Adequate.
 
-- **Cloudflare Tunnel** — the backend is never directly exposed to the public internet. TLS terminates at the Cloudflare edge; the tunnel forwards traffic to the home-lab Windows PC running Minikube. Evidence: `CLAUDE.md:36-40`.
+- **Cloudflare Tunnel** — the backend is never directly exposed to the public internet. TLS terminates at the Cloudflare edge; the tunnel forwards traffic to the home-lab Debian 13 server running Minikube. The tunnel daemon is the only process listening on `127.0.0.1:80` on the host, gated by UFW (see [`linux-server-hardening.md`](linux-server-hardening.md) §2). Evidence: `CLAUDE.md:36-40`.
 - **NGINX Ingress** with path-based routing inside Minikube.
 - **Frontend on Vercel** with managed HTTPS; Cloudflare-managed certificates for the API subdomain.
 
@@ -149,14 +160,16 @@ This layer was built in response to a real production incident on 2026-04-08, wh
 
 ## 9. Kubernetes runtime posture
 
-**Status:** Weak. These are the most significant gaps in the current assessment.
+**Status:** Adequate. Pod-level controls are now in place across every Deployment; namespace-level enforcement and network isolation remain gaps.
 
-- **No `NetworkPolicy`.** Pods across all namespaces can reach each other without restriction. The gateway/downstream auth trust model (§5) depends on implicit network isolation that does not exist.
-- **No `PodSecurityContext` at the Kubernetes level.** Containers run as non-root via the Dockerfile `USER` directive, but Kubernetes itself is not enforcing `runAsNonRoot: true`, `runAsUser`, `fsGroup`, or `seccompProfile`.
-- **No `readOnlyRootFilesystem: true`.** Containers can write anywhere on their root filesystem at runtime.
-- **No Pod Security Standards (PSS) profile** — neither `baseline` nor `restricted` is enforced at the namespace level.
+- **Pod security contexts on every Deployment.** `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, and `capabilities.drop: ["ALL"]` are set on the container `securityContext` of every workload. Evidence: `java/k8s/deployments/activity-service.yml:47-53`, `gateway-service.yml:52-59`, `notification-service.yml:46-53`, `task-service.yml:67-74`; `go/k8s/deployments/ai-service.yml:37-44`, `auth-service.yml:47-54`, `ecommerce-service.yml:37-44`.
 
-**Accepted risk:** all four gaps are acknowledged as future work. A single commit adding PSS `restricted` profiles plus targeted `NetworkPolicy` resources would close the majority of this surface. See "Recommended next steps" below.
+**Remaining gaps (accepted risk):**
+
+- **No `NetworkPolicy`.** Pods across all namespaces can reach each other without restriction. With JWT propagation in place (§5), this is no longer a confused-deputy auth risk, but lateral movement after a single-pod compromise is still unconstrained.
+- **No Pod Security Standards (PSS) profile** enforced at the namespace level — the per-Deployment `securityContext` blocks are unenforced *defaults* rather than namespace-mandated policy. A new Deployment without those fields would not be rejected.
+
+A single commit adding PSS `restricted` labels to the `ai-services`, `java-tasks`, and `go-ecommerce` namespaces plus targeted `NetworkPolicy` resources would close the bulk of this remaining surface. See "Recommended next steps" below.
 
 ---
 
@@ -168,7 +181,25 @@ This layer was built in response to a real production incident on 2026-04-08, wh
 - **Grafana dashboard** at `https://grafana.kylebradshaw.dev` (public read-only).
 - **Health endpoints** on every service, used by readiness probes and production smoke tests.
 
-**Gaps:** there is no alerting on authentication failures, no anomaly detection, no SIEM integration, no centralized log aggregation (Loki / ELK), and no audit logging of privileged actions. For security purposes the current stack is observational rather than detective.
+**Gaps:** there is no alerting on authentication failures, no anomaly detection, no SIEM integration, no centralized log aggregation (Loki / ELK), and no application-layer audit logging of privileged actions. For security purposes the current stack is observational rather than detective. (The host OS does have local `auditd` — see §11.)
+
+---
+
+## 11. Host / OS hardening
+
+**Status:** Strong. Detailed in [`linux-server-hardening.md`](linux-server-hardening.md); summarized here.
+
+The Debian 13 home-lab server that runs Minikube, Ollama, and the Cloudflare Tunnel was hardened on 2026-04-16:
+
+- **SSH locked to Tailscale.** Listener binds only `100.82.52.82:22` (Tailscale IP) and `127.0.0.1:22` — never `0.0.0.0:22`. Public-internet SSH is gone.
+- **UFW default-deny firewall** with narrow allow rules. Ollama is firewall-fenced to docker bridges and the tailnet (no LAN exposure).
+- **Narrow passwordless sudo allowlist** for routine ops (`systemctl`, `journalctl`, `apt`, `kubectl`, `minikube`, `docker`, `ufw status`, `lynis audit system`). Privilege-changing actions still require password.
+- **`auditd`** with immutable baseline rules covering identity files, sudo/sshd configs, and privilege-escalation invocations. Persistent `journald` with retention caps.
+- **`sysctl` kernel hardening** drop-in (`kptr_restrict`, `ptrace_scope`, `unprivileged_bpf_disabled`, network-stack hygiene).
+- **Patch management fix.** Discovered that `unattended-upgrades` had been silently doing nothing since the migration because `/etc/apt/sources.list` was missing the `security.debian.org` entry. Fixed; 15 stale patches applied including kernel `6.12.73 → 6.12.74`.
+- **Lynis hardening index: 77** (target was ≥75).
+
+For implementation rationale and as-built decisions, see the engineering ADR at [`docs/adr/2026-04-16-debian-host-hardening.md`](../adr/2026-04-16-debian-host-hardening.md).
 
 ---
 
@@ -176,13 +207,14 @@ This layer was built in response to a real production incident on 2026-04-08, wh
 
 Ordered by impact-to-effort ratio:
 
-1. **Add a PSS `restricted` label** to the `ai-services`, `java-tasks`, and `go-ecommerce` namespaces and fix any resulting violations. High impact, low effort.
-2. **Add minimal `NetworkPolicy` resources** — default-deny ingress in each namespace, plus explicit allow rules for gateway→downstream and ingress-controller→gateway. Closes the §5 trust-model gap.
-3. **Pin production container images by digest** (`@sha256:…`) instead of `:latest`. Eliminates the mutable-tag supply chain risk.
-4. **Promote Java OWASP Dependency Check from reporting to gating.** One-line CI change.
-5. **Add Prometheus alert rules** for 4xx/5xx rate spikes and authentication failure bursts. Converts observability into detection.
-6. **Run a dedicated IaC scanner** (e.g. `kube-linter`, `checkov`) alongside the existing custom policy script. Catches the broader class of rules the homegrown script was intentionally narrow about.
-7. **Migrate to envelope-encrypted secrets** (SOPS with age, or external-secrets-operator with a cloud KMS) to remove dependence on Kubernetes Secrets' at-rest model.
+1. **Add a PSS `restricted` label** to the `ai-services`, `java-tasks`, and `go-ecommerce` namespaces and fix any resulting violations. The per-Deployment `securityContext` blocks (§9) already satisfy `restricted` — labeling the namespaces enforces it on future workloads.
+2. **Add minimal `NetworkPolicy` resources** — default-deny ingress in each namespace, plus explicit allow rules for gateway→downstream and ingress-controller→gateway. Limits lateral movement after a single-pod compromise.
+3. **Forward host audit logs to a remote sink.** §11's `auditd` and `journald` are local-only — a remote forwarder (Loki via `journald-remote`, or a SIEM) makes the audit trail survive a host compromise. Pairs naturally with §10 alerting work.
+4. **Pin production container images by digest** (`@sha256:…`) instead of `:latest`. Eliminates the mutable-tag supply chain risk.
+5. **Promote Java OWASP Dependency Check from reporting to gating.** One-line CI change.
+6. **Add Prometheus alert rules** for 4xx/5xx rate spikes and authentication failure bursts. Converts observability into detection.
+7. **Run a dedicated IaC scanner** (e.g. `kube-linter`, `checkov`) alongside the existing custom policy script. Catches the broader class of rules the homegrown script was intentionally narrow about.
+8. **Migrate to envelope-encrypted secrets** (SOPS with age, or external-secrets-operator with a cloud KMS) to remove dependence on Kubernetes Secrets' at-rest model.
 
 ---
 
@@ -204,11 +236,28 @@ Every file path cited in this assessment, for quick navigation:
 - `docker-compose.ci.yml` — compose overlay for CI smoke runs
 - `frontend/e2e/smoke.spec.ts` — post-deploy production smoke tests
 - `frontend/e2e/smoke-ci.spec.ts` — pre-deploy compose smoke tests
-- `go/auth-service/internal/service/auth.go` — JWT and bcrypt implementation
+- `go/auth-service/internal/service/auth.go` — JWT, bcrypt, and signing-method validation
+- `go/auth-service/internal/handler/auth.go` — login/refresh/logout handlers, httpOnly cookie setup
+- `go/auth-service/internal/service/token_denylist.go` — Redis token revocation
 - `go/auth-service/internal/middleware/cors.go` — Go CORS enforcement
+- `go/auth-service/internal/model/user.go` — password validation (min 12 chars)
+- `go/ecommerce-service/internal/middleware/auth.go` — JWT signing-method validation in ecommerce
 - `java/gateway-service/src/main/java/.../SecurityConfig.java` — Spring Security configuration
+- `java/gateway-service/src/main/java/.../config/GraphQlConfig.java` — GraphQL depth/complexity limits
+- `java/gateway-service/src/main/resources/application.yml` — GraphiQL disabled in prod
 - `java/task-service/src/main/java/.../SecurityConfig.java` — Spring Security configuration
-- `java/k8s/deployments/postgres.yml`, `mongodb.yml`, `redis.yml` — stateful service manifests with readiness probes
+- `java/task-service/src/main/java/.../controller/AuthController.java` — httpOnly cookie setup
+- `java/task-service/src/main/java/.../security/JwtAuthenticationFilter.java` — cookie-based JWT extraction
+- `java/k8s/deployments/*.yml` — Deployment manifests with `securityContext` (runAsNonRoot, readOnlyRootFilesystem, capabilities.drop)
+- `go/k8s/deployments/*.yml` — Deployment manifests with `securityContext`
 - `go/k8s/configmaps/*.yml` — Go service ConfigMaps with `sslmode=disable`
+- `services/shared/auth.py` — shared FastAPI JWT dependency (`create_auth_dependency`)
+- `services/ingestion/app/main.py`, `services/chat/app/main.py`, `services/debug/app/main.py` — `Depends(require_auth)` on every mutating endpoint, slowapi rate-limit decorators
+- `services/chat/app/prompt.py`, `services/debug/app/prompts.py` — XML-delimited prompt templates with injection-defense system instructions
 - `docs/adr/password-authentication.md` — auth architecture ADR
 - `docs/adr/java-task-management/03_authentication_and_security.md` — Java auth ADR
+- `docs/security/linux-server-hardening.md` — companion host-OS assessment
+- `docs/adr/2026-04-16-debian-host-hardening.md` — host-hardening engineering ADR
+- `docs/superpowers/specs/2026-04-15-security-audit-hardening-design.md` — application-layer audit spec
+- `docs/superpowers/specs/2026-04-16-debian-host-hardening-design.md` — host hardening spec
+- `docs/security/lynis-baseline-2026-04-16.log` — captured lynis baseline report

--- a/docs/superpowers/specs/2026-04-16-frontend-security-page-design.md
+++ b/docs/superpowers/specs/2026-04-16-frontend-security-page-design.md
@@ -1,0 +1,108 @@
+# Frontend Security Section Design
+
+**Date:** 2026-04-16
+**Status:** Approved (via Claude Code plan-mode review on 2026-04-16)
+
+## Context
+
+The 2026-04-15 application-layer security audit and the 2026-04-16 Debian 13 host hardening shipped substantial security work, captured in two evidence-cited assessments at `docs/security/security-assessment.md` and `docs/security/linux-server-hardening.md`. Both went live on `main` in commits `98913ff` and `c6b4120`.
+
+That work is currently invisible to anyone visiting the live portfolio at `kylebradshaw.dev` — discovery requires finding the GitHub repo and digging into `docs/security/`. Hiring managers and recruiters who land on the site won't see any of it.
+
+This spec adds a visible "Security" entry on the live site that conveys the depth of the security work and links to the source-of-truth `.md` files for evidence-curious readers. It mirrors the existing `/aws` and `/cicd` pattern (info-dense single page, prose + tables + one diagram, no sub-routes).
+
+## Decisions made
+
+Confirmed via clarifying questions during brainstorming:
+
+| Decision | Choice | Rejected alternatives |
+|---|---|---|
+| Page structure | Single `/security` page | Sub-pages (`/security/application` + `/security/linux-host`); tabs |
+| Landing-page treatment | 6th card in the existing card grid | Hero callout above the grid; both card + status strip |
+| Content density | Curated summary with deep-link to docs | Full verbatim port; tiered weight per topic |
+| Visual treatment | One Mermaid defense-in-depth diagram + tables + prose | Tables-only; two diagrams (defense + attack-surface) |
+
+## Files
+
+| Path | Action |
+|---|---|
+| `frontend/src/app/page.tsx` | Modify — add a 6th card for "Security" in the existing card grid |
+| `frontend/src/app/security/page.tsx` | Create — the new security landing page (~250 lines TSX, mirrors `/aws` and `/cicd` shape) |
+| `frontend/src/components/SiteHeader.tsx` | Modify — add "Security" nav item between "CI/CD" and the Grafana link |
+| `README.md` | Modify — add `/security` to the numbered "For hiring managers" read-this-first list |
+
+## Reusable existing patterns (don't reinvent)
+
+- **`Card` / `CardHeader` / `CardTitle` / `CardDescription` / `CardContent`** at `frontend/src/components/ui/card.tsx`
+- **`Badge`** at `frontend/src/components/ui/badge.tsx` — for status pills in the summary table
+- **`MermaidDiagram`** at `frontend/src/components/MermaidDiagram.tsx` — already used by `/aws`, `/cicd`, `/go`, `/ai`
+- **Page layout pattern from `/aws/page.tsx` and `/cicd/page.tsx`** — `<main>` container, h2/h3 typography, callout box styling
+- **`SiteHeader`** at `frontend/src/components/SiteHeader.tsx` — `usePathname()` for active-link highlighting
+
+No new dependencies. No new design system primitives.
+
+## Detailed changes
+
+### 1. Landing page — `frontend/src/app/page.tsx`
+
+Add a 6th `<Card>` to the existing grid, identical structure to the existing 5. Place it after the CI/CD card.
+
+- **Title:** `Security`
+- **Description:** `Defense-in-depth across the stack — application, CI/CD, Kubernetes, and the hardened Linux host that runs it all. Lynis baseline 77.`
+- **Link target:** `/security`
+
+Match the existing visual treatment exactly (same `<Card>` slot composition, same `hover:ring-foreground/20` effect, same `<Link>` wrapper).
+
+### 2. New page — `frontend/src/app/security/page.tsx`
+
+Single-file TSX, ~250 lines, mirroring the structure of `frontend/src/app/aws/page.tsx`. Sections in order:
+
+1. **Hero / intro paragraph** (50-60 words) — one sentence framing the work as layered, one sentence stating evidence stance, two prominent inline links to the two `.md` files on GitHub (use the new repo URL `kabradshaw1/portfolio` per the GitHub redirect).
+
+2. **Defense-in-depth diagram** (Mermaid, top-down flowchart) wrapped in the `<MermaidDiagram>` component. Layers: Internet → Cloudflare Tunnel → Debian host → Minikube cluster → Application → Data. Each layer annotated with the controls that defend it.
+
+3. **Public attack surface callout** — one-line bordered box: "Public attack surface: zero. `nmap` against the public IP returns no open ports."
+
+4. **Status summary table** — port the summary table from `security-assessment.md` plus the host-OS row, rendered as a real `<table>`. Eleven rows. `<Badge>` for the status column with variant by status: Strong → `default`, Adequate → `secondary`, Foundation only → `outline`. (No "Weak" rows currently.)
+
+5. **Application & infrastructure highlights** (h2) — one subsection each for Authentication & Authorization, Shift-left CI, Kubernetes runtime, Supply chain. ~3-5 sentences each. Each subsection ends with a "Full breakdown: §N of [doc]" link to the section anchor on GitHub.
+
+6. **Linux host hardening** (h2) — single subsection covering: SSH Tailscale-only, UFW default-deny + LAN-Ollama leak fix, narrow passwordless sudo, auditd immutable rules, sysctl drop-in, fail2ban, lynis 77. Highlights the `security.debian.org` repo gap as the most "interesting" finding. Ends with link to `linux-server-hardening.md`.
+
+7. **Recommended next steps** — short list of 3-4 priorities from the assessment's recommended-next-steps section: PSS + NetworkPolicy, remote audit log forwarding, image digest pinning, Java OWASP gating.
+
+8. **Footer "evidence" pointer** — one-paragraph closing.
+
+**Metadata:** `export const metadata: Metadata = { title: "Security · Kyle Bradshaw", description: "Defense-in-depth security assessment of the portfolio: application, CI/CD, Kubernetes, and the Debian 13 host." }` — match how `/aws/page.tsx` exports metadata.
+
+### 3. Site header — `frontend/src/components/SiteHeader.tsx`
+
+Add `Security` nav item to the existing nav-link list, between `CI/CD` and the Grafana external link. Same shape as the other internal nav items. Active-state highlighting works automatically via existing `usePathname()` logic.
+
+### 4. README — `README.md`
+
+Add `docs/security/` to the "For hiring managers" numbered list (lines 114-125), suggested as a new item 5. Renumber subsequent items.
+
+## Verification
+
+Frontend-only change. Verification steps:
+
+1. `cd frontend && npm run dev` — visual check at `localhost:3000`. Click new Security card, confirm page renders with diagram.
+2. `cd frontend && npx tsc --noEmit` — must pass clean.
+3. `cd frontend && npm run lint` — must pass clean.
+4. `cd frontend && npm run build` — must succeed; new route appears in build output.
+5. Mobile responsive check at ~375px width — card grid reflows, Mermaid diagram doesn't overflow.
+6. Both GitHub deep links resolve.
+
+## Branch & commit strategy
+
+Per CLAUDE.md feature-branch flow:
+- Worktree at `.claude/worktrees/agent-feat-security-page/` on branch `agent/feat-security-page` (created from `main`).
+- Commit on the feature branch, push, watch CI, open PR to `qa`.
+- Single commit if work is tight; split README/SiteHeader if they feel separable.
+
+## Out of scope (deferred)
+
+- Sub-pages under `/security` — single-page chosen for now; can split later if content density grows.
+- Markdown rendering library — would let us render the `.md` files directly, but adds a dependency for a one-page use case. Hardcoded JSX matches the existing `/aws` and `/cicd` pattern.
+- E2E test for the new page — content-only with no interactive behavior; visual verification + build success suffice.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -127,6 +127,24 @@ export default function Home() {
               </CardContent>
             </Card>
           </Link>
+          <Link href="/security" className="block">
+            <Card className="hover:ring-foreground/20 transition-all">
+              <CardHeader>
+                <CardTitle>Security</CardTitle>
+                <CardDescription>
+                  Defense-in-depth across the stack — application, CI/CD,
+                  Kubernetes, and the hardened Linux host that runs it all
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-sm">
+                  Six CI security gates, JWT + httpOnly cookies, pod security
+                  contexts, UFW default-deny firewall, Tailscale-only SSH,
+                  auditd, sysctl hardening, and a lynis baseline score of 77.
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/app/security/page.tsx
+++ b/frontend/src/app/security/page.tsx
@@ -1,0 +1,383 @@
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+import { Badge } from "@/components/ui/badge";
+
+const REPO = "https://github.com/kabradshaw1/gen_ai_engineer";
+
+const defenseInDepthDiagram = `flowchart TD
+  INET["Internet"]
+  CF["Cloudflare Tunnel<br/><i>TLS edge · outbound-only</i>"]
+  HOST["Debian 13 Host<br/><i>UFW default-deny · auditd · sysctl · Tailscale-only SSH</i>"]
+  K8S["Minikube Cluster<br/><i>per-Deployment securityContext · readiness probes</i>"]
+  APP["Application Layer<br/><i>JWT validation · httpOnly cookies · rate limiting · prompt-injection defenses</i>"]
+  DATA["Data Layer<br/><i>bcrypt passwords · Redis token denylist · secretKeyRef injection</i>"]
+
+  INET --> CF --> HOST --> K8S --> APP --> DATA`;
+
+const STATUS_ROWS: { area: string; status: string; variant: "default" | "secondary" | "outline"; notes: string }[] = [
+  { area: "Shift-left security in CI", status: "Strong", variant: "default", notes: "Six gating jobs: Bandit, pip-audit, npm audit, gitleaks, Hadolint, CORS guardrail" },
+  { area: "Infrastructure-as-Code validation", status: "Strong", variant: "default", notes: "kubeconform, kind dry-run, custom policy-as-code script" },
+  { area: "Supply chain", status: "Adequate", variant: "secondary", notes: "Multi-stage non-root builds, private GHCR; no image signing or digest pinning" },
+  { area: "Secrets management", status: "Strong", variant: "default", notes: "Gitignored files, full-history gitleaks, K8s secretKeyRef injection" },
+  { area: "Application AuthN/AuthZ", status: "Strong", variant: "default", notes: "JWT + bcrypt + OAuth 2.0, httpOnly cookies, Redis token revocation, Python JWT enforcement" },
+  { area: "Transport security", status: "Adequate", variant: "secondary", notes: "TLS at Cloudflare edge; no direct internet exposure; intra-cluster traffic unencrypted" },
+  { area: "Developer guardrails", status: "Strong", variant: "default", notes: "Pre-commit hooks, preflight Makefile targets, structured branch workflow" },
+  { area: "Post-deploy verification", status: "Strong", variant: "default", notes: "Production Playwright smoke tests + compose-smoke CI job" },
+  { area: "Kubernetes runtime posture", status: "Adequate", variant: "secondary", notes: "Pod security contexts on every Deployment; NetworkPolicy and namespace PSS still gaps" },
+  { area: "Observability", status: "Foundation", variant: "outline", notes: "Prometheus + Grafana dashboards; no security alerting" },
+  { area: "Host / OS hardening", status: "Strong", variant: "default", notes: "Debian 13: UFW, SSH Tailscale-only, narrow sudo, auditd, sysctl, lynis 77" },
+];
+
+export default function SecurityPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="mt-8 text-3xl font-bold">Security</h1>
+
+      {/* Intro */}
+      <section className="mt-8">
+        <p className="text-muted-foreground leading-relaxed">
+          I treat security as a layered concern — every request crosses the
+          perimeter, the host, the cluster, and the application before it touches
+          data. Every claim below cites the file (and often the line) that
+          implements it; the full assessments live alongside the code in the
+          repo:{" "}
+          <a
+            href={`${REPO}/blob/main/docs/security/security-assessment.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            security-assessment.md
+          </a>{" "}
+          and{" "}
+          <a
+            href={`${REPO}/blob/main/docs/security/linux-server-hardening.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            linux-server-hardening.md
+          </a>
+          .
+        </p>
+      </section>
+
+      {/* Defense-in-depth diagram */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Defense in Depth</h2>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          Five layers of controls compose from the internet edge to the data
+          store. A compromise at any single layer is contained by the layers
+          below it.
+        </p>
+        <div className="mt-6 rounded-xl border border-foreground/10 bg-card p-6">
+          <MermaidDiagram chart={defenseInDepthDiagram} />
+        </div>
+      </section>
+
+      {/* Zero-attack-surface callout */}
+      <section className="mt-8">
+        <div className="rounded-lg border border-foreground/10 bg-card p-4">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-semibold text-foreground">
+              Public attack surface: zero.
+            </span>{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              nmap
+            </code>{" "}
+            against the public IP returns no open ports. Cloudflare Tunnel is
+            outbound-only; SSH binds only to the Tailscale interface; Ollama is
+            firewall-fenced to docker bridges and the tailnet.
+          </p>
+        </div>
+      </section>
+
+      {/* Status summary table */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Summary of Findings</h2>
+        <div className="mt-6 overflow-x-auto">
+          <table className="w-full text-sm text-muted-foreground">
+            <thead>
+              <tr className="border-b text-left">
+                <th className="pb-2 pr-4 font-medium text-foreground">Area</th>
+                <th className="pb-2 pr-4 font-medium text-foreground">
+                  Status
+                </th>
+                <th className="pb-2 font-medium text-foreground">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {STATUS_ROWS.map((row) => (
+                <tr key={row.area}>
+                  <td className="py-2 pr-4 text-foreground">{row.area}</td>
+                  <td className="py-2 pr-4">
+                    <Badge variant={row.variant}>{row.status}</Badge>
+                  </td>
+                  <td className="py-2">{row.notes}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Application & Infrastructure Highlights */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">
+          Application & Infrastructure
+        </h2>
+
+        <div className="mt-8 space-y-8">
+          <div>
+            <h3 className="text-lg font-medium">
+              Authentication & Authorization
+            </h3>
+            <p className="mt-2 text-muted-foreground leading-relaxed">
+              JWT access and refresh tokens (HMAC-SHA256, 15-min / 7-day TTLs)
+              with bcrypt password hashes. Both Go services explicitly validate
+              the signing method to prevent alg-confusion attacks. Tokens are
+              delivered as httpOnly cookies (Secure, SameSite=Lax) — the
+              frontend never touches the JWT in JavaScript. On logout, the token
+              hash is written to a Redis denylist with matching TTL. Python AI
+              services share a JWT auth dependency that enforces authentication
+              on every mutating endpoint.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Full breakdown:{" "}
+              <a
+                href={`${REPO}/blob/main/docs/security/security-assessment.md#5-application-authnauthorz`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground transition-colors"
+              >
+                §5 of security-assessment.md
+              </a>
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium">Shift-Left CI</h3>
+            <p className="mt-2 text-muted-foreground leading-relaxed">
+              Six dedicated security jobs in the GitHub Actions workflow gate
+              every push: Bandit (Python SAST), pip-audit (dependency CVEs), npm
+              audit, gitleaks (full-history secret scanning), Hadolint
+              (Dockerfile lint), and a custom CORS guardrail that blocks
+              wildcard origins. The deploy job declares{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                needs:
+              </code>{" "}
+              on all six — a single failure blocks production deployment.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Full breakdown:{" "}
+              <a
+                href={`${REPO}/blob/main/docs/security/security-assessment.md#1-shift-left-security-in-ci`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground transition-colors"
+              >
+                §1 of security-assessment.md
+              </a>
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium">Kubernetes Runtime</h3>
+            <p className="mt-2 text-muted-foreground leading-relaxed">
+              Every Deployment manifest sets{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                runAsNonRoot: true
+              </code>
+              ,{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                readOnlyRootFilesystem: true
+              </code>
+              ,{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                allowPrivilegeEscalation: false
+              </code>
+              , and{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                capabilities.drop: [&quot;ALL&quot;]
+              </code>
+              . Readiness probes on every stateful service are enforced by a
+              custom policy-as-code script in CI. Remaining gaps: namespace-level
+              Pod Security Standards and NetworkPolicy are documented as accepted
+              risks.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Full breakdown:{" "}
+              <a
+                href={`${REPO}/blob/main/docs/security/security-assessment.md#9-kubernetes-runtime-posture`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground transition-colors"
+              >
+                §9 of security-assessment.md
+              </a>
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium">Supply Chain</h3>
+            <p className="mt-2 text-muted-foreground leading-relaxed">
+              Multi-stage Docker builds on every service — the builder stage
+              compiles code; the final image is slim/Alpine with an explicit
+              non-root{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                USER
+              </code>
+              . Images are pushed to a private GHCR registry with{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                imagePullSecrets
+              </code>{" "}
+              on every Deployment. Tool versions in CI are pinned for
+              reproducibility. Accepted gap: images are tagged{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                :latest
+              </code>{" "}
+              rather than pinned by digest.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Full breakdown:{" "}
+              <a
+                href={`${REPO}/blob/main/docs/security/security-assessment.md#3-supply-chain`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground transition-colors"
+              >
+                §3 of security-assessment.md
+              </a>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Linux Host Hardening */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Linux Host Hardening</h2>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          The production server is a hand-installed Debian 13 box with an RTX
+          3090. SSH binds only to the Tailscale IP — public SSH is gone entirely.
+          UFW runs a default-deny firewall with narrow allow rules (during
+          hardening, a pre-existing rule that silently exposed Ollama to the home
+          LAN was discovered and removed). Privileged operations use a narrow
+          passwordless sudo allowlist for routine ops; privilege-changing actions
+          still require a password.
+        </p>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            auditd
+          </code>{" "}
+          runs with immutable baseline rules covering identity files, sudo/sshd
+          configs, and privilege-escalation invocations. A{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            sysctl
+          </code>{" "}
+          drop-in hardens the kernel (kptr_restrict, ptrace_scope,
+          unprivileged_bpf, network-stack hygiene).{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            fail2ban
+          </code>{" "}
+          watches SSH with a 1-hour ban after 3 attempts. Lynis hardening index:{" "}
+          <span className="font-semibold text-foreground">77</span>.
+        </p>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          The most consequential finding was a silent gap in patch management:{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            unattended-upgrades
+          </code>{" "}
+          was active and configured to allow security-origin packages, but{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            /etc/apt/sources.list
+          </code>{" "}
+          was missing the{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            security.debian.org
+          </code>{" "}
+          repository since the migration. Adding it pulled 15 stale patches
+          including a kernel update (6.12.73 → 6.12.74).
+        </p>
+        <p className="mt-4 text-sm text-muted-foreground">
+          Full breakdown:{" "}
+          <a
+            href={`${REPO}/blob/main/docs/security/linux-server-hardening.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            linux-server-hardening.md
+          </a>
+        </p>
+      </section>
+
+      {/* Recommended next steps */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Recommended Next Steps</h2>
+        <ul className="mt-4 list-disc pl-6 text-muted-foreground space-y-2">
+          <li>
+            <span className="text-foreground font-medium">
+              Pod Security Standards
+            </span>{" "}
+            — add PSS{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              restricted
+            </code>{" "}
+            labels to all namespaces (the per-Deployment security contexts
+            already satisfy it)
+          </li>
+          <li>
+            <span className="text-foreground font-medium">NetworkPolicy</span>{" "}
+            — default-deny ingress in each namespace with explicit allow rules
+            for gateway→downstream and ingress→gateway
+          </li>
+          <li>
+            <span className="text-foreground font-medium">
+              Remote audit log forwarding
+            </span>{" "}
+            — send host auditd/journald to a remote sink so the audit trail
+            survives a host compromise
+          </li>
+          <li>
+            <span className="text-foreground font-medium">
+              Image digest pinning
+            </span>{" "}
+            — replace{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              :latest
+            </code>{" "}
+            tags with{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              @sha256:…
+            </code>{" "}
+            digests to eliminate mutable-tag supply chain risk
+          </li>
+        </ul>
+      </section>
+
+      {/* Evidence footer */}
+      <section className="mt-12 mb-8">
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Every assertion above is verifiable in the repo. Start at{" "}
+          <a
+            href={`${REPO}/blob/main/docs/security/security-assessment.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            security-assessment.md
+          </a>{" "}
+          or{" "}
+          <a
+            href={`${REPO}/blob/main/docs/security/linux-server-hardening.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-foreground transition-colors"
+          >
+            linux-server-hardening.md
+          </a>
+          , or browse the cited source files directly on GitHub.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -38,6 +38,9 @@ export function SiteHeader() {
             <Link href="/cicd" className={navLinkClass("/cicd")}>
               CI/CD
             </Link>
+            <Link href="/security" className={navLinkClass("/security")}>
+              Security
+            </Link>
           </nav>
         </div>
         <div className="flex items-center gap-5">


### PR DESCRIPTION
## Summary

- New `/security` page with defense-in-depth Mermaid diagram, 11-row status summary table (Badge components for Strong/Adequate/Foundation), curated highlight sections (AuthN/AuthZ, Shift-left CI, K8s runtime, Supply chain, Linux host hardening), and recommended next steps
- 6th card on the landing page in the existing portfolio grid
- "Security" nav item added to SiteHeader between CI/CD and Grafana
- README "For hiring managers" list updated to include `docs/security/`
- Design spec at `docs/superpowers/specs/2026-04-16-frontend-security-page-design.md`

Surfaces the 2026-04-15 application-layer security audit and the 2026-04-16 Debian 13 host hardening work on the live site. Content is a curated summary with deep links to the source-of-truth `.md` files in `docs/security/` — single source of truth stays in the repo.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint .` passes (0 errors)
- [ ] `npm run build` succeeds with `/security` in the route table
- [ ] Visual review: landing page shows 6th card, SiteHeader shows Security nav item, `/security` renders diagram + table + prose
- [ ] Mobile responsive check at ~375px width
- [ ] Both GitHub deep-links to `.md` files resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)