### PR TITLE
feat: structured logging + distributed tracing for Python services

### DIFF
--- a/docs/adr/structured-logging-tracing.md
+++ b/docs/adr/structured-logging-tracing.md
@@ -1,0 +1,148 @@
+# Structured Logging and Distributed Tracing
+
+- **Date:** 2026-04-16
+- **Status:** Accepted
+
+## Context
+
+The Python AI services (ingestion, chat, debug) emit log output that feeds into observability tooling. Without structure, those logs are format strings — you can read them in a terminal but can't filter them by field, correlate them across services, or join them with distributed traces. When a `/search` request is slow, finding the cause requires correlating logs from the Go ai-service, the Python chat service, and Qdrant. Without a shared trace identifier, that correlation is guess-work.
+
+Two problems to solve:
+
+1. **Log structure** — logs must be machine-parseable so they can be filtered and searched in aggregators (Loki, ELK, CloudWatch) without regex parsing.
+2. **Request correlation** — a single logical request that crosses three services must produce logs and traces that can be joined on a shared identifier.
+
+## 1. structlog Over python-json-logger
+
+`python-json-logger` is a formatter — it serializes the log message and any extra kwargs as JSON. Each call site must pass every field it wants to appear. There's no built-in concept of per-request context.
+
+`structlog` solves this differently:
+
+- **Context variables** — call `structlog.contextvars.bind_contextvars(request_id=..., path=...)` once at the start of a request and every log line emitted during that request automatically carries those fields. No manual passing.
+- **Processor pipeline** — each log record passes through a chain of transforms. Individual processors are small, composable, and testable. The final processor renders to JSON or colored console text depending on environment.
+- **OpenTelemetry integration** — a custom processor can pull `trace_id` and `span_id` from the active OTel span and inject them into every log record automatically.
+
+`services/shared/logging.py` uses structlog exclusively. The processor chain is configured in `configure_logging()` and both structlog-native and stdlib `logging.getLogger()` calls flow through it via `ProcessorFormatter`.
+
+## 2. Structured Logging
+
+A structured log line is a JSON object, not a format string:
+
+```json
+{
+  "event": "request_finished",
+  "level": "info",
+  "timestamp": "2026-04-16T12:34:56.789Z",
+  "service": "chat",
+  "request_id": "a1b2c3d4-...",
+  "method": "POST",
+  "path": "/search",
+  "status_code": 200,
+  "duration_ms": 142.3,
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7"
+}
+```
+
+Every field is a first-class key. A log aggregator can filter `duration_ms > 1000` or group by `service` without parsing the message string. One structured log line at `request_finished` carries what would otherwise require multiple unstructured lines, a separate metrics call, and regex post-processing.
+
+### Processor Pipeline
+
+The pipeline in `configure_logging()` (`services/shared/logging.py`, lines 79–91) runs every log record through these processors in order:
+
+1. `structlog.contextvars.merge_contextvars` — merges per-request context (request_id, method, path) bound by `RequestLoggingMiddleware`
+2. `structlog.processors.add_log_level` — adds `"level": "info"` etc.
+3. `structlog.processors.TimeStamper(fmt="iso")` — adds ISO-8601 timestamp
+4. `_make_add_service_name(service_name)` — stamps the service name (e.g. `"chat"`, `"ingestion"`)
+5. `_add_otel_context` — pulls `trace_id` and `span_id` from the active OTel span
+6. `structlog.processors.StackInfoRenderer` — serializes stack info if present
+7. `structlog.processors.format_exc_info` — serializes exceptions
+8. Final renderer — `JSONRenderer` in production, `ConsoleRenderer` in development
+
+The `foreign_pre_chain` in `ProcessorFormatter` (lines 96–115) applies the same chain to records from third-party libraries that use `logging.getLogger()` directly, so uvicorn, httpx, and LangChain logs also appear as structured JSON.
+
+### RequestLoggingMiddleware
+
+`RequestLoggingMiddleware` (`services/shared/logging.py`, lines 132–170) runs on every incoming HTTP request:
+
+- Generates a UUID4 `request_id` and binds it along with `method` and `path` to structlog's contextvars
+- Logs `request_finished` with `status_code` and `duration_ms` on success
+- Logs `request_failed` with `exc_info=True` on unhandled exception, then re-raises
+- Sets `x-request-id` response header so clients can correlate their own logs
+
+Because context is stored in async-safe contextvars (not a thread-local), this works correctly under uvicorn's async request handling.
+
+## 3. Distributed Tracing
+
+### What Trace Context Is
+
+A **trace** is a tree of **spans**. Each span represents one unit of work (an HTTP handler, a database query, an LLM call). Spans share a `trace_id` — a 128-bit identifier assigned when the first service receives a request. Child spans add their own `span_id`. Together they form a causal tree you can visualize in Jaeger or Grafana Tempo.
+
+### W3C traceparent
+
+The W3C Trace Context standard defines the `traceparent` HTTP header:
+
+```
+traceparent: 00-{trace_id}-{span_id}-{flags}
+```
+
+- `00` — version
+- `trace_id` — 32 hex chars (128 bits), same across the entire request chain
+- `span_id` — 16 hex chars (64 bits), unique per span
+- `flags` — `01` = sampled, `00` = not sampled
+
+When service A calls service B, it injects its current span context into the outbound request headers. Service B extracts the header and creates a child span under service A's span. The trace_id is preserved.
+
+### Span Tree Across Services
+
+```
+Go ai-service (parent span, span_id=aaa)
+  ├─ traceparent: 00-{trace_id}-aaa-01
+  └─ Python chat service (child span, span_id=bbb)
+       ├─ traceparent: 00-{trace_id}-bbb-01
+       └─ Qdrant HTTP call (child span, span_id=ccc)
+```
+
+**Go side** (`go/pkg/tracing/tracing.go`): `tracing.Init()` registers a global `TracerProvider` and sets `propagation.TraceContext{}` as the global text map propagator. `otelgin` middleware (wired in `go/ai-service/cmd/server/main.go`, line 180) auto-instruments every Gin handler, creating a span and extracting any incoming `traceparent`. Outbound HTTP calls from the ai-service use `otelhttp.NewTransport` which injects `traceparent` automatically.
+
+**Python side** (`services/shared/tracing.py`): `configure_tracing()` sets `TraceContextTextMapPropagator` as the global propagator (line 38). `FastAPIInstrumentor` creates a child span for every incoming request, reading the `traceparent` header to continue the trace. `HTTPXClientInstrumentor` propagates trace context on outbound httpx calls (e.g. to Ollama), linking the full chain.
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is not set (local dev, CI), `configure_tracing()` returns `None` — no exporter, zero overhead — but propagation still works so `trace_id` and `span_id` still appear in log lines.
+
+### Logs Carry Trace Context
+
+The `_add_otel_context` processor (`services/shared/logging.py`, lines 20–42) reads the active span from the OTel context at log time and injects `trace_id` and `span_id` into the event dict. Because `FastAPIInstrumentor` creates a span for every request, every log line emitted during that request carries the same `trace_id` as the OTel span — the same ID that appears in Jaeger.
+
+## 4. Correlation: request_id + trace_id
+
+Two identifiers appear on every log line:
+
+| Field | Scope | Generated By |
+|-------|-------|--------------|
+| `request_id` | Per-service | `RequestLoggingMiddleware` (UUID4 on each incoming request) |
+| `trace_id` | Cross-service | OTel instrumentation (propagated via `traceparent` header) |
+
+`request_id` is useful for isolating all logs from a single service handling a single request. `trace_id` is useful for following a logical request across service boundaries.
+
+**Example — debugging a slow `/search` response:**
+
+1. Find the slow request in the Go ai-service logs: `trace_id=4bf92f3...`, `duration_ms=3240`
+2. Search Python chat service logs for the same `trace_id` — find the Qdrant search took 2800ms
+3. In Jaeger, look up the trace by `trace_id` to see the full span tree and where time was spent
+
+Without `trace_id` on every log line, step 2 requires guessing which chat service request corresponds to which ai-service request based on timestamps.
+
+## 5. Production Considerations
+
+**Sampling.** Exporting every span in high-traffic production generates significant volume. The OTLP exporter in `go/pkg/tracing/tracing.go` uses `sdktrace.WithBatcher` — a `BatchSpanProcessor` with default sampling (100%). In production, add a `ParentBased(TraceIDRatioBased(0.1))` sampler to export ~10% of traces while preserving full traces for errors and slow requests.
+
+**Log volume.** Structured logs are larger per line (JSON overhead vs a bare string) but fewer lines are needed. One `request_finished` line with `status_code`, `duration_ms`, `trace_id`, `request_id`, `method`, and `path` replaces what would otherwise be multiple unstructured lines plus a separate metrics call. The net effect is typically lower total bytes with much higher utility.
+
+**PII.** Never log request bodies, auth tokens, or user-identifying fields. The structlog processor pipeline is the right place to enforce this — a `_redact_sensitive_fields` processor inserted before `JSONRenderer` can strip or mask any key matching a blocklist (e.g. `authorization`, `password`, `token`, `email`). This runs at log time, before anything is written to stdout or shipped to an aggregator.
+
+**Log aggregation.** Structured JSON logs on stdout are ready for:
+- **Loki** — label by `service` and `level`, query with LogQL (`{service="chat"} | json | duration_ms > 1000`)
+- **ELK** — Filebeat ships stdout, Elasticsearch indexes each JSON key, Kibana filters by field
+- **CloudWatch Logs Insights** — native JSON field querying without parsing config
+
+No regex parsing configuration is needed for any of these because every field is already a JSON key.

--- a/services/chat/app/main.py
+++ b/services/chat/app/main.py
@@ -1,7 +1,7 @@
 import json
-import logging
 
 import httpx
+import structlog
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -9,6 +9,8 @@ from llm.factory import get_embedding_provider, get_llm_provider
 from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient
 from shared.auth import create_auth_dependency
+from shared.logging import RequestLoggingMiddleware, configure_logging
+from shared.tracing import configure_tracing, instrument_app
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -19,7 +21,10 @@ from app.chain import rag_query
 from app.config import settings
 from app.metrics import instrumentator
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
+
+configure_logging(service_name="chat")
+configure_tracing(service_name="chat")
 
 app = FastAPI(title="Chat API")
 
@@ -29,8 +34,10 @@ app.add_middleware(
     allow_methods=["GET", "POST"],
     allow_headers=["Authorization", "Content-Type"],
 )
+app.add_middleware(RequestLoggingMiddleware)
 
 instrumentator.instrument(app).expose(app, include_in_schema=False)
+instrument_app(app)
 
 limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
@@ -114,10 +121,10 @@ async def chat(
             ):
                 yield {"data": json.dumps(event)}
         except (httpx.ConnectError, httpx.TimeoutException) as e:
-            logger.error("Backend service error: %s", e)
+            logger.error("backend_service_error", error=str(e))
             yield {"data": json.dumps({"error": "Service unavailable"})}
         except Exception as e:
-            logger.error("Internal error: %s", e, exc_info=True)
+            logger.error("internal_error", error=str(e), exc_info=True)
             yield {"data": json.dumps({"error": "Internal error"})}
 
     return EventSourceResponse(event_generator())

--- a/services/chat/requirements.txt
+++ b/services/chat/requirements.txt
@@ -12,3 +12,11 @@ slowapi==0.1.9
 openai>=1.0
 anthropic>=0.30
 pyjwt==2.12.0
+
+# Structured logging + tracing
+structlog==25.5.0
+opentelemetry-api==1.41.0
+opentelemetry-sdk==1.41.0
+opentelemetry-instrumentation-fastapi==0.62b0
+opentelemetry-instrumentation-httpx==0.62b0
+opentelemetry-exporter-otlp-proto-grpc==1.41.0

--- a/services/debug/app/main.py
+++ b/services/debug/app/main.py
@@ -1,7 +1,7 @@
 import json
-import logging
 import os
 
+import structlog
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -9,6 +9,8 @@ from llm.factory import get_embedding_provider, get_llm_provider
 from pydantic import BaseModel, Field
 from qdrant_client import QdrantClient
 from shared.auth import create_auth_dependency
+from shared.logging import RequestLoggingMiddleware, configure_logging
+from shared.tracing import configure_tracing, instrument_app
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -20,7 +22,10 @@ from app.config import settings
 from app.indexer import index_project
 from app.metrics import instrumentator
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger()
+
+configure_logging(service_name="debug")
+configure_tracing(service_name="debug")
 
 app = FastAPI(title="Debug Assistant API")
 
@@ -30,8 +35,10 @@ app.add_middleware(
     allow_methods=["GET", "POST"],
     allow_headers=["Authorization", "Content-Type"],
 )
+app.add_middleware(RequestLoggingMiddleware)
 
 instrumentator.instrument(app).expose(app, include_in_schema=False)
+instrument_app(app)
 
 limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
@@ -135,7 +142,7 @@ async def index(
             qdrant_port=settings.qdrant_port,
         )
     except Exception as e:
-        logger.error("Indexing failed: %s", e, exc_info=True)
+        logger.error("indexing_failed", error=str(e), exc_info=True)
         raise HTTPException(status_code=500, detail="Indexing failed")
 
     _project_paths[result["collection"]] = body.path
@@ -170,7 +177,7 @@ async def debug(
             ):
                 yield {"event": event["event"], "data": json.dumps(event["data"])}
         except Exception as e:
-            logger.error("Debug session error: %s", e, exc_info=True)
+            logger.error("debug_session_error", error=str(e), exc_info=True)
             yield {
                 "event": "diagnosis",
                 "data": json.dumps({"content": "Internal error during debug session."}),

--- a/services/debug/requirements.txt
+++ b/services/debug/requirements.txt
@@ -13,3 +13,11 @@ slowapi==0.1.9
 openai>=1.0
 anthropic>=0.30
 pyjwt==2.12.0
+
+# Structured logging + tracing
+structlog==25.5.0
+opentelemetry-api==1.41.0
+opentelemetry-sdk==1.41.0
+opentelemetry-instrumentation-fastapi==0.62b0
+opentelemetry-instrumentation-httpx==0.62b0
+opentelemetry-exporter-otlp-proto-grpc==1.41.0

--- a/services/ingestion/app/main.py
+++ b/services/ingestion/app/main.py
@@ -1,15 +1,17 @@
-import logging
 import re
 import uuid
 from io import BytesIO
 
 import httpx
+import structlog
 from fastapi import Depends, FastAPI, File, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from llm.factory import get_embedding_provider
 from qdrant_client import QdrantClient
 from shared.auth import create_auth_dependency
+from shared.logging import RequestLoggingMiddleware, configure_logging
+from shared.tracing import configure_tracing, instrument_app
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -22,7 +24,10 @@ from app.metrics import CHUNKS_CREATED, instrumentator
 from app.pdf_parser import extract_pages
 from app.store import QdrantStore
 
-logger = logging.getLogger(__name__)
+configure_logging(service_name="ingestion")
+configure_tracing(service_name="ingestion")
+
+logger = structlog.get_logger()
 
 app = FastAPI(title="Ingestion API")
 
@@ -34,8 +39,10 @@ app.add_middleware(
     allow_methods=["GET", "POST", "DELETE"],
     allow_headers=["Authorization", "Content-Type"],
 )
+app.add_middleware(RequestLoggingMiddleware)
 
 instrumentator.instrument(app).expose(app, include_in_schema=False)
+instrument_app(app)
 
 limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
@@ -149,7 +156,7 @@ async def ingest(
             model=settings.embedding_model,
         )
     except (httpx.ConnectError, httpx.TimeoutException) as e:
-        logger.error("Embedding service error: %s", e)
+        logger.error("embedding_service_error", error=str(e))
         raise HTTPException(status_code=503, detail="Embedding service unavailable")
 
     document_id = str(uuid.uuid4())
@@ -169,7 +176,7 @@ async def ingest(
             filename=file.filename,
         )
     except Exception as e:
-        logger.error("Vector store error: %s", e, exc_info=True)
+        logger.error("vector_store_error", error=str(e), exc_info=True)
         raise HTTPException(status_code=503, detail="Vector store unavailable")
 
     CHUNKS_CREATED.labels(service="ingestion").inc(len(chunks))

--- a/services/ingestion/requirements.txt
+++ b/services/ingestion/requirements.txt
@@ -14,3 +14,11 @@ slowapi==0.1.9
 openai>=1.0
 anthropic>=0.30
 pyjwt==2.12.0
+
+# Structured logging + tracing
+structlog==25.5.0
+opentelemetry-api==1.41.0
+opentelemetry-sdk==1.41.0
+opentelemetry-instrumentation-fastapi==0.62b0
+opentelemetry-instrumentation-httpx==0.62b0
+opentelemetry-exporter-otlp-proto-grpc==1.41.0

--- a/services/shared/logging.py
+++ b/services/shared/logging.py
@@ -7,9 +7,13 @@ fields: timestamp, level, service name, and OpenTelemetry trace/span IDs.
 
 import logging
 import sys
+import time
+import uuid
 from typing import Any
 
 import structlog
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
 from structlog.types import EventDict, WrappedLogger
 
 
@@ -123,3 +127,44 @@ def configure_logging(
 
     # Step 4: quiet noisy third-party loggers.
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware that adds per-request structured logging context.
+
+    For every incoming request:
+    - Generates a UUID4 request_id and binds it (plus method + path) to
+      structlog's contextvars so every log line emitted during the request
+      automatically carries those fields — no manual passing needed.
+    - Logs ``request_finished`` with status_code and duration_ms on success.
+    - Logs ``request_failed`` with exc_info on unhandled exception, then
+      re-raises so FastAPI's exception handlers still fire.
+    - Sets the ``x-request-id`` response header for client correlation.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = str(uuid.uuid4())
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id,
+            method=request.method,
+            path=request.url.path,
+        )
+
+        logger = structlog.get_logger()
+        start = time.perf_counter()
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            logger.error("request_failed", exc_info=True)
+            raise
+        else:
+            duration_ms = round((time.perf_counter() - start) * 1000, 1)
+            logger.info(
+                "request_finished",
+                status_code=response.status_code,
+                duration_ms=duration_ms,
+            )
+            response.headers["x-request-id"] = request_id
+            return response

--- a/services/shared/logging.py
+++ b/services/shared/logging.py
@@ -1,0 +1,125 @@
+"""Structured logging configuration using structlog.
+
+All Python services import and call configure_logging() at startup to get
+consistent JSON (production) or text (development) log output with automatic
+fields: timestamp, level, service name, and OpenTelemetry trace/span IDs.
+"""
+
+import logging
+import sys
+from typing import Any
+
+import structlog
+from structlog.types import EventDict, WrappedLogger
+
+
+def _add_otel_context(
+    logger: WrappedLogger, method_name: str, event_dict: EventDict
+) -> EventDict:
+    """Add OpenTelemetry trace_id and span_id to every log record.
+
+    Gracefully falls back to empty strings if opentelemetry is not installed
+    or no active span exists.
+    """
+    try:
+        from opentelemetry import trace
+
+        span = trace.get_current_span()
+        ctx = span.get_span_context()
+        if ctx and ctx.is_valid:
+            event_dict["trace_id"] = format(ctx.trace_id, "032x")
+            event_dict["span_id"] = format(ctx.span_id, "016x")
+        else:
+            event_dict["trace_id"] = ""
+            event_dict["span_id"] = ""
+    except ImportError:
+        event_dict["trace_id"] = ""
+        event_dict["span_id"] = ""
+    return event_dict
+
+
+def _make_add_service_name(service_name: str):
+    """Return a structlog processor that stamps every log with the service name."""
+
+    def _add_service_name(
+        logger: WrappedLogger, method_name: str, event_dict: EventDict
+    ) -> EventDict:
+        event_dict["service"] = service_name
+        return event_dict
+
+    return _add_service_name
+
+
+def configure_logging(
+    service_name: str,
+    log_format: str = "json",
+    log_level: str = "INFO",
+) -> None:
+    """Configure structlog and Python's root logger for structured logging.
+
+    Args:
+        service_name: Stamped onto every log record (e.g. "chat", "ingestion").
+        log_format:   "json" for production JSON output; "text" for dev console.
+        log_level:    Standard Python log level name (e.g. "INFO", "DEBUG").
+    """
+    renderer: Any
+    if log_format == "json":
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+
+    # Step 1: configure structlog's internal pipeline.
+    # The last processor must be wrap_for_formatter so that structlog hands
+    # off the event dict to ProcessorFormatter (the stdlib bridge).
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            _make_add_service_name(service_name),
+            _add_otel_context,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    # Shared pre-chain processors applied to ALL log records (both structlog
+    # and foreign stdlib records).  These run before the final renderer.
+    shared_processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        _make_add_service_name(service_name),
+        _add_otel_context,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+
+    # Step 2: build the stdlib formatter that handles final rendering.
+    # foreign_pre_chain applies shared_processors to non-structlog log records
+    # (i.e. any logging.getLogger(__name__).info(...) call).
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+        foreign_pre_chain=shared_processors,
+    )
+
+    # Step 3: attach a StreamHandler with the structlog formatter to the root
+    # logger so all logging.getLogger(__name__) calls flow through it.
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    # Remove any existing handlers to avoid duplicate output on re-configure.
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(log_level.upper())
+
+    # Step 4: quiet noisy third-party loggers.
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/services/shared/tests/test_logging.py
+++ b/services/shared/tests/test_logging.py
@@ -2,11 +2,14 @@
 
 import json
 import logging
+import uuid
 from io import StringIO
 
 import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
 
-from shared.logging import configure_logging
+from shared.logging import RequestLoggingMiddleware, configure_logging
 
 
 def test_configure_logging_json_format():
@@ -87,3 +90,19 @@ def test_configure_logging_text_format():
         root_logger.removeHandler(handler)
         for h in original_handlers:
             root_logger.addHandler(h)
+
+
+def test_request_logging_middleware_adds_request_id():
+    configure_logging(service_name="test", log_format="json")
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get("/test")
+    assert response.status_code == 200
+    assert "x-request-id" in response.headers
+    uuid.UUID(response.headers["x-request-id"])  # validates it's a valid UUID

--- a/services/shared/tests/test_logging.py
+++ b/services/shared/tests/test_logging.py
@@ -1,0 +1,89 @@
+"""Tests for shared.logging structured logging configuration."""
+
+import json
+import logging
+from io import StringIO
+
+import pytest
+
+from shared.logging import configure_logging
+
+
+def test_configure_logging_json_format():
+    """JSON mode produces valid JSON with expected fields."""
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+
+    configure_logging(service_name="test-service", log_format="json", log_level="DEBUG")
+
+    # Replace the root logger's handlers with our capturing handler
+    root_logger = logging.getLogger()
+    # Store original handlers and replace
+    original_handlers = root_logger.handlers[:]
+    for h in original_handlers:
+        root_logger.removeHandler(h)
+
+    # Re-run configure to get a fresh formatter on our handler
+    # Instead, apply the formatter from configure_logging to our test handler
+    configure_logging(service_name="test-service", log_format="json", log_level="DEBUG")
+    if root_logger.handlers:
+        formatter = root_logger.handlers[0].formatter
+        handler.setFormatter(formatter)
+
+    root_logger.addHandler(handler)
+
+    try:
+        logger = logging.getLogger("test.json")
+        logger.info("hello json world")
+
+        output = stream.getvalue().strip()
+        assert output, "Expected log output, got nothing"
+
+        parsed = json.loads(output)
+        assert parsed["event"] == "hello json world"
+        assert parsed["level"] == "info"
+        assert "timestamp" in parsed
+        assert parsed["service"] == "test-service"
+    finally:
+        root_logger.removeHandler(handler)
+        for h in original_handlers:
+            root_logger.addHandler(h)
+
+
+def test_configure_logging_text_format():
+    """Text mode produces human-readable output (not JSON)."""
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+
+    configure_logging(service_name="test-service", log_format="text", log_level="DEBUG")
+
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+    for h in original_handlers:
+        root_logger.removeHandler(h)
+
+    # Re-configure and grab the formatter
+    configure_logging(service_name="test-service", log_format="text", log_level="DEBUG")
+    if root_logger.handlers:
+        formatter = root_logger.handlers[0].formatter
+        handler.setFormatter(formatter)
+
+    root_logger.addHandler(handler)
+
+    try:
+        logger = logging.getLogger("test.text")
+        logger.info("hello text world")
+
+        output = stream.getvalue().strip()
+        assert output, "Expected log output, got nothing"
+
+        # Text mode should NOT be valid JSON
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(output)
+
+        # But it should contain the event name
+        assert "hello text world" in output
+    finally:
+        root_logger.removeHandler(handler)
+        for h in original_handlers:
+            root_logger.addHandler(h)

--- a/services/shared/tests/test_tracing.py
+++ b/services/shared/tests/test_tracing.py
@@ -1,0 +1,51 @@
+"""Tests for shared.tracing OpenTelemetry configuration."""
+
+import os
+from unittest.mock import patch
+
+from opentelemetry.sdk.trace import TracerProvider
+
+
+def test_configure_tracing_returns_none_without_endpoint():
+    """Without OTEL_EXPORTER_OTLP_ENDPOINT, returns None."""
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_EXPORTER_OTLP_ENDPOINT"}
+    with patch.dict(os.environ, env, clear=True):
+        from shared.tracing import configure_tracing
+
+        result = configure_tracing(service_name="test")
+        assert result is None
+
+
+def test_configure_tracing_sets_service_name_with_endpoint():
+    """With endpoint set, returns a TracerProvider with correct service name."""
+    with patch.dict(
+        os.environ, {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}
+    ):
+        from shared.tracing import configure_tracing
+
+        provider = configure_tracing(service_name="my-service")
+        assert isinstance(provider, TracerProvider)
+        attrs = dict(provider.resource.attributes)
+        assert attrs.get("service.name") == "my-service"
+
+
+def test_configure_tracing_no_endpoint_no_side_effects():
+    """Without endpoint, calling configure_tracing is safe and has no side effects."""
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_EXPORTER_OTLP_ENDPOINT"}
+    with patch.dict(os.environ, env, clear=True):
+        from shared.tracing import configure_tracing
+
+        # Should not raise anything
+        result = configure_tracing(service_name="no-op-service")
+        assert result is None
+
+
+def test_instrument_app_does_not_raise():
+    """instrument_app can be called without raising on a bare FastAPI app."""
+    from fastapi import FastAPI
+
+    from shared.tracing import instrument_app
+
+    app = FastAPI()
+    # Should not raise
+    instrument_app(app)

--- a/services/shared/tracing.py
+++ b/services/shared/tracing.py
@@ -1,0 +1,69 @@
+"""OpenTelemetry tracing configuration for all Python services."""
+
+from __future__ import annotations
+
+import os
+
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+def configure_tracing(service_name: str) -> TracerProvider | None:
+    """Configure OpenTelemetry tracing for a service.
+
+    Always sets up W3C trace context propagation so incoming ``traceparent``
+    headers from the Go ai-service (sent via otelhttp.NewTransport) are
+    extracted and made available to structlog's ``_add_otel_context`` processor.
+
+    When ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set, creates a ``TracerProvider``
+    with a gRPC OTLP exporter and registers it globally.  When the env var is
+    absent (local dev / CI), returns ``None`` — no exporter, zero overhead, but
+    propagation still works so trace context flows through log lines.
+
+    Args:
+        service_name: Stamped as ``service.name`` in the OTel resource
+                      (e.g. ``"chat"``, ``"ingestion"``).
+
+    Returns:
+        The configured ``TracerProvider`` when an endpoint is configured,
+        ``None`` otherwise.
+    """
+    set_global_textmap(CompositePropagator([TraceContextTextMapPropagator()]))
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+    if not endpoint:
+        return None
+
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter,
+    )
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    return provider
+
+
+def instrument_app(app) -> None:
+    """Instrument a FastAPI app with OpenTelemetry auto-instrumentation.
+
+    - ``FastAPIInstrumentor``: creates spans for every incoming HTTP request,
+      reading the incoming ``traceparent`` header to continue distributed traces.
+    - ``HTTPXClientInstrumentor``: propagates trace context on outbound httpx
+      requests (e.g. calls to Ollama), so the full request chain is linked.
+
+    Args:
+        app: The FastAPI application instance to instrument.
+    """
+    FastAPIInstrumentor.instrument_app(app)
+    HTTPXClientInstrumentor().instrument()


### PR DESCRIPTION
## Summary

- **Shared logging module** (`services/shared/logging.py`): structlog configuration with JSON/text output modes, automatic fields (timestamp, service, level, trace_id, request_id), and request logging middleware
- **Shared tracing module** (`services/shared/tracing.py`): OpenTelemetry initialization with W3C trace context propagation, FastAPI + httpx auto-instrumentation
- **All 3 Python services** (chat, ingestion, debug): wired with structured logging, request middleware, and distributed tracing
- **Dependencies**: structlog, opentelemetry-api/sdk, OTel instrumentors added to all services
- **ADR**: Learning notes on structured logging, distributed tracing, and correlation

Trace context from the Go ai-service now propagates into Python services via `traceparent` headers. Every log line includes trace_id, request_id, service name, and structured fields.

## Test plan

- [x] Unit tests for shared logging module (3 tests)
- [x] Unit tests for shared tracing module (4 tests)
- [x] ruff lint + format passes
- [ ] CI pipeline passes (pytest across all services)
- [ ] pip-audit passes with new dependencies
- [ ] Local smoke test: start chat service, verify JSON log output with request_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)