### PR TITLE
feat: add eval service UI with cross-service JWT auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       context: ./services
       dockerfile: eval/Dockerfile
     env_file: .env
+    environment:
+      - JWT_SECRET=${JWT_SECRET}
     volumes:
       - eval_data:/app/data
     depends_on:

--- a/docs/superpowers/plans/2026-04-17-eval-service-ui.md
+++ b/docs/superpowers/plans/2026-04-17-eval-service-ui.md
@@ -1,0 +1,1421 @@
+# Eval Service UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an interactive frontend at `/ai/eval` for managing golden datasets, running RAGAS evaluations, and viewing scorecards — with cross-service JWT auth (Go auth → Python eval).
+
+**Architecture:** Tabbed client-side UI (Datasets / Evaluate / Results) wrapped in HealthGate + GoAuthProvider. The eval service already has JWT auth middleware via `shared.auth`; we modify it to also read from the `access_token` httpOnly cookie (set by the Go auth service). Frontend uses `credentials: "include"` with retry-on-401 pattern from `go-api.ts`.
+
+**Tech Stack:** Next.js, TypeScript, FastAPI, PyJWT (already installed), shadcn/ui, SVG radial gauges
+
+---
+
+## File Structure
+
+### Backend (Python)
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `services/shared/auth.py` | Modify | Add cookie-based JWT extraction alongside Bearer header |
+| `services/shared/tests/test_auth.py` | Create | Tests for shared auth (header + cookie + empty secret) |
+| `services/eval/app/main.py` | Modify | Add `allow_credentials=True` to CORS config |
+| `services/eval/tests/test_main.py` | Modify | Add test for CORS credentials header |
+
+### Frontend
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `frontend/src/lib/eval-api.ts` | Create | API client — all eval service endpoints with auth |
+| `frontend/src/app/ai/eval/page.tsx` | Create | Page — HealthGate + GoAuthProvider + tab state + auth gate |
+| `frontend/src/components/eval/RadialGauge.tsx` | Create | Reusable SVG radial gauge component |
+| `frontend/src/components/eval/DatasetTab.tsx` | Create | Dataset creation form + list |
+| `frontend/src/components/eval/EvaluateTab.tsx` | Create | Dataset selector + run button + polling |
+| `frontend/src/components/eval/ResultsTab.tsx` | Create | Eval selector + scorecard + per-query breakdown |
+
+### Infrastructure
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `k8s/ai-services/configmaps/eval-config.yml` | Modify | Add `ALLOWED_ORIGINS` for QA domain |
+| `docker-compose.yml` | Modify | Add `JWT_SECRET` env var to eval service |
+
+---
+
+## Task 1: Shared Auth — Cookie Support
+
+**Files:**
+- Modify: `services/shared/auth.py`
+- Create: `services/shared/tests/test_auth.py`
+
+- [ ] **Step 1: Write tests for shared auth**
+
+Create `services/shared/tests/__init__.py` (empty) and `services/shared/tests/test_auth.py`:
+
+```python
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from shared.auth import create_auth_dependency
+
+SECRET = "test-secret-key"
+
+
+def _make_app(secret: str):
+    """Create a minimal FastAPI app with auth dependency."""
+    app = FastAPI()
+    require_auth = create_auth_dependency(secret)
+
+    @app.get("/protected")
+    async def protected(user_id: str = Depends(require_auth)):
+        return {"user_id": user_id}
+
+    return app
+
+
+def _make_token(sub: str = "user-123", secret: str = SECRET, exp_offset: int = 3600):
+    import time
+
+    return jwt.encode(
+        {"sub": sub, "exp": int(time.time()) + exp_offset},
+        secret,
+        algorithm="HS256",
+    )
+
+
+# --- Empty secret (auth disabled) ---
+
+
+def test_empty_secret_allows_anonymous():
+    app = _make_app("")
+    client = TestClient(app)
+    res = client.get("/protected")
+    assert res.status_code == 200
+    assert res.json()["user_id"] == "anonymous"
+
+
+# --- Bearer header ---
+
+
+def test_bearer_header_valid():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    token = _make_token()
+    res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert res.json()["user_id"] == "user-123"
+
+
+def test_bearer_header_expired():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    token = _make_token(exp_offset=-10)
+    res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 401
+
+
+def test_bearer_header_wrong_secret():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    token = _make_token(secret="wrong-secret")
+    res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 401
+
+
+# --- Cookie ---
+
+
+def test_cookie_valid():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    token = _make_token()
+    client.cookies.set("access_token", token)
+    res = client.get("/protected")
+    assert res.status_code == 200
+    assert res.json()["user_id"] == "user-123"
+
+
+def test_cookie_expired():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    token = _make_token(exp_offset=-10)
+    client.cookies.set("access_token", token)
+    res = client.get("/protected")
+    assert res.status_code == 401
+
+
+# --- No auth at all ---
+
+
+def test_no_auth_returns_401():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    res = client.get("/protected")
+    assert res.status_code == 401
+
+
+# --- Bearer takes precedence over cookie ---
+
+
+def test_bearer_takes_precedence_over_cookie():
+    app = _make_app(SECRET)
+    client = TestClient(app)
+    bearer_token = _make_token(sub="bearer-user")
+    cookie_token = _make_token(sub="cookie-user")
+    client.cookies.set("access_token", cookie_token)
+    res = client.get(
+        "/protected", headers={"Authorization": f"Bearer {bearer_token}"}
+    )
+    assert res.status_code == 200
+    assert res.json()["user_id"] == "bearer-user"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd services && python -m pytest shared/tests/test_auth.py -v`
+Expected: Cookie tests fail (cookie reading not implemented yet), header tests should pass.
+
+- [ ] **Step 3: Modify shared auth to support cookies**
+
+Edit `services/shared/auth.py`:
+
+```python
+"""JWT authentication dependency for FastAPI services."""
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def create_auth_dependency(secret: str):
+    """Create a FastAPI dependency that validates JWT Bearer tokens or cookies.
+
+    Checks Authorization header first, then access_token cookie.
+    When secret is empty, auth is disabled (all requests pass as anonymous).
+    """
+    if not secret:
+
+        async def no_auth(
+            credentials: HTTPAuthorizationCredentials | None = Depends(
+                _bearer_scheme
+            ),
+        ) -> str:
+            return "anonymous"
+
+        return no_auth
+
+    async def require_auth(
+        request: Request,
+        credentials: HTTPAuthorizationCredentials | None = Depends(
+            _bearer_scheme
+        ),
+    ) -> str:
+        """Validate JWT from Bearer header or access_token cookie."""
+        token: str | None = None
+
+        # Prefer Bearer header
+        if credentials is not None:
+            token = credentials.credentials
+        else:
+            # Fall back to cookie
+            token = request.cookies.get("access_token")
+
+        if token is None:
+            raise HTTPException(status_code=401, detail="Missing authorization")
+
+        try:
+            payload = jwt.decode(
+                token,
+                secret,
+                algorithms=["HS256"],
+                options={"require": ["sub", "exp"]},
+            )
+        except jwt.ExpiredSignatureError:
+            raise HTTPException(status_code=401, detail="Token expired")
+        except jwt.InvalidTokenError:
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+        user_id = payload.get("sub")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return user_id
+
+    return require_auth
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd services && python -m pytest shared/tests/test_auth.py -v`
+Expected: All 8 tests pass.
+
+- [ ] **Step 5: Run existing eval tests to verify no regression**
+
+Run: `cd services && python -m pytest eval/tests/ -v`
+Expected: All existing tests pass (they use empty secret → anonymous path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/shared/auth.py services/shared/tests/
+git commit -m "feat(auth): add cookie-based JWT support to shared auth
+
+Read access_token cookie as fallback when no Bearer header is present.
+Bearer header takes precedence. Existing behavior unchanged."
+```
+
+---
+
+## Task 2: Eval Service CORS + Infrastructure Config
+
+**Files:**
+- Modify: `services/eval/app/main.py:28-34`
+- Modify: `docker-compose.yml` (eval service section)
+- Modify: `k8s/ai-services/configmaps/eval-config.yml`
+
+- [ ] **Step 1: Add `allow_credentials=True` to CORS**
+
+In `services/eval/app/main.py`, update the CORS middleware block:
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins.split(","),
+    allow_credentials=True,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization", "Content-Type"],
+)
+```
+
+- [ ] **Step 2: Add JWT_SECRET to docker-compose.yml**
+
+In `docker-compose.yml`, add the `JWT_SECRET` env var to the eval service. Find the eval service section and add an `environment` block:
+
+```yaml
+  eval:
+    image: ghcr.io/kabradshaw1/portfolio/eval:latest
+    build:
+      context: ./services
+      dockerfile: eval/Dockerfile
+    env_file: .env
+    environment:
+      - JWT_SECRET=${JWT_SECRET}
+    volumes:
+      - eval_data:/app/data
+    depends_on:
+      chat:
+        condition: service_started
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+- [ ] **Step 3: Add QA origin to eval ConfigMap**
+
+In `k8s/ai-services/configmaps/eval-config.yml`, add the QA domain to `ALLOWED_ORIGINS`:
+
+```yaml
+  ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev,https://qa.kylebradshaw.dev
+```
+
+- [ ] **Step 4: Run eval tests to confirm nothing broke**
+
+Run: `cd services && python -m pytest eval/tests/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 5: Run preflight-python**
+
+Run: `make preflight-python`
+Expected: All lint/format/test checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/eval/app/main.py docker-compose.yml k8s/ai-services/configmaps/eval-config.yml
+git commit -m "feat(eval): enable CORS credentials and configure JWT_SECRET
+
+Add allow_credentials=True so browser sends httpOnly cookies.
+Wire JWT_SECRET in docker-compose and add QA origin to ConfigMap."
+```
+
+---
+
+## Task 3: API Client
+
+**Files:**
+- Create: `frontend/src/lib/eval-api.ts`
+
+- [ ] **Step 1: Create the eval API client**
+
+Create `frontend/src/lib/eval-api.ts`:
+
+```typescript
+import { refreshGoAccessToken } from "@/lib/go-auth";
+
+const EVAL_API_URL =
+  process.env.NEXT_PUBLIC_EVAL_API_URL || "http://localhost:8000/eval";
+
+async function evalFetch(
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(options.headers);
+  if (!headers.has("Content-Type") && options.body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const res = await fetch(`${EVAL_API_URL}${path}`, {
+    ...options,
+    headers,
+    credentials: "include",
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    const success = await refreshGoAccessToken();
+    if (success) {
+      return fetch(`${EVAL_API_URL}${path}`, {
+        ...options,
+        headers,
+        credentials: "include",
+      });
+    }
+  }
+
+  return res;
+}
+
+// --- Types ---
+
+export interface GoldenItem {
+  query: string;
+  expected_answer: string;
+  expected_sources: string[];
+}
+
+export interface DatasetSummary {
+  id: string;
+  name: string;
+  item_count: number;
+  created_at: string;
+}
+
+export interface QueryScore {
+  faithfulness: number | null;
+  answer_relevancy: number | null;
+  context_precision: number | null;
+  context_recall: number | null;
+}
+
+export interface QueryResult {
+  query: string;
+  answer: string;
+  contexts: string[];
+  scores: QueryScore;
+}
+
+export interface EvaluationSummary {
+  id: string;
+  dataset_id: string;
+  status: "running" | "completed" | "failed";
+  collection: string | null;
+  aggregate_scores: QueryScore | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface EvaluationDetail extends EvaluationSummary {
+  results: QueryResult[] | null;
+  error: string | null;
+}
+
+// --- API Functions ---
+
+export async function getHealth(): Promise<boolean> {
+  try {
+    const res = await fetch(`${EVAL_API_URL}/health`, { signal: AbortSignal.timeout(3000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function createDataset(
+  name: string,
+  items: GoldenItem[],
+): Promise<{ id: string }> {
+  const res = await evalFetch("/datasets", {
+    method: "POST",
+    body: JSON.stringify({ name, items }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(err.detail || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function listDatasets(): Promise<DatasetSummary[]> {
+  const res = await evalFetch("/datasets");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return data.datasets ?? data;
+}
+
+export async function startEvaluation(
+  datasetId: string,
+  collection?: string,
+): Promise<{ id: string; status: string }> {
+  const body: Record<string, string> = { dataset_id: datasetId };
+  if (collection) body.collection = collection;
+  const res = await evalFetch("/evaluations", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: "Request failed" }));
+    throw new Error(err.detail || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function getEvaluation(id: string): Promise<EvaluationDetail> {
+  const res = await evalFetch(`/evaluations/${id}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function listEvaluations(): Promise<EvaluationSummary[]> {
+  const res = await evalFetch("/evaluations");
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return data.evaluations ?? data;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/eval-api.ts
+git commit -m "feat(frontend): add eval service API client
+
+Wraps all eval endpoints with credentials:include for cookie auth
+and retry-on-401 pattern matching go-api.ts."
+```
+
+---
+
+## Task 4: RadialGauge Component
+
+**Files:**
+- Create: `frontend/src/components/eval/RadialGauge.tsx`
+
+- [ ] **Step 1: Create the RadialGauge component**
+
+Create `frontend/src/components/eval/RadialGauge.tsx`:
+
+```tsx
+interface RadialGaugeProps {
+  value: number | null;
+  label: string;
+  size?: number;
+}
+
+function scoreColor(value: number): string {
+  if (value >= 0.7) return "#22c55e"; // green
+  if (value >= 0.4) return "#eab308"; // yellow
+  return "#ef4444"; // red
+}
+
+export function RadialGauge({ value, label, size = 80 }: RadialGaugeProps) {
+  const radius = size * 0.4;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+  const strokeWidth = size * 0.08;
+
+  const displayValue = value !== null ? value : 0;
+  const offset = circumference - displayValue * circumference;
+  const color = value !== null ? scoreColor(value) : "#64748b";
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {/* Background track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="#1e293b"
+          strokeWidth={strokeWidth}
+        />
+        {/* Score arc */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+        {/* Score text */}
+        <text
+          x={center}
+          y={center + size * 0.05}
+          textAnchor="middle"
+          fill="white"
+          fontSize={size * 0.18}
+          fontWeight="bold"
+        >
+          {value !== null ? value.toFixed(2) : "N/A"}
+        </text>
+      </svg>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/eval/RadialGauge.tsx
+git commit -m "feat(frontend): add RadialGauge SVG component
+
+Reusable gauge with color thresholds (green/yellow/red) for RAGAS metrics."
+```
+
+---
+
+## Task 5: DatasetTab Component
+
+**Files:**
+- Create: `frontend/src/components/eval/DatasetTab.tsx`
+
+- [ ] **Step 1: Create the DatasetTab component**
+
+Create `frontend/src/components/eval/DatasetTab.tsx`:
+
+```tsx
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  createDataset,
+  listDatasets,
+  type DatasetSummary,
+  type GoldenItem,
+} from "@/lib/eval-api";
+
+const EXAMPLE_ITEMS: GoldenItem[] = [
+  {
+    query: "What is chunking in document processing?",
+    expected_answer:
+      "Chunking is the process of splitting documents into smaller pieces for embedding and retrieval.",
+    expected_sources: ["ingestion.pdf"],
+  },
+];
+
+export function DatasetTab() {
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [name, setName] = useState("");
+  const [itemsJson, setItemsJson] = useState(
+    JSON.stringify(EXAMPLE_ITEMS, null, 2),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await listDatasets();
+      setDatasets(data);
+    } catch {
+      // silently fail on list
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function handleCreate() {
+    setError(null);
+    let items: GoldenItem[];
+    try {
+      items = JSON.parse(itemsJson);
+      if (!Array.isArray(items) || items.length === 0) {
+        setError("Items must be a non-empty JSON array.");
+        return;
+      }
+    } catch {
+      setError("Invalid JSON. Check syntax and try again.");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      await createDataset(name.trim(), items);
+      setName("");
+      setItemsJson(JSON.stringify(EXAMPLE_ITEMS, null, 2));
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create dataset");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Create form */}
+      <div className="rounded-lg border border-border p-4 space-y-4">
+        <h3 className="text-sm font-medium">Create a Golden Dataset</h3>
+        <p className="text-xs text-muted-foreground">
+          A golden dataset is a set of test queries with expected answers, used
+          to measure RAG pipeline quality. Each item has a query, expected
+          answer, and optional expected source documents.
+        </p>
+        <input
+          type="text"
+          placeholder="Dataset name (e.g., rag-baseline-v1)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+        />
+        <textarea
+          value={itemsJson}
+          onChange={(e) => setItemsJson(e.target.value)}
+          rows={10}
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono"
+        />
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <button
+          onClick={handleCreate}
+          disabled={creating || !name.trim()}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+        >
+          {creating ? "Creating..." : "Create Dataset"}
+        </button>
+      </div>
+
+      {/* Dataset list */}
+      <div>
+        <h3 className="text-sm font-medium mb-3">Existing Datasets</h3>
+        {datasets.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No datasets yet. Create one above to get started.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {datasets.map((ds) => (
+              <div key={ds.id} className="rounded-lg border border-border">
+                <button
+                  onClick={() =>
+                    setExpandedId(expandedId === ds.id ? null : ds.id)
+                  }
+                  className="w-full flex items-center justify-between p-3 text-sm hover:bg-muted/50 transition-colors"
+                >
+                  <span className="font-medium">{ds.name}</span>
+                  <span className="text-muted-foreground text-xs">
+                    {new Date(ds.created_at).toLocaleDateString()}
+                  </span>
+                </button>
+                {expandedId === ds.id && (
+                  <div className="border-t border-border p-3 text-xs text-muted-foreground">
+                    <p>ID: {ds.id}</p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/eval/DatasetTab.tsx
+git commit -m "feat(frontend): add DatasetTab component
+
+Form for creating golden datasets with JSON input and expandable list."
+```
+
+---
+
+## Task 6: EvaluateTab Component
+
+**Files:**
+- Create: `frontend/src/components/eval/EvaluateTab.tsx`
+
+- [ ] **Step 1: Create the EvaluateTab component**
+
+Create `frontend/src/components/eval/EvaluateTab.tsx`:
+
+```tsx
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  listDatasets,
+  startEvaluation,
+  getEvaluation,
+  type DatasetSummary,
+  type EvaluationDetail,
+} from "@/lib/eval-api";
+
+interface EvaluateTabProps {
+  onComplete: (evaluation: EvaluationDetail) => void;
+}
+
+export function EvaluateTab({ onComplete }: EvaluateTabProps) {
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [selectedDatasetId, setSelectedDatasetId] = useState("");
+  const [collection, setCollection] = useState("documents");
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    listDatasets()
+      .then((data) => {
+        setDatasets(data);
+        if (data.length > 0) setSelectedDatasetId(data[0].id);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const pollForCompletion = useCallback(
+    (evalId: string) => {
+      pollRef.current = setInterval(async () => {
+        try {
+          const detail = await getEvaluation(evalId);
+          if (detail.status === "completed") {
+            if (pollRef.current) clearInterval(pollRef.current);
+            setRunning(false);
+            setStatus(null);
+            onComplete(detail);
+          } else if (detail.status === "failed") {
+            if (pollRef.current) clearInterval(pollRef.current);
+            setRunning(false);
+            setStatus(null);
+            setError(detail.error || "Evaluation failed");
+          }
+        } catch {
+          // keep polling on transient errors
+        }
+      }, 5000);
+    },
+    [onComplete],
+  );
+
+  async function handleRun() {
+    setError(null);
+    setRunning(true);
+    setStatus("Starting evaluation...");
+
+    try {
+      const { id } = await startEvaluation(
+        selectedDatasetId,
+        collection || undefined,
+      );
+      setStatus("Evaluating... this may take a few minutes.");
+      pollForCompletion(id);
+    } catch (e) {
+      setRunning(false);
+      setStatus(null);
+      setError(e instanceof Error ? e.message : "Failed to start evaluation");
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-border p-4 space-y-4">
+        <h3 className="text-sm font-medium">Run Evaluation</h3>
+        <p className="text-xs text-muted-foreground">
+          Select a golden dataset and run RAGAS metrics against the RAG
+          pipeline. The evaluation runs in the background — results appear when
+          complete.
+        </p>
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs text-muted-foreground block mb-1">
+              Dataset
+            </label>
+            <select
+              value={selectedDatasetId}
+              onChange={(e) => setSelectedDatasetId(e.target.value)}
+              disabled={running || datasets.length === 0}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            >
+              {datasets.length === 0 && (
+                <option value="">No datasets available</option>
+              )}
+              {datasets.map((ds) => (
+                <option key={ds.id} value={ds.id}>
+                  {ds.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="text-xs text-muted-foreground block mb-1">
+              Collection (optional)
+            </label>
+            <input
+              type="text"
+              value={collection}
+              onChange={(e) => setCollection(e.target.value)}
+              placeholder="documents"
+              disabled={running}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            />
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {status && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <svg
+              className="h-4 w-4 animate-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+                className="opacity-25"
+              />
+              <path
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                className="opacity-75"
+              />
+            </svg>
+            {status}
+          </div>
+        )}
+
+        <button
+          onClick={handleRun}
+          disabled={running || !selectedDatasetId}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 transition-colors"
+        >
+          {running ? "Running..." : "Run Evaluation"}
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/eval/EvaluateTab.tsx
+git commit -m "feat(frontend): add EvaluateTab component
+
+Dataset selector, run button, and polling for async evaluation completion."
+```
+
+---
+
+## Task 7: ResultsTab Component
+
+**Files:**
+- Create: `frontend/src/components/eval/ResultsTab.tsx`
+
+- [ ] **Step 1: Create the ResultsTab component**
+
+Create `frontend/src/components/eval/ResultsTab.tsx`:
+
+```tsx
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  listEvaluations,
+  getEvaluation,
+  type EvaluationSummary,
+  type EvaluationDetail,
+  type QueryScore,
+} from "@/lib/eval-api";
+import { RadialGauge } from "@/components/eval/RadialGauge";
+
+interface ResultsTabProps {
+  selectedEvaluation: EvaluationDetail | null;
+}
+
+function averageScore(scores: QueryScore): number | null {
+  const values = [
+    scores.faithfulness,
+    scores.answer_relevancy,
+    scores.context_precision,
+    scores.context_recall,
+  ].filter((v): v is number => v !== null);
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function ResultsTab({ selectedEvaluation }: ResultsTabProps) {
+  const [evaluations, setEvaluations] = useState<EvaluationSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [detail, setDetail] = useState<EvaluationDetail | null>(
+    selectedEvaluation,
+  );
+  const [expandedQuery, setExpandedQuery] = useState<number | null>(null);
+
+  useEffect(() => {
+    listEvaluations()
+      .then((data) => {
+        setEvaluations(data);
+        if (selectedEvaluation) {
+          setSelectedId(selectedEvaluation.id);
+        } else if (data.length > 0) {
+          setSelectedId(data[0].id);
+        }
+      })
+      .catch(() => {});
+  }, [selectedEvaluation]);
+
+  useEffect(() => {
+    if (selectedEvaluation && selectedId === selectedEvaluation.id) {
+      setDetail(selectedEvaluation);
+      return;
+    }
+    if (!selectedId) return;
+    getEvaluation(selectedId)
+      .then(setDetail)
+      .catch(() => setDetail(null));
+  }, [selectedId, selectedEvaluation]);
+
+  return (
+    <div className="space-y-6">
+      {/* Evaluation selector */}
+      <div>
+        <label className="text-xs text-muted-foreground block mb-1">
+          Select Evaluation
+        </label>
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+        >
+          {evaluations.length === 0 && (
+            <option value="">No evaluations yet</option>
+          )}
+          {evaluations.map((ev) => (
+            <option key={ev.id} value={ev.id}>
+              {new Date(ev.created_at).toLocaleString()} — {ev.status}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {!detail && evaluations.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No evaluation results yet. Go to the Evaluate tab to run one.
+        </p>
+      )}
+
+      {detail && detail.status === "failed" && (
+        <div className="rounded-lg border border-red-800 bg-red-950/50 p-4">
+          <p className="text-sm text-red-400">
+            Evaluation failed: {detail.error || "Unknown error"}
+          </p>
+        </div>
+      )}
+
+      {detail && detail.status === "running" && (
+        <p className="text-sm text-muted-foreground">
+          This evaluation is still running. Results will appear when complete.
+        </p>
+      )}
+
+      {/* Aggregate Scorecard */}
+      {detail?.aggregate_scores && detail.status === "completed" && (
+        <div className="rounded-lg border border-border p-6">
+          <h3 className="text-sm font-medium mb-4">Aggregate Scores</h3>
+          <div className="flex justify-center gap-8 flex-wrap">
+            <RadialGauge
+              value={detail.aggregate_scores.faithfulness}
+              label="Faithfulness"
+            />
+            <RadialGauge
+              value={detail.aggregate_scores.answer_relevancy}
+              label="Relevancy"
+            />
+            <RadialGauge
+              value={detail.aggregate_scores.context_precision}
+              label="Precision"
+            />
+            <RadialGauge
+              value={detail.aggregate_scores.context_recall}
+              label="Recall"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Per-query breakdown */}
+      {detail?.results && detail.results.length > 0 && (
+        <div>
+          <h3 className="text-sm font-medium mb-3">Per-Query Breakdown</h3>
+          <div className="space-y-2">
+            {detail.results.map((result, idx) => {
+              const avg = averageScore(result.scores);
+              return (
+                <div key={idx} className="rounded-lg border border-border">
+                  <button
+                    onClick={() =>
+                      setExpandedQuery(expandedQuery === idx ? null : idx)
+                    }
+                    className="w-full flex items-center justify-between p-3 text-sm hover:bg-muted/50 transition-colors text-left"
+                  >
+                    <span className="truncate flex-1 mr-4">
+                      {result.query}
+                    </span>
+                    <span
+                      className={`shrink-0 font-mono text-xs ${
+                        avg !== null && avg >= 0.7
+                          ? "text-green-400"
+                          : avg !== null && avg >= 0.4
+                            ? "text-yellow-400"
+                            : "text-red-400"
+                      }`}
+                    >
+                      {avg !== null ? avg.toFixed(2) : "N/A"}
+                    </span>
+                  </button>
+                  {expandedQuery === idx && (
+                    <div className="border-t border-border p-4 space-y-4 text-sm">
+                      <div>
+                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                          Answer
+                        </span>
+                        <p className="mt-1 text-muted-foreground">
+                          {result.answer}
+                        </p>
+                      </div>
+                      <div>
+                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                          Retrieved Contexts
+                        </span>
+                        <ul className="mt-1 space-y-1">
+                          {result.contexts.map((ctx, i) => (
+                            <li
+                              key={i}
+                              className="text-xs text-muted-foreground bg-muted/30 rounded p-2"
+                            >
+                              {ctx}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div>
+                        <span className="text-xs text-muted-foreground uppercase tracking-wide">
+                          Scores
+                        </span>
+                        <div className="mt-1 grid grid-cols-2 gap-2 text-xs">
+                          <div>
+                            Faithfulness:{" "}
+                            <span className="font-mono">
+                              {result.scores.faithfulness?.toFixed(2) ?? "N/A"}
+                            </span>
+                          </div>
+                          <div>
+                            Relevancy:{" "}
+                            <span className="font-mono">
+                              {result.scores.answer_relevancy?.toFixed(2) ??
+                                "N/A"}
+                            </span>
+                          </div>
+                          <div>
+                            Precision:{" "}
+                            <span className="font-mono">
+                              {result.scores.context_precision?.toFixed(2) ??
+                                "N/A"}
+                            </span>
+                          </div>
+                          <div>
+                            Recall:{" "}
+                            <span className="font-mono">
+                              {result.scores.context_recall?.toFixed(2) ??
+                                "N/A"}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/eval/ResultsTab.tsx
+git commit -m "feat(frontend): add ResultsTab component
+
+Evaluation selector, radial gauge scorecard, and expandable per-query breakdown."
+```
+
+---
+
+## Task 8: Eval Page
+
+**Files:**
+- Create: `frontend/src/app/ai/eval/page.tsx`
+
+- [ ] **Step 1: Create the eval page**
+
+Create `frontend/src/app/ai/eval/page.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { HealthGate } from "@/components/HealthGate";
+import { GoAuthProvider, useGoAuth } from "@/components/go/GoAuthProvider";
+import { DatasetTab } from "@/components/eval/DatasetTab";
+import { EvaluateTab } from "@/components/eval/EvaluateTab";
+import { ResultsTab } from "@/components/eval/ResultsTab";
+import type { EvaluationDetail } from "@/lib/eval-api";
+
+const evalHealthUrl =
+  process.env.NEXT_PUBLIC_EVAL_API_URL || "http://localhost:8000/eval";
+
+type Tab = "datasets" | "evaluate" | "results";
+
+function EvalPageInner() {
+  const { isLoggedIn } = useGoAuth();
+  const [activeTab, setActiveTab] = useState<Tab>("datasets");
+  const [completedEval, setCompletedEval] = useState<EvaluationDetail | null>(
+    null,
+  );
+
+  function handleEvalComplete(evaluation: EvaluationDetail) {
+    setCompletedEval(evaluation);
+    setActiveTab("results");
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <div className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto max-w-3xl px-6 py-12">
+          <h1 className="mt-8 text-3xl font-bold">RAG Evaluation</h1>
+          <div className="mt-8 rounded-lg border border-border p-8 text-center">
+            <p className="text-muted-foreground">
+              Log in to use the evaluation tool.
+            </p>
+            <Link
+              href="/go/login?next=/ai/eval"
+              className="mt-4 inline-block rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 transition-colors"
+            >
+              Log in
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "datasets", label: "Datasets" },
+    { key: "evaluate", label: "Evaluate" },
+    { key: "results", label: "Results" },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="mt-8 text-3xl font-bold">RAG Evaluation</h1>
+        <p className="mt-2 text-muted-foreground">
+          Measure RAG pipeline quality with golden datasets and RAGAS metrics.
+        </p>
+
+        {/* Tabs */}
+        <div className="mt-8 flex gap-1 border-b border-border">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                activeTab === tab.key
+                  ? "border-b-2 border-indigo-500 text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div className="mt-6">
+          {activeTab === "datasets" && <DatasetTab />}
+          {activeTab === "evaluate" && (
+            <EvaluateTab onComplete={handleEvalComplete} />
+          )}
+          {activeTab === "results" && (
+            <ResultsTab selectedEvaluation={completedEval} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function EvalPage() {
+  return (
+    <GoAuthProvider>
+      <HealthGate
+        endpoint={`${evalHealthUrl}/health`}
+        stack="Eval Service"
+        docsHref="/ai"
+      >
+        <EvalPageInner />
+      </HealthGate>
+    </GoAuthProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run frontend preflight**
+
+Run: `make preflight-frontend`
+Expected: Lint, type check, and build all pass. The `/ai/eval` route should appear in the build output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/ai/eval/page.tsx
+git commit -m "feat(frontend): add /ai/eval page with tabbed eval UI
+
+HealthGate + GoAuthProvider wrapper, three tabs for datasets,
+evaluation runner, and results with radial gauge scorecards."
+```
+
+---
+
+## Task 9: Add Eval Link to AI Hub Page
+
+**Files:**
+- Modify: `frontend/src/app/ai/page.tsx`
+
+- [ ] **Step 1: Read the AI hub page**
+
+Read `frontend/src/app/ai/page.tsx` to find where the existing links to RAG and Debug are.
+
+- [ ] **Step 2: Add eval link following existing pattern**
+
+Add a link to `/ai/eval` in the same section as the RAG and Debug links. Follow the exact same card/link pattern used for the existing entries. The eval link should have:
+- Title: "RAG Evaluation"
+- Description: "Measure pipeline quality with golden datasets and RAGAS metrics"
+- Href: `/ai/eval`
+
+- [ ] **Step 3: Verify frontend builds**
+
+Run: `cd frontend && npx tsc --noEmit && npx next build`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/ai/page.tsx
+git commit -m "feat(frontend): add eval link to AI hub page"
+```
+
+---
+
+## Task 10: Vercel Env Var + Final Preflight
+
+**Files:**
+- No code changes — configuration only
+
+- [ ] **Step 1: Add NEXT_PUBLIC_EVAL_API_URL to Vercel**
+
+```bash
+cd frontend
+printf 'https://api.kylebradshaw.dev/eval' | vercel env add NEXT_PUBLIC_EVAL_API_URL production
+printf 'https://qa-api.kylebradshaw.dev/eval' | vercel env add NEXT_PUBLIC_EVAL_API_URL preview
+```
+
+- [ ] **Step 2: Run full frontend preflight**
+
+Run: `make preflight-frontend`
+Expected: All checks pass.
+
+- [ ] **Step 3: Run full Python preflight**
+
+Run: `make preflight-python`
+Expected: All checks pass.
+
+- [ ] **Step 4: Run security preflight**
+
+Run: `make preflight-security`
+Expected: All checks pass.
+
+- [ ] **Step 5: Commit any remaining changes and push**
+
+```bash
+git push
+```

--- a/docs/superpowers/specs/2026-04-17-eval-service-ui-design.md
+++ b/docs/superpowers/specs/2026-04-17-eval-service-ui-design.md
@@ -1,0 +1,138 @@
+# Eval Service UI — Interactive Frontend for RAG Evaluation
+
+## What
+
+New frontend route at `/ai/eval` with a tabbed interface for managing golden datasets, running RAGAS evaluations, and viewing scorecards with per-query breakdowns. Uses the Go auth system for JWT-based authentication, demonstrating cross-service auth propagation (Browser → Python eval service, validated with the same HS256 secret as the Go auth service).
+
+## Why
+
+Makes the eval service usable and demonstrable in the portfolio. Shows interviewers that Kyle builds measurement tooling for RAG pipelines, not just the pipelines themselves. The cross-service auth adds a real-world integration pattern.
+
+## Architecture
+
+- `/ai/eval` page wrapped in `HealthGate` (checks `GET /eval/health`)
+- Three client-side tabs: **Datasets**, **Evaluate**, **Results**
+- Auth: Go auth service sets an httpOnly `access_token` cookie with `Path: "/"`. Since the eval service is behind the same reverse proxy (nginx in dev, ingress in prod), the browser automatically sends the cookie with `credentials: "include"`. The eval service reads the JWT from the cookie and validates it using the shared `JWT_SECRET`.
+- If not logged in (no `go_user` in localStorage), page shows login prompt linking to `/go/login` with `returnTo` param
+- On 401 from eval API, attempt a cookie refresh via `refreshGoAccessToken()` (same pattern as `goApiFetch` in `go-api.ts`)
+
+### Service Chain
+
+```
+Browser (cookie: access_token=<jwt>)
+    → nginx/ingress → eval service (Python/FastAPI)
+                          ↓ reads JWT from cookie
+                    Go auth service signed it (same HS256 JWT_SECRET)
+```
+
+## API Client
+
+New file: `frontend/src/lib/eval-api.ts`
+
+| Function | Method | Path | Auth |
+|----------|--------|------|------|
+| `getHealth()` | GET | `/health` | No |
+| `createDataset(data)` | POST | `/datasets` | Yes |
+| `listDatasets()` | GET | `/datasets` | Yes |
+| `startEvaluation(datasetId, collection?)` | POST | `/evaluations` | Yes |
+| `getEvaluation(id)` | GET | `/evaluations/{id}` | Yes |
+| `listEvaluations()` | GET | `/evaluations` | Yes |
+
+Base URL from `NEXT_PUBLIC_EVAL_API_URL` with localhost fallback for dev. All authenticated calls use `credentials: "include"` to send the httpOnly `access_token` cookie. On 401, retry once after calling `refreshGoAccessToken()`.
+
+## Tab Details
+
+### Datasets Tab
+
+- **Create form:** name input + JSON textarea for golden items array (`query`, `expected_answer`, `expected_sources`). "Create Dataset" button.
+- **Dataset list:** table showing name, item count, created date. Clicking a row expands to show items preview.
+- **Empty state:** guidance text explaining what a golden dataset is and how to format one.
+
+### Evaluate Tab
+
+- **Dataset selector:** dropdown populated from `listDatasets()`
+- **Collection input:** optional text input, defaults to "documents"
+- **Run button:** "Run Evaluation" triggers `startEvaluation()`, receives 202 with eval ID
+- **Polling:** while status is `running`, poll `getEvaluation(id)` every 5 seconds, show spinner with "Evaluating..." badge
+- **On completion:** auto-switch to Results tab with the new evaluation selected
+- **On failure:** inline error message showing the error string from the API
+
+### Results Tab
+
+- **Evaluation selector:** dropdown of past evaluations (dataset name + date) from `listEvaluations()`
+- **Aggregate scorecard:** four radial gauges in a row — faithfulness, answer relevancy, context precision, context recall. Color-coded: green (≥0.7), yellow (0.4–0.7), red (<0.4). Score displayed in center of each gauge.
+- **Per-query breakdown:** expandable row table. Default view shows query text + average score per row. Expanding a row shows:
+  - Generated answer
+  - Retrieved contexts (as a list)
+  - Individual metric scores (four values)
+
+## Components
+
+### New Frontend Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/lib/eval-api.ts` | API client for eval service |
+| `frontend/src/app/ai/eval/page.tsx` | Page: HealthGate + auth check + tab state |
+| `frontend/src/components/eval/DatasetTab.tsx` | Dataset creation form + list |
+| `frontend/src/components/eval/EvaluateTab.tsx` | Run form + polling status |
+| `frontend/src/components/eval/ResultsTab.tsx` | Eval selector + scorecard + breakdown |
+| `frontend/src/components/eval/RadialGauge.tsx` | Reusable SVG radial gauge |
+
+### Backend Changes
+
+| File | Purpose |
+|------|---------|
+| `services/eval/app/auth.py` | JWT validation middleware (HS256, shared secret) |
+| `services/eval/app/main.py` | Wire auth dependency into protected routes (currently has placeholder auth) |
+
+### Infrastructure Changes
+
+- Add `JWT_SECRET` env var to eval service in:
+  - `docker-compose.yml`
+  - `k8s/ai-services/` manifests
+  - K8s QA overlay
+
+## Auth Integration
+
+### Backend (eval service)
+
+New `services/eval/app/auth.py`:
+- Read `JWT_SECRET` from environment
+- Extract JWT from the `access_token` cookie (matching the Go auth service's cookie name)
+- Decode and validate HS256 signature
+- Extract user identity (for logging/audit, not for user lookup)
+- Return 401 on missing/invalid/expired token
+- Wire as a FastAPI dependency on all routes except `/health`
+
+### Frontend
+
+- Check `go_user` in `localStorage` to determine login state (same as Go ecommerce pages)
+- If not logged in: show "Log in to use the evaluation tool" with link to `/go/login?returnTo=/ai/eval`
+- All eval API calls use `credentials: "include"` so the browser sends the httpOnly `access_token` cookie automatically
+- On 401 response: attempt `refreshGoAccessToken()`, retry once. If still 401, dispatch `go-auth-cleared` event and show login prompt.
+
+## Scorecard Visualization
+
+Radial gauges using inline SVG (no charting library needed):
+- Circle background track + colored arc proportional to score
+- Score value centered inside
+- Color thresholds: green ≥0.7, yellow 0.4–0.7, red <0.4
+- Metric name below each gauge
+- Four gauges in a responsive row
+
+## Dependencies
+
+- No new npm packages (SVG gauges, native fetch, existing shadcn components)
+- `PyJWT` package added to eval service requirements (for HS256 token decoding)
+- Eval service must be deployed (already done)
+- Go auth service must be running (already deployed)
+- `JWT_SECRET` must match between Go auth and eval service configs
+- Eval service must be behind the same reverse proxy as the Go auth service so the `access_token` cookie (set with `Path: "/"`) is sent on eval API requests
+
+## Out of Scope
+
+- Dataset editing/deletion (datasets are immutable in the current API)
+- Evaluation comparison or history trends (Specs 3 and 4)
+- File upload for datasets (JSON textarea is sufficient for now)
+- SSE/WebSocket for real-time eval progress (polling is adequate)

--- a/frontend/src/app/ai/eval/page.tsx
+++ b/frontend/src/app/ai/eval/page.tsx
@@ -63,7 +63,7 @@ function EvalPageInner() {
               onClick={() => setActiveTab(tab.id)}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
                 activeTab === tab.id
-                  ? "border-b-2 border-indigo-500 text-indigo-600"
+                  ? "border-b-2 border-indigo-500 text-foreground"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >

--- a/frontend/src/app/ai/eval/page.tsx
+++ b/frontend/src/app/ai/eval/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { HealthGate } from "@/components/HealthGate";
+import { GoAuthProvider, useGoAuth } from "@/components/go/GoAuthProvider";
+import { DatasetTab } from "@/components/eval/DatasetTab";
+import EvaluateTab from "@/components/eval/EvaluateTab";
+import ResultsTab from "@/components/eval/ResultsTab";
+import { EvaluationDetail } from "@/lib/eval-api";
+
+type TabId = "datasets" | "evaluate" | "results";
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "datasets", label: "Datasets" },
+  { id: "evaluate", label: "Evaluate" },
+  { id: "results", label: "Results" },
+];
+
+function EvalPageInner() {
+  const { isLoggedIn } = useGoAuth();
+  const [activeTab, setActiveTab] = useState<TabId>("datasets");
+  const [completedEval, setCompletedEval] = useState<EvaluationDetail | null>(
+    null,
+  );
+
+  if (!isLoggedIn) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <div className="rounded-lg border bg-card p-8 shadow-sm text-center max-w-sm w-full">
+          <p className="mb-6 text-muted-foreground">
+            Log in to use the evaluation tool
+          </p>
+          <Link
+            href="/go/login?next=/ai/eval"
+            className="inline-block rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
+          >
+            Log in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  function handleEvalComplete(evaluation: EvaluationDetail) {
+    setCompletedEval(evaluation);
+    setActiveTab("results");
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-5xl px-4 py-10">
+        <h1 className="text-2xl font-bold mb-1">RAG Evaluation</h1>
+        <p className="text-muted-foreground mb-6">
+          Measure RAG pipeline quality with golden datasets and RAGAS metrics.
+        </p>
+
+        {/* Tab bar */}
+        <div className="flex flex-row border-b mb-6">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                activeTab === tab.id
+                  ? "border-b-2 border-indigo-500 text-indigo-600"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        {activeTab === "datasets" && <DatasetTab />}
+        {activeTab === "evaluate" && (
+          <EvaluateTab onComplete={handleEvalComplete} />
+        )}
+        {activeTab === "results" && (
+          <ResultsTab selectedEvaluation={completedEval} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function EvalPage() {
+  const evalHealthUrl =
+    process.env.NEXT_PUBLIC_EVAL_API_URL || "http://localhost:8000/eval";
+
+  return (
+    <GoAuthProvider>
+      <HealthGate
+        endpoint={`${evalHealthUrl}/health`}
+        stack="Eval Service"
+        docsHref="/ai"
+      >
+        <EvalPageInner />
+      </HealthGate>
+    </GoAuthProvider>
+  );
+}

--- a/frontend/src/app/ai/page.tsx
+++ b/frontend/src/app/ai/page.tsx
@@ -153,6 +153,36 @@ export default function AISection() {
             Try the Debug Demo &rarr;
           </Link>
         </section>
+
+        {/* RAG Evaluation Section */}
+        <section className="mt-16">
+          <h2 className="text-2xl font-semibold">RAG Evaluation</h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            A measurement tool for systematically tracking RAG pipeline quality.
+            Create golden datasets with expected answers, run RAGAS evaluations
+            against the live pipeline, and view scorecards with per-query
+            breakdowns — faithfulness, answer relevancy, context precision, and
+            context recall.
+          </p>
+
+          <h3 className="mt-6 text-lg font-medium">What It Demonstrates</h3>
+          <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
+            <li>RAGAS evaluation framework for RAG quality measurement</li>
+            <li>Cross-service JWT authentication (Go auth → Python eval)</li>
+            <li>Async evaluation with polling for long-running LLM judge calls</li>
+            <li>Golden dataset management for repeatable quality tracking</li>
+          </ul>
+        </section>
+
+        {/* Eval Demo Link */}
+        <section className="mt-12">
+          <Link
+            href="/ai/eval"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Try RAG Evaluation &rarr;
+          </Link>
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/components/eval/DatasetTab.tsx
+++ b/frontend/src/components/eval/DatasetTab.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  createDataset,
+  listDatasets,
+  DatasetSummary,
+  GoldenItem,
+} from "@/lib/eval-api";
+
+const EXAMPLE_ITEMS = JSON.stringify(
+  [
+    {
+      query: "What is chunking in document processing?",
+      expected_answer:
+        "Chunking is the process of splitting documents into smaller pieces for embedding and retrieval.",
+      expected_sources: ["ingestion.pdf"],
+    },
+  ],
+  null,
+  2,
+);
+
+export function DatasetTab() {
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [name, setName] = useState("");
+  const [itemsJson, setItemsJson] = useState(EXAMPLE_ITEMS);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    listDatasets()
+      .then(setDatasets)
+      .catch(() => {
+        // silently ignore load errors — user can still create datasets
+      });
+  }, []);
+
+  async function handleCreate() {
+    setError(null);
+
+    let items: GoldenItem[];
+    try {
+      items = JSON.parse(itemsJson);
+      if (!Array.isArray(items)) throw new Error("Expected a JSON array");
+    } catch (e) {
+      setError(
+        e instanceof Error ? `Invalid JSON: ${e.message}` : "Invalid JSON",
+      );
+      return;
+    }
+
+    if (!name.trim()) {
+      setError("Dataset name is required");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      await createDataset(name.trim(), items);
+      setName("");
+      setItemsJson(EXAMPLE_ITEMS);
+      const updated = await listDatasets();
+      setDatasets(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create dataset");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function toggleExpand(id: string) {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Create form */}
+      <div className="rounded-lg border border-border p-4 space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Create a Golden Dataset</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            A golden dataset is a curated set of queries with known expected
+            answers and sources. It serves as the ground truth for evaluating
+            RAG pipeline quality — run evaluations against it to measure
+            faithfulness, answer relevancy, and retrieval precision.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Dataset name (e.g., rag-baseline-v1)"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          />
+
+          <textarea
+            value={itemsJson}
+            onChange={(e) => setItemsJson(e.target.value)}
+            rows={8}
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-y"
+          />
+
+          {error && <p className="text-sm text-red-400">{error}</p>}
+
+          <button
+            onClick={handleCreate}
+            disabled={creating}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {creating ? "Creating…" : "Create Dataset"}
+          </button>
+        </div>
+      </div>
+
+      {/* Dataset list */}
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Existing Datasets</h2>
+
+        {datasets.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No datasets yet. Create one above to get started.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {datasets.map((ds) => (
+              <div
+                key={ds.id}
+                className="rounded-lg border border-border p-4 cursor-pointer hover:border-indigo-500 transition-colors"
+                onClick={() => toggleExpand(ds.id)}
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <span className="font-medium">{ds.name}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {ds.item_count} item{ds.item_count !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(ds.created_at).toLocaleDateString()}
+                  </span>
+                </div>
+
+                {expandedId === ds.id && (
+                  <div className="mt-3 pt-3 border-t border-border text-sm text-muted-foreground">
+                    <span className="font-mono text-xs">ID: {ds.id}</span>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/eval/EvaluateTab.tsx
+++ b/frontend/src/components/eval/EvaluateTab.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  DatasetSummary,
+  EvaluationDetail,
+  getEvaluation,
+  listDatasets,
+  startEvaluation,
+} from "@/lib/eval-api";
+
+interface EvaluateTabProps {
+  onComplete: (evaluation: EvaluationDetail) => void;
+}
+
+export default function EvaluateTab({ onComplete }: EvaluateTabProps) {
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [selectedDatasetId, setSelectedDatasetId] = useState<string>("");
+  const [collection, setCollection] = useState<string>("documents");
+  const [running, setRunning] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    listDatasets()
+      .then((data) => {
+        setDatasets(data);
+        if (data.length > 0) {
+          setSelectedDatasetId(data[0].id);
+        }
+      })
+      .catch(() => {
+        // silently ignore load failure — user can retry via the run button
+      });
+
+    return () => {
+      if (pollIntervalRef.current !== null) {
+        clearInterval(pollIntervalRef.current);
+      }
+    };
+  }, []);
+
+  async function handleRun() {
+    if (!selectedDatasetId || running) return;
+
+    setError("");
+    setRunning(true);
+    setStatusMessage("Starting evaluation...");
+
+    let evalId: string;
+    try {
+      const result = await startEvaluation(
+        selectedDatasetId,
+        collection.trim() || undefined,
+      );
+      evalId = result.id;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start evaluation");
+      setRunning(false);
+      setStatusMessage("");
+      return;
+    }
+
+    setStatusMessage("Evaluating... this may take a few minutes.");
+
+    pollIntervalRef.current = setInterval(async () => {
+      try {
+        const detail = await getEvaluation(evalId);
+        if (detail.status === "completed") {
+          if (pollIntervalRef.current !== null) {
+            clearInterval(pollIntervalRef.current);
+            pollIntervalRef.current = null;
+          }
+          setRunning(false);
+          setStatusMessage("");
+          onComplete(detail);
+        } else if (detail.status === "failed") {
+          if (pollIntervalRef.current !== null) {
+            clearInterval(pollIntervalRef.current);
+            pollIntervalRef.current = null;
+          }
+          setRunning(false);
+          setStatusMessage("");
+          setError(detail.error ?? "Evaluation failed");
+        }
+        // status === "running": keep polling
+      } catch {
+        // transient error — keep polling
+      }
+    }, 5000);
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <h2 className="mb-2 text-xl font-semibold text-gray-900">
+        Run Evaluation
+      </h2>
+      <p className="mb-6 text-sm text-gray-600">
+        Select a golden dataset and run the RAG evaluation pipeline. The
+        evaluator queries each item against the live retrieval stack and scores
+        faithfulness, answer relevancy, context precision, and context recall
+        using the Ollama judge model.
+      </p>
+
+      <div className="space-y-4">
+        {/* Dataset selector */}
+        <div>
+          <label
+            htmlFor="dataset-select"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Dataset
+          </label>
+          <select
+            id="dataset-select"
+            value={selectedDatasetId}
+            onChange={(e) => setSelectedDatasetId(e.target.value)}
+            disabled={running}
+            className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
+          >
+            {datasets.length === 0 && (
+              <option value="">No datasets available</option>
+            )}
+            {datasets.map((ds) => (
+              <option key={ds.id} value={ds.id}>
+                {ds.name} ({ds.item_count} items)
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Collection input */}
+        <div>
+          <label
+            htmlFor="collection-input"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Collection{" "}
+            <span className="font-normal text-gray-400">(optional)</span>
+          </label>
+          <input
+            id="collection-input"
+            type="text"
+            value={collection}
+            onChange={(e) => setCollection(e.target.value)}
+            placeholder="documents"
+            disabled={running}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-400"
+          />
+        </div>
+
+        {/* Error */}
+        {error && (
+          <p className="text-sm text-red-600">{error}</p>
+        )}
+
+        {/* Status */}
+        {running && statusMessage && (
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <svg
+              className="h-4 w-4 animate-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+                className="opacity-25"
+              />
+              <path
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                className="opacity-75"
+              />
+            </svg>
+            <span>{statusMessage}</span>
+          </div>
+        )}
+
+        {/* Run button */}
+        <button
+          onClick={handleRun}
+          disabled={running || !selectedDatasetId}
+          className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Run Evaluation
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/eval/RadialGauge.tsx
+++ b/frontend/src/components/eval/RadialGauge.tsx
@@ -1,0 +1,63 @@
+interface RadialGaugeProps {
+  value: number | null;
+  label: string;
+  size?: number;
+}
+
+function scoreColor(value: number): string {
+  if (value >= 0.7) return "#22c55e"; // green
+  if (value >= 0.4) return "#eab308"; // yellow
+  return "#ef4444"; // red
+}
+
+export function RadialGauge({ value, label, size = 80 }: RadialGaugeProps) {
+  const radius = size * 0.4;
+  const circumference = 2 * Math.PI * radius;
+  const center = size / 2;
+  const strokeWidth = size * 0.08;
+
+  const displayValue = value !== null ? value : 0;
+  const offset = circumference - displayValue * circumference;
+  const color = value !== null ? scoreColor(value) : "#64748b";
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {/* Background track */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="#1e293b"
+          strokeWidth={strokeWidth}
+        />
+        {/* Score arc */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+        {/* Score text */}
+        <text
+          x={center}
+          y={center + size * 0.05}
+          textAnchor="middle"
+          fill="white"
+          fontSize={size * 0.18}
+          fontWeight="bold"
+        >
+          {value !== null ? value.toFixed(2) : "N/A"}
+        </text>
+      </svg>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/eval/ResultsTab.tsx
+++ b/frontend/src/components/eval/ResultsTab.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  EvaluationDetail,
+  EvaluationSummary,
+  QueryScore,
+  getEvaluation,
+  listEvaluations,
+} from "@/lib/eval-api";
+import { RadialGauge } from "@/components/eval/RadialGauge";
+
+interface ResultsTabProps {
+  selectedEvaluation: EvaluationDetail | null;
+}
+
+function averageScore(scores: QueryScore): number | null {
+  const values = [
+    scores.faithfulness,
+    scores.answer_relevancy,
+    scores.context_precision,
+    scores.context_recall,
+  ].filter((v): v is number => v !== null);
+  if (values.length === 0) return null;
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+function scoreColorClass(value: number | null): string {
+  if (value === null) return "text-gray-400";
+  if (value >= 0.7) return "text-green-600";
+  if (value >= 0.4) return "text-yellow-600";
+  return "text-red-600";
+}
+
+export default function ResultsTab({ selectedEvaluation }: ResultsTabProps) {
+  const [evaluations, setEvaluations] = useState<EvaluationSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [detail, setDetail] = useState<EvaluationDetail | null>(null);
+  const [expandedQuery, setExpandedQuery] = useState<number | null>(null);
+
+  // On mount: load list, and if a freshly-completed evaluation is passed in, use it
+  useEffect(() => {
+    listEvaluations()
+      .then((list) => {
+        setEvaluations(list);
+        if (selectedEvaluation) {
+          // Merge in case it's not in the list yet
+          const inList = list.some((e) => e.id === selectedEvaluation.id);
+          if (!inList) {
+            setEvaluations([selectedEvaluation, ...list]);
+          }
+          setSelectedId(selectedEvaluation.id);
+          setDetail(selectedEvaluation);
+        } else if (list.length > 0) {
+          setSelectedId(list[0].id);
+        }
+      })
+      .catch(() => {
+        // silently ignore load failure
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // When selectedEvaluation prop changes (new run completed), switch to it
+  useEffect(() => {
+    if (selectedEvaluation) {
+      setEvaluations((prev) => {
+        const inList = prev.some((e) => e.id === selectedEvaluation.id);
+        return inList ? prev : [selectedEvaluation, ...prev];
+      });
+      setSelectedId(selectedEvaluation.id);
+      setDetail(selectedEvaluation);
+      setExpandedQuery(null);
+    }
+  }, [selectedEvaluation]);
+
+  // When selectedId changes, load the full detail (unless we already have it from the prop)
+  useEffect(() => {
+    if (!selectedId) return;
+    if (selectedEvaluation && selectedEvaluation.id === selectedId) {
+      setDetail(selectedEvaluation);
+      return;
+    }
+    getEvaluation(selectedId)
+      .then((d) => {
+        setDetail(d);
+        setExpandedQuery(null);
+      })
+      .catch(() => {
+        // silently ignore — stale detail stays visible
+      });
+  }, [selectedId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function handleSelectChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setSelectedId(e.target.value);
+    setExpandedQuery(null);
+  }
+
+  function toggleQuery(index: number) {
+    setExpandedQuery((prev) => (prev === index ? null : index));
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Evaluation selector */}
+      <div>
+        <label
+          htmlFor="eval-select"
+          className="mb-1 block text-sm font-medium text-gray-700"
+        >
+          Evaluation
+        </label>
+        <select
+          id="eval-select"
+          value={selectedId}
+          onChange={handleSelectChange}
+          className="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        >
+          {evaluations.length === 0 && (
+            <option value="">No evaluations yet</option>
+          )}
+          {evaluations.map((ev) => (
+            <option key={ev.id} value={ev.id}>
+              {new Date(ev.created_at).toLocaleString()} — {ev.status}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Empty state */}
+      {!detail && evaluations.length === 0 && (
+        <p className="text-sm text-gray-500">
+          No evaluation results yet. Go to the Evaluate tab to run one.
+        </p>
+      )}
+
+      {/* Detail states */}
+      {detail && (
+        <div className="space-y-6">
+          {/* Failed state */}
+          {detail.status === "failed" && (
+            <div className="rounded-lg border border-red-300 bg-red-50 p-4">
+              <p className="text-sm font-medium text-red-700">
+                Evaluation failed
+              </p>
+              {detail.error && (
+                <p className="mt-1 text-sm text-red-600">{detail.error}</p>
+              )}
+            </div>
+          )}
+
+          {/* Running state */}
+          {detail.status === "running" && (
+            <p className="text-sm text-gray-600">
+              This evaluation is still running.
+            </p>
+          )}
+
+          {/* Aggregate scorecard */}
+          {detail.status === "completed" && detail.aggregate_scores && (
+            <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+              <h3 className="mb-4 text-lg font-semibold text-gray-900">
+                Aggregate Scores
+              </h3>
+              <div className="flex flex-wrap justify-center gap-8">
+                <RadialGauge
+                  value={detail.aggregate_scores.faithfulness}
+                  label="Faithfulness"
+                />
+                <RadialGauge
+                  value={detail.aggregate_scores.answer_relevancy}
+                  label="Relevancy"
+                />
+                <RadialGauge
+                  value={detail.aggregate_scores.context_precision}
+                  label="Precision"
+                />
+                <RadialGauge
+                  value={detail.aggregate_scores.context_recall}
+                  label="Recall"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Per-query breakdown */}
+          {detail.status === "completed" && detail.results && detail.results.length > 0 && (
+            <div>
+              <h3 className="mb-3 text-lg font-semibold text-gray-900">
+                Per-Query Breakdown
+              </h3>
+              <div className="space-y-2">
+                {detail.results.map((result, index) => {
+                  const avg = averageScore(result.scores);
+                  const isExpanded = expandedQuery === index;
+
+                  return (
+                    <div
+                      key={index}
+                      className="rounded-lg border border-gray-200 bg-white shadow-sm"
+                    >
+                      {/* Row header */}
+                      <button
+                        onClick={() => toggleQuery(index)}
+                        className="flex w-full items-center justify-between px-4 py-3 text-left"
+                      >
+                        <span className="truncate pr-4 text-sm text-gray-800">
+                          {result.query}
+                        </span>
+                        <span
+                          className={`shrink-0 text-sm font-semibold ${scoreColorClass(avg)}`}
+                        >
+                          {avg !== null ? avg.toFixed(2) : "N/A"}
+                        </span>
+                      </button>
+
+                      {/* Expanded view */}
+                      {isExpanded && (
+                        <div className="border-t border-gray-100 px-4 pb-4 pt-3 space-y-4">
+                          {/* Answer */}
+                          <div>
+                            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                              Answer
+                            </p>
+                            <p className="text-sm text-gray-800">
+                              {result.answer}
+                            </p>
+                          </div>
+
+                          {/* Retrieved Contexts */}
+                          {result.contexts.length > 0 && (
+                            <div>
+                              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                Retrieved Contexts
+                              </p>
+                              <ul className="space-y-2">
+                                {result.contexts.map((ctx, ci) => (
+                                  <li
+                                    key={ci}
+                                    className="rounded-md bg-muted/30 px-3 py-2 text-sm text-gray-700"
+                                  >
+                                    {ctx}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+
+                          {/* Scores */}
+                          <div>
+                            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                              Scores
+                            </p>
+                            <div className="grid grid-cols-2 gap-2">
+                              {(
+                                [
+                                  ["Faithfulness", result.scores.faithfulness],
+                                  ["Relevancy", result.scores.answer_relevancy],
+                                  ["Precision", result.scores.context_precision],
+                                  ["Recall", result.scores.context_recall],
+                                ] as [string, number | null][]
+                              ).map(([label, val]) => (
+                                <div
+                                  key={label}
+                                  className="flex items-center justify-between rounded-md border border-gray-100 px-3 py-2"
+                                >
+                                  <span className="text-xs text-gray-600">
+                                    {label}
+                                  </span>
+                                  <span
+                                    className={`text-sm font-semibold ${scoreColorClass(val)}`}
+                                  >
+                                    {val !== null ? val.toFixed(2) : "N/A"}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/eval-api.ts
+++ b/frontend/src/lib/eval-api.ts
@@ -1,0 +1,158 @@
+import { refreshGoAccessToken } from "@/lib/go-auth";
+
+const EVAL_API_URL =
+  process.env.NEXT_PUBLIC_EVAL_API_URL || "http://localhost:8000/eval";
+
+async function evalFetch(
+  path: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  const headers = new Headers(options.headers);
+  if (!headers.has("Content-Type") && options.body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const res = await fetch(`${EVAL_API_URL}${path}`, {
+    ...options,
+    headers,
+    credentials: "include",
+  });
+
+  // Retry once on 401/403 after refreshing the httpOnly cookie
+  if (res.status === 401 || res.status === 403) {
+    const success = await refreshGoAccessToken();
+    if (success) {
+      return fetch(`${EVAL_API_URL}${path}`, {
+        ...options,
+        headers,
+        credentials: "include",
+      });
+    }
+  }
+
+  return res;
+}
+
+// --- Types ---
+
+export type GoldenItem = {
+  query: string;
+  expected_answer: string;
+  expected_sources: string[];
+};
+
+export type DatasetSummary = {
+  id: string;
+  name: string;
+  item_count: number;
+  created_at: string;
+};
+
+export type QueryScore = {
+  faithfulness: number | null;
+  answer_relevancy: number | null;
+  context_precision: number | null;
+  context_recall: number | null;
+};
+
+export type QueryResult = {
+  query: string;
+  answer: string;
+  contexts: string[];
+  scores: QueryScore;
+};
+
+export type EvaluationSummary = {
+  id: string;
+  dataset_id: string;
+  status: "running" | "completed" | "failed";
+  collection: string | null;
+  aggregate_scores: QueryScore | null;
+  created_at: string;
+  completed_at: string | null;
+};
+
+export type EvaluationDetail = EvaluationSummary & {
+  results: QueryResult[] | null;
+  error: string | null;
+};
+
+// --- API functions ---
+
+export async function getHealth(): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(`${EVAL_API_URL}/health`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function createDataset(
+  name: string,
+  items: GoldenItem[],
+): Promise<{ id: string }> {
+  const res = await evalFetch("/datasets", {
+    method: "POST",
+    body: JSON.stringify({ name, items }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create dataset: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function listDatasets(): Promise<DatasetSummary[]> {
+  const res = await evalFetch("/datasets");
+  if (!res.ok) {
+    throw new Error(`Failed to list datasets: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  return data.datasets ?? data;
+}
+
+export async function startEvaluation(
+  datasetId: string,
+  collection?: string,
+): Promise<{ id: string; status: string }> {
+  const body: Record<string, string> = { dataset_id: datasetId };
+  if (collection !== undefined) {
+    body.collection = collection;
+  }
+  const res = await evalFetch("/evaluations", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to start evaluation: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res.json();
+}
+
+export async function getEvaluation(id: string): Promise<EvaluationDetail> {
+  const res = await evalFetch(`/evaluations/${id}`);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to get evaluation: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res.json();
+}
+
+export async function listEvaluations(): Promise<EvaluationSummary[]> {
+  const res = await evalFetch("/evaluations");
+  if (!res.ok) {
+    throw new Error(
+      `Failed to list evaluations: ${res.status} ${res.statusText}`,
+    );
+  }
+  const data = await res.json();
+  return data.evaluations ?? data;
+}

--- a/k8s/ai-services/configmaps/eval-config.yml
+++ b/k8s/ai-services/configmaps/eval-config.yml
@@ -9,4 +9,4 @@ data:
   LLM_BASE_URL: http://ollama:11434
   LLM_MODEL: qwen2.5:14b
   DB_PATH: /app/data/eval.db
-  ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
+  ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev,https://qa.kylebradshaw.dev

--- a/services/eval/app/main.py
+++ b/services/eval/app/main.py
@@ -29,6 +29,7 @@ app = FastAPI(title="Eval API")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins.split(","),
+    allow_credentials=True,
     allow_methods=["GET", "POST"],
     allow_headers=["Authorization", "Content-Type"],
 )

--- a/services/shared/auth.py
+++ b/services/shared/auth.py
@@ -1,17 +1,21 @@
 """JWT authentication dependency for FastAPI services."""
 
 import jwt
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 _bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def create_auth_dependency(secret: str):
-    """Create a FastAPI dependency that validates JWT Bearer tokens.
+    """Create a FastAPI dependency that validates JWT Bearer tokens or cookies.
 
     When secret is empty, auth is disabled (all requests pass as anonymous).
     This allows compose-smoke CI tests to run without token generation.
+
+    Auth resolution order:
+    1. Authorization: Bearer <token> header (takes precedence)
+    2. access_token cookie (set by Go auth service as httpOnly cookie)
     """
     if not secret:
 
@@ -23,12 +27,22 @@ def create_auth_dependency(secret: str):
         return no_auth
 
     async def require_auth(
+        request: Request,
         credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
     ) -> str:
-        """Validate JWT and return userId."""
-        if credentials is None:
+        """Validate JWT from Bearer header or cookie and return userId."""
+        token: str | None = None
+
+        # Bearer header takes precedence over cookie
+        if credentials is not None:
+            token = credentials.credentials
+        else:
+            # Fall back to access_token cookie (set by Go auth service)
+            token = request.cookies.get("access_token")
+
+        if token is None:
             raise HTTPException(status_code=401, detail="Missing authorization")
-        token = credentials.credentials
+
         try:
             payload = jwt.decode(
                 token,

--- a/services/shared/tests/test_auth.py
+++ b/services/shared/tests/test_auth.py
@@ -1,0 +1,140 @@
+"""Tests for shared.auth JWT authentication dependency."""
+
+import time
+
+import jwt
+from fastapi import Depends, FastAPI
+from starlette.testclient import TestClient
+
+from shared.auth import create_auth_dependency
+
+SECRET = "test-secret"
+ALGORITHM = "HS256"
+
+
+def _make_token(secret: str, sub: str = "user-123", exp_offset: int = 3600) -> str:
+    """Helper to create a signed JWT token."""
+    payload = {
+        "sub": sub,
+        "email": "test@example.com",
+        "exp": int(time.time()) + exp_offset,
+    }
+    return jwt.encode(payload, secret, algorithm=ALGORITHM)
+
+
+def _make_app(secret: str) -> FastAPI:
+    """Create a minimal FastAPI app using the auth dependency."""
+    app = FastAPI()
+    auth_dep = create_auth_dependency(secret)
+
+    @app.get("/protected")
+    async def protected(user_id: str = Depends(auth_dep)):
+        return {"user_id": user_id}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Empty secret — anonymous access
+# ---------------------------------------------------------------------------
+
+
+def test_empty_secret_allows_anonymous():
+    """When secret is empty, all requests pass through as 'anonymous'."""
+    client = TestClient(_make_app(""))
+    resp = client.get("/protected")
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": "anonymous"}
+
+
+# ---------------------------------------------------------------------------
+# Bearer header — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_bearer_returns_user_id():
+    """Valid Bearer token returns the sub claim as user_id."""
+    token = _make_token(SECRET, sub="user-abc")
+    client = TestClient(_make_app(SECRET))
+    resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": "user-abc"}
+
+
+# ---------------------------------------------------------------------------
+# Bearer header — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_expired_bearer_returns_401():
+    """Expired Bearer token returns 401."""
+    token = _make_token(SECRET, exp_offset=-10)
+    client = TestClient(_make_app(SECRET))
+    resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_wrong_secret_bearer_returns_401():
+    """Bearer token signed with wrong secret returns 401."""
+    token = _make_token("wrong-secret")
+    client = TestClient(_make_app(SECRET))
+    resp = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Cookie — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_cookie_returns_user_id():
+    """Valid access_token cookie returns the sub claim as user_id."""
+    token = _make_token(SECRET, sub="cookie-user")
+    client = TestClient(_make_app(SECRET))
+    resp = client.get("/protected", cookies={"access_token": token})
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": "cookie-user"}
+
+
+# ---------------------------------------------------------------------------
+# Cookie — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_expired_cookie_returns_401():
+    """Expired access_token cookie returns 401."""
+    token = _make_token(SECRET, exp_offset=-10)
+    client = TestClient(_make_app(SECRET))
+    resp = client.get("/protected", cookies={"access_token": token})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# No auth at all
+# ---------------------------------------------------------------------------
+
+
+def test_no_auth_returns_401():
+    """Request with no Bearer header and no cookie returns 401."""
+    client = TestClient(_make_app(SECRET))
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Precedence: Bearer header takes priority over cookie
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_takes_precedence_over_cookie():
+    """When both Bearer and cookie are present, Bearer wins."""
+    bearer_token = _make_token(SECRET, sub="bearer-user")
+    cookie_token = _make_token(SECRET, sub="cookie-user")
+    client = TestClient(_make_app(SECRET))
+    resp = client.get(
+        "/protected",
+        headers={"Authorization": f"Bearer {bearer_token}"},
+        cookies={"access_token": cookie_token},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": "bearer-user"}


### PR DESCRIPTION
## Summary
- New `/ai/eval` page with tabbed interface (Datasets, Evaluate, Results) for managing golden datasets and running RAGAS evaluations
- Cross-service JWT authentication: Go auth service sets httpOnly cookies, Python eval service validates them via shared auth module
- Radial gauge scorecards for RAGAS metrics (faithfulness, relevancy, precision, recall) with expandable per-query breakdown
- Shared auth module updated to read JWT from `access_token` cookie alongside Bearer header
- CORS credentials enabled on eval service, JWT_SECRET wired in docker-compose and K8s config

Closes #83

## Test plan
- [x] Verify `/ai/eval` page builds and renders
- [ ] Verify HealthGate shows maintenance message when eval service is down
- [ ] Verify login prompt appears when not authenticated
- [ ] Verify dataset creation form validates JSON and creates datasets
- [ ] Verify evaluation polling shows spinner and completes
- [ ] Verify radial gauges render with correct colors
- [ ] Verify per-query breakdown expands/collapses
- [ ] Verify shared auth tests pass (header + cookie)
- [ ] No TypeScript or lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)