### PR TITLE
chore(ci): add GHSA-fv5p-p927-qmxr to pip-audit ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,7 @@ jobs:
           --ignore-vuln CVE-2025-71176
           --ignore-vuln GHSA-rr7j-v2q5-chgv
           --ignore-vuln CVE-2026-34070
+          --ignore-vuln GHSA-fv5p-p927-qmxr
 
   security-npm-audit:
     name: Security - npm audit


### PR DESCRIPTION
## Summary
- Adds `--ignore-vuln GHSA-fv5p-p927-qmxr` to pip-audit args in CI
- `langchain-text-splitters 0.2.4` — fix at 1.1.2, requires langchain 0.2→0.3 migration
- Out of scope per issue #62; same family as the other 8 langchain ignores

## Test plan
- [ ] All three pip-audit jobs (chat, ingestion, debug) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)