### PR TITLE
fix(deps): bump pypdf 6.10.1 → 6.10.2 (3 CVEs)

### DIFF
--- a/services/ingestion/requirements.txt
+++ b/services/ingestion/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.135.3
 uvicorn[standard]==0.30.0
 python-multipart==0.0.26
-pypdf==6.10.1
+pypdf==6.10.2
 langchain-text-splitters==0.2.4
 langchain-community==0.2.19
 qdrant-client==1.9.0


### PR DESCRIPTION
## Summary
- Bumps `pypdf` 6.10.1 → 6.10.2 in `services/ingestion/requirements.txt`
- Fixes GHSA-4pxv-j86v-mhcw, GHSA-7gw9-cf7v-778f, GHSA-x284-j5p8-9c5p
- These CVEs appeared in the PyPI vulnerability database today and block `pip-audit (ingestion)` on every CI run

## Test plan
- [ ] pip-audit (ingestion) passes without new ignores
- [ ] Backend Tests (ingestion) pass
- [ ] QA Smoke Tests pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)