### PR TITLE
refactor(go): split main.go and extract shared helpers

### DIFF
--- a/docs/adr/gpu-ollama-monitoring.md
+++ b/docs/adr/gpu-ollama-monitoring.md
@@ -1,0 +1,76 @@
+# GPU & Ollama Monitoring with Telegram Alerts
+
+- **Date:** 2026-04-18
+- **Status:** Accepted
+
+## Context
+
+On 2026-04-18, the shopping assistant (Go ai-service) became unresponsive in production. Investigation revealed a silent failure chain:
+
+1. Debian auto-updated the kernel from 6.12.73 to 6.12.74
+2. Kernel headers weren't installed, so DKMS couldn't rebuild the NVIDIA module for the new kernel
+3. On next module load, the GPU driver failed — `/dev/nvidia*` devices disappeared
+4. Ollama silently fell back to 100% CPU inference
+5. The 14B model went from ~2s per response to ~45s, causing the agent loop to effectively hang (no tool calls, timeouts)
+
+There was no monitoring or alerting for any of these failure modes. The issue was only discovered through manual testing.
+
+The infrastructure runs on a single Debian server (RTX 3090) with Minikube (Docker driver), Prometheus, and Grafana already deployed. Ollama runs as a host systemd service, not in Kubernetes.
+
+## Decision
+
+### Prevention: Kernel headers meta-package
+
+Install `linux-headers-amd64` on the Debian host. This meta-package ensures that when `unattended-upgrades` installs a new kernel, the matching headers are pulled automatically, allowing DKMS to rebuild the NVIDIA module without manual intervention.
+
+### Prevention: Ollama keep-alive override
+
+Create a systemd override at `/etc/systemd/system/ollama.service.d/override.conf` setting `OLLAMA_KEEP_ALIVE=-1`. This keeps models loaded in GPU memory permanently, avoiding cold-start latency. The override file survives Ollama package updates (which may replace the main service file).
+
+### Detection: nvidia_gpu_exporter
+
+Install `nvidia_gpu_exporter` (v1.4.1, `.deb` package) as a host systemd service on port 9835. Prometheus already had a scrape target configured for this port from a previous Windows-based setup — no Prometheus config changes were needed for the exporter itself.
+
+An iptables rule was required to allow Minikube containers to reach the host on port 9835 (persisted via `iptables-persistent`). Ollama on port 11434 worked without this rule for reasons that remain unclear — both services bind to `0.0.0.0` identically.
+
+### Detection: Grafana alert rules with Telegram notifications
+
+Four Grafana-managed alert rules, provisioned declaratively via a ConfigMap mounted into `/etc/grafana/provisioning/alerting/`:
+
+| Alert | Condition | Severity | For |
+|-------|-----------|----------|-----|
+| GPU Exporter Down | `up{job="nvidia-gpu"} == 0` | critical | 2m |
+| AI Service Not Ready | `kube_pod_status_ready{pod=~"go-ai-service.*"} == 0` | critical | 3m |
+| GPU Temperature High | `nvidia_smi_temperature_gpu > 85` | warning | 5m |
+| GPU VRAM High | `nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes > 0.9` | warning | 10m |
+
+Notifications go to a Telegram bot via Grafana's native Telegram contact point.
+
+### Alternatives considered and rejected
+
+**AlertManager deployment.** Grafana's built-in alerting handles our single notification channel without needing a separate AlertManager pod. If we add more notification channels or complex routing, AlertManager would become worthwhile.
+
+**DCGM Exporter (NVIDIA's official tool).** Designed for data center GPU fleets with rich metrics (ECC errors, PCIe throughput, per-process usage). Overkill for a single-GPU dev server. Requires NVIDIA Container Toolkit and runs as a K8s DaemonSet with host device access. `nvidia_gpu_exporter` is a single binary wrapping `nvidia-smi` — simpler and sufficient.
+
+**Direct Ollama Prometheus scrape target.** We initially added an Ollama scrape job targeting `/api/tags`. This failed because Ollama 0.20.7 doesn't expose a `/metrics` endpoint — `/api/tags` returns JSON that Prometheus can't parse as metrics, causing the target to report `down` even when Ollama is healthy. We also tried `OLLAMA_METRICS=true` as an environment variable but the feature doesn't exist in this version.
+
+The Ollama health gap is covered indirectly: the ai-service readiness probe (`/ready`) checks Ollama connectivity by hitting `/api/tags` with a 2-second timeout. If Ollama is down, the probe fails, Kubernetes marks the pod not-ready, and the AI Service Not Ready alert fires.
+
+**Pushover / ntfy.sh for notifications.** Both are viable alternatives to Telegram. Pushover costs $5 one-time. ntfy.sh is free and self-hostable. Telegram was chosen because Grafana has native support (built-in contact point type, no webhook plumbing) and Kyle already uses messaging apps.
+
+**Environment variable / secret-based Telegram credentials.** We tried both `$__file{}` (file-based secret mount) and `$__env{}` (environment variable) for the Telegram chat ID. Both failed because Grafana's provisioning YAML parser unmarshals the all-numeric chat ID as a JSON number, but the Telegram integration expects a string. The credentials are inlined in the ConfigMap — the bot token can only send messages to Kyle's chat, so the security impact is minimal.
+
+## Consequences
+
+**Positive:**
+- Today's exact failure scenario (kernel update → GPU driver loss → CPU fallback) would now trigger the GPU Exporter Down alert within 2 minutes
+- Ollama going down triggers AI Service Not Ready within 3 minutes via the readiness probe chain
+- Kernel header auto-install prevents the root cause from recurring
+- Models stay permanently loaded in GPU memory, eliminating cold-start latency
+- All alerting config is declarative (ConfigMaps), versioned in git, and survives pod restarts
+
+**Trade-offs:**
+- Telegram bot token is stored in plaintext in a ConfigMap (git-tracked). Acceptable risk given the token's limited capability, but should be revisited if the repo goes public.
+- No direct Ollama health metric — detection is indirect through the ai-service readiness probe, adding ~1 minute of latency to Ollama-down detection.
+- The iptables rule for port 9835 is a manual host-level dependency outside of version control. Documented in the plan but could drift.
+- `OLLAMA_KEEP_ALIVE=-1` means models never unload, consuming ~17GB VRAM permanently. Fine for a dedicated inference server, but would need adjustment if other GPU workloads are added.

--- a/docs/superpowers/plans/2026-04-18-gpu-ollama-monitoring.md
+++ b/docs/superpowers/plans/2026-04-18-gpu-ollama-monitoring.md
@@ -1,0 +1,681 @@
+# GPU & Ollama Monitoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add alerting for GPU, Ollama, and ai-service failures so Kyle gets a Telegram notification when infrastructure degrades.
+
+**Architecture:** Prometheus scrapes a new Ollama target and the existing GPU exporter. Grafana evaluates alert rules against Prometheus queries and sends notifications via a provisioned Telegram contact point. Host-level systemd services (Ollama override, nvidia_gpu_exporter) are configured manually via SSH.
+
+**Tech Stack:** Prometheus, Grafana (provisioned alerting), Telegram Bot API, nvidia_gpu_exporter, systemd
+
+---
+
+### Task 1: Install kernel headers meta-package (manual — Debian server)
+
+This prevents a repeat of the root cause: kernel updates without matching headers break DKMS NVIDIA module rebuilds.
+
+**Files:** None (host-level change)
+
+- [ ] **Step 1: SSH into Debian and install the meta-package**
+
+```bash
+ssh debian
+sudo apt install linux-headers-amd64
+```
+
+Expected: Package installs (may already be installed from today's fix). This meta-package ensures future kernel upgrades automatically pull matching headers.
+
+- [ ] **Step 2: Verify DKMS is healthy**
+
+```bash
+sudo dkms status
+```
+
+Expected: Output shows `nvidia-current` built for the current kernel `6.12.74+deb13+1-amd64`.
+
+---
+
+### Task 2: Create Ollama keep-alive systemd override (manual — Debian server)
+
+Models must stay loaded in GPU memory permanently. Without this, Ollama unloads models after 5 minutes of inactivity.
+
+**Files:** None (host-level change)
+
+- [ ] **Step 1: Create the override file**
+
+```bash
+sudo systemctl edit ollama
+```
+
+In the editor that opens, paste exactly:
+
+```ini
+[Service]
+Environment=OLLAMA_KEEP_ALIVE=-1
+```
+
+Save and exit.
+
+- [ ] **Step 2: Reload and restart Ollama**
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+```
+
+- [ ] **Step 3: Verify models are loaded with Forever keep-alive**
+
+```bash
+# Warm up the models first
+curl -s -X POST http://localhost:11434/api/generate -d '{"model":"qwen2.5:14b","prompt":"hi","stream":false}' > /dev/null
+curl -s -X POST http://localhost:11434/api/embeddings -d '{"model":"nomic-embed-text","prompt":"hi"}' > /dev/null
+
+# Check they're loaded on GPU with Forever keep-alive
+ollama ps
+```
+
+Expected:
+```
+NAME                       ID              SIZE      PROCESSOR    CONTEXT    UNTIL
+qwen2.5:14b                ...             17 GB     100% GPU     32768      Forever
+nomic-embed-text:latest    ...             565 MB    100% GPU     2048       Forever
+```
+
+- [ ] **Step 4: Verify override persists**
+
+```bash
+cat /etc/systemd/system/ollama.service.d/override.conf
+```
+
+Expected:
+```ini
+[Service]
+Environment=OLLAMA_KEEP_ALIVE=-1
+```
+
+---
+
+### Task 3: Install nvidia_gpu_exporter (manual — Debian server)
+
+Prometheus already scrapes `host.minikube.internal:9835` but nothing is listening. This installs the exporter.
+
+**Files:** None (host-level change)
+
+- [ ] **Step 1: Download the binary**
+
+```bash
+# Check latest release at https://github.com/utkuozdemir/nvidia_gpu_exporter/releases
+# As of writing, v1.2.1 is latest
+cd /tmp
+curl -LO https://github.com/utkuozdemir/nvidia_gpu_exporter/releases/download/v1.2.1/nvidia_gpu_exporter_1.2.1_linux_amd64.tar.gz
+tar xzf nvidia_gpu_exporter_1.2.1_linux_amd64.tar.gz
+sudo mv nvidia_gpu_exporter /usr/local/bin/
+sudo chmod +x /usr/local/bin/nvidia_gpu_exporter
+```
+
+- [ ] **Step 2: Create a dedicated user**
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin nvidia-exporter
+```
+
+- [ ] **Step 3: Create the systemd service**
+
+```bash
+sudo tee /etc/systemd/system/nvidia_gpu_exporter.service > /dev/null << 'EOF'
+[Unit]
+Description=NVIDIA GPU Exporter for Prometheus
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/nvidia_gpu_exporter
+User=nvidia-exporter
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+```
+
+- [ ] **Step 4: Enable and start the service**
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable nvidia_gpu_exporter
+sudo systemctl start nvidia_gpu_exporter
+```
+
+- [ ] **Step 5: Verify the exporter is serving metrics**
+
+```bash
+curl -s http://localhost:9835/metrics | head -20
+```
+
+Expected: Prometheus-format metrics including `nvidia_smi_temperature_gpu`, `nvidia_smi_utilization_gpu_ratio`, `nvidia_smi_memory_used_bytes`, etc.
+
+- [ ] **Step 6: Verify Prometheus can scrape it from inside Minikube**
+
+```bash
+# From the host, check the minikube-internal route
+curl -s http://$(minikube ip):9835/metrics 2>/dev/null | head -5 || echo "Direct IP won't work — checking via Prometheus targets"
+
+# Check Prometheus targets page
+kubectl exec -n monitoring deploy/prometheus -- wget -qO- 'http://localhost:9090/api/v1/targets' 2>/dev/null | python3 -m json.tool | grep -A5 '"nvidia-gpu"'
+```
+
+Expected: Target `nvidia-gpu` shows `health: "up"`.
+
+---
+
+### Task 4: Add Ollama scrape target to Prometheus ConfigMap
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/prometheus-config.yml:22-23`
+
+- [ ] **Step 1: Add the ollama scrape job**
+
+In `k8s/monitoring/configmaps/prometheus-config.yml`, add a new job after the `nvidia-gpu` job (after line 23):
+
+```yaml
+      - job_name: "ollama"
+        metrics_path: /api/tags
+        scrape_interval: 30s
+        static_configs:
+          - targets: ["host.minikube.internal:11434"]
+```
+
+The `metrics_path: /api/tags` is used because Ollama doesn't expose `/metrics`. Prometheus will still record `up{job="ollama"}` based on whether the HTTP request succeeds. The `scrape_interval: 30s` is slightly longer than default since this is just a health check, not real metrics.
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('k8s/monitoring/configmaps/prometheus-config.yml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/prometheus-config.yml
+git commit -m "feat(monitoring): add Ollama scrape target to Prometheus"
+```
+
+---
+
+### Task 5: Create Telegram bot (manual — Kyle's phone)
+
+**Files:** None
+
+- [ ] **Step 1: Create the bot**
+
+1. Open Telegram and search for `@BotFather`
+2. Send `/newbot`
+3. Name: `Portfolio Alerts` (or whatever you prefer)
+4. Username: `kylebradshaw_alerts_bot` (must be unique, end in `bot`)
+5. Save the **bot token** (looks like `123456789:ABCdefGHIjklMNOpqrSTUvwxYZ`)
+
+- [ ] **Step 2: Get your chat ID**
+
+1. Send any message to your new bot in Telegram
+2. Open this URL in a browser (replace `<TOKEN>` with your bot token):
+   ```
+   https://api.telegram.org/bot<TOKEN>/getUpdates
+   ```
+3. Find the `"chat":{"id": 123456789}` value in the response — that's your chat ID
+
+- [ ] **Step 3: Test the bot sends messages**
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot<TOKEN>/sendMessage" \
+  -d "chat_id=<CHAT_ID>" \
+  -d "text=🔔 Test alert from Portfolio Monitoring"
+```
+
+Expected: You receive the message on your phone.
+
+- [ ] **Step 4: Store credentials in a K8s secret**
+
+```bash
+ssh debian "kubectl create secret generic telegram-bot \
+  --namespace=monitoring \
+  --from-literal=bot-token='<TOKEN>' \
+  --from-literal=chat-id='<CHAT_ID>' \
+  --dry-run=client -o yaml | kubectl apply -f -"
+```
+
+---
+
+### Task 6: Create Grafana alerting provisioning ConfigMap
+
+Grafana supports provisioning alert rules, contact points, and notification policies via YAML files mounted into `/etc/grafana/provisioning/alerting/`. This is the declarative equivalent of configuring alerts through the UI.
+
+**Files:**
+- Create: `k8s/monitoring/configmaps/grafana-alerting.yml`
+
+- [ ] **Step 1: Create the alerting provisioning ConfigMap**
+
+Create `k8s/monitoring/configmaps/grafana-alerting.yml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting
+  namespace: monitoring
+data:
+  alerting.yml: |
+    apiVersion: 1
+
+    contactPoints:
+      - orgId: 1
+        name: telegram
+        receivers:
+          - uid: telegram-default
+            type: telegram
+            settings:
+              bottoken: $__file{/etc/grafana/secrets/bot-token}
+              chatid: $__file{/etc/grafana/secrets/chat-id}
+            disableResolveMessage: false
+
+    policies:
+      - orgId: 1
+        receiver: telegram
+        group_by:
+          - grafana_folder
+          - alertname
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+
+    groups:
+      - orgId: 1
+        name: Infrastructure
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: gpu-exporter-down
+            title: GPU Exporter Down
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: up{job="nvidia-gpu"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: lt
+                        params:
+                          - 1
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "GPU exporter is unreachable — NVIDIA GPU may be down or driver unloaded"
+
+          - uid: ollama-down
+            title: Ollama Down
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: up{job="ollama"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: lt
+                        params:
+                          - 1
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Ollama is not responding — AI services will be degraded"
+
+          - uid: ai-service-not-ready
+            title: AI Service Not Ready
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: kube_pod_status_ready{pod=~"go-ai-service.*", condition="true"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: lt
+                        params:
+                          - 1
+                  refId: C
+            for: 3m
+            labels:
+              severity: critical
+            annotations:
+              summary: "go-ai-service pod is not ready — shopping assistant is down"
+
+          - uid: gpu-temperature-high
+            title: GPU Temperature High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: nvidia_smi_temperature_gpu
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 85
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "GPU temperature is above 85°C"
+
+          - uid: gpu-vram-high
+            title: GPU VRAM Usage High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0.9
+                  refId: C
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "GPU VRAM usage is above 90%"
+```
+
+**Note on the datasourceUid:** Grafana provisioned datasources use the `name` field as UID by default. The existing datasource is named `Prometheus`. We need to verify this matches. If Grafana assigns a different UID, we'll update the alert rules to use the correct one. Check with:
+
+```bash
+ssh debian "kubectl exec -n monitoring deploy/grafana -- curl -s http://localhost:3000/api/datasources 2>/dev/null" | python3 -m json.tool
+```
+
+If the UID is not `prometheus`, update every `datasourceUid: prometheus` in the ConfigMap to match.
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('k8s/monitoring/configmaps/grafana-alerting.yml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-alerting.yml
+git commit -m "feat(monitoring): add Grafana alerting provisioning with Telegram contact point"
+```
+
+---
+
+### Task 7: Mount alerting ConfigMap and secrets in Grafana deployment
+
+**Files:**
+- Modify: `k8s/monitoring/deployments/grafana.yml`
+- Modify: `k8s/monitoring/kustomization.yaml`
+
+- [ ] **Step 1: Add the alerting volume mount and secret mount to the Grafana deployment**
+
+In `k8s/monitoring/deployments/grafana.yml`, add to the `volumeMounts` section (after the dashboards mount, line 42):
+
+```yaml
+            - name: alerting
+              mountPath: /etc/grafana/provisioning/alerting/alerting.yml
+              subPath: alerting.yml
+            - name: telegram-secret
+              mountPath: /etc/grafana/secrets
+              readOnly: true
+```
+
+Add to the `volumes` section (after the dashboards volume, line 65):
+
+```yaml
+        - name: alerting
+          configMap:
+            name: grafana-alerting
+        - name: telegram-secret
+          secret:
+            secretName: telegram-bot
+```
+
+Also add an env var to enable Grafana's unified alerting (it's on by default in recent versions, but let's be explicit):
+
+```yaml
+            - name: GF_UNIFIED_ALERTING_ENABLED
+              value: "true"
+```
+
+- [ ] **Step 2: Add the alerting ConfigMap to kustomization.yaml**
+
+In `k8s/monitoring/kustomization.yaml`, add after line 14 (`configmaps/grafana-datasource.yml`):
+
+```yaml
+  - configmaps/grafana-alerting.yml
+```
+
+- [ ] **Step 3: Validate YAML for both files**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('k8s/monitoring/deployments/grafana.yml'))" && echo "grafana.yml valid"
+python3 -c "import yaml; yaml.safe_load(open('k8s/monitoring/kustomization.yaml'))" && echo "kustomization.yaml valid"
+```
+
+Expected: Both valid.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k8s/monitoring/deployments/grafana.yml k8s/monitoring/kustomization.yaml
+git commit -m "feat(monitoring): mount alerting provisioning and Telegram secret in Grafana"
+```
+
+---
+
+### Task 8: Deploy and verify
+
+**Files:** None (deployment commands)
+
+- [ ] **Step 1: Deploy the monitoring stack**
+
+```bash
+ssh debian "cd ~/repos/gen_ai_engineer && git pull && kubectl apply -k k8s/monitoring"
+```
+
+Expected: ConfigMaps updated, Grafana deployment updated (triggers pod restart).
+
+- [ ] **Step 2: Wait for Grafana to restart**
+
+```bash
+ssh debian "kubectl rollout status deployment/grafana -n monitoring --timeout=120s"
+```
+
+Expected: `deployment "grafana" successfully rolled out`
+
+- [ ] **Step 3: Verify Prometheus targets**
+
+```bash
+ssh debian "kubectl exec -n monitoring deploy/prometheus -- wget -qO- 'http://localhost:9090/api/v1/targets' 2>/dev/null" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for t in data['data']['activeTargets']:
+    print(f\"{t['labels'].get('job', 'unknown'):20s} {t['health']:6s} {t['lastError'] or 'OK'}\")
+"
+```
+
+Expected: Both `nvidia-gpu` and `ollama` targets show `up` health.
+
+- [ ] **Step 4: Verify Grafana alert rules are loaded**
+
+```bash
+ssh debian "kubectl exec -n monitoring deploy/grafana -- curl -s http://localhost:3000/api/v1/provisioning/alert-rules 2>/dev/null" | python3 -c "
+import json, sys
+rules = json.load(sys.stdin)
+for r in rules:
+    print(f\"{r['title']:30s} uid={r['uid']}\")
+"
+```
+
+Expected: All 5 alert rules listed (GPU Exporter Down, Ollama Down, AI Service Not Ready, GPU Temperature High, GPU VRAM Usage High).
+
+- [ ] **Step 5: Verify Telegram contact point**
+
+```bash
+ssh debian "kubectl exec -n monitoring deploy/grafana -- curl -s http://localhost:3000/api/v1/provisioning/contact-points 2>/dev/null" | python3 -m json.tool
+```
+
+Expected: `telegram` contact point listed with type `telegram`.
+
+- [ ] **Step 6: Send a test notification**
+
+```bash
+ssh debian "kubectl exec -n monitoring deploy/grafana -- curl -s -X POST http://localhost:3000/api/v1/provisioning/contact-points/telegram-default/test 2>/dev/null"
+```
+
+If this endpoint isn't available, test by temporarily stopping the GPU exporter to trigger the GPUExporterDown alert:
+
+```bash
+ssh debian "sudo systemctl stop nvidia_gpu_exporter"
+# Wait ~3 minutes for the alert to fire
+# Check your Telegram — you should receive a notification
+# Then restart it:
+ssh debian "sudo systemctl start nvidia_gpu_exporter"
+```
+
+- [ ] **Step 7: Commit any adjustments and push**
+
+If any datasource UIDs, metric names, or config needed adjustment during verification:
+
+```bash
+git add -A
+git commit -m "fix(monitoring): adjust alerting config after deployment verification"
+git push
+```

--- a/docs/superpowers/plans/2026-04-18-gpu-ollama-monitoring.md
+++ b/docs/superpowers/plans/2026-04-18-gpu-ollama-monitoring.md
@@ -107,8 +107,8 @@ Prometheus already scrapes `host.minikube.internal:9835` but nothing is listenin
 # Check latest release at https://github.com/utkuozdemir/nvidia_gpu_exporter/releases
 # As of writing, v1.2.1 is latest
 cd /tmp
-curl -LO https://github.com/utkuozdemir/nvidia_gpu_exporter/releases/download/v1.2.1/nvidia_gpu_exporter_1.2.1_linux_amd64.tar.gz
-tar xzf nvidia_gpu_exporter_1.2.1_linux_amd64.tar.gz
+curl -LO https://github.com/utkuozdemir/nvidia_gpu_exporter/releases/download/v1.4.1/nvidia_gpu_exporter_1.4.1_linux_amd64.tar.gz
+tar xzf nvidia_gpu_exporter_1.4.1_linux_amd64.tar.gz
 sudo mv nvidia_gpu_exporter /usr/local/bin/
 sudo chmod +x /usr/local/bin/nvidia_gpu_exporter
 ```

--- a/docs/superpowers/specs/2026-04-18-gpu-ollama-monitoring-design.md
+++ b/docs/superpowers/specs/2026-04-18-gpu-ollama-monitoring-design.md
@@ -117,8 +117,8 @@ We'll use provisioning: add a `grafana-alerting.yml` ConfigMap with the contact 
 | GPUExporterDown | `up{job="nvidia-gpu"} == 0` | critical | 2m | GPU exporter unreachable — GPU may be down |
 | OllamaDown | `up{job="ollama"} == 0` | critical | 2m | Ollama not responding to health checks |
 | AIServiceNotReady | `kube_pod_status_ready{pod=~"go-ai-service.*", condition="true"} == 0` | critical | 3m | AI service pod not ready |
-| GPUTemperatureHigh | `nvidia_gpu_temperature_celsius > 85` | warning | 5m | GPU running hot |
-| GPUVRAMHigh | `(nvidia_gpu_vram_used_bytes / nvidia_gpu_vram_total_bytes) > 0.9` | warning | 10m | GPU memory nearly full |
+| GPUTemperatureHigh | `nvidia_smi_temperature_gpu > 85` | warning | 5m | GPU running hot |
+| GPUVRAMHigh | `(nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes) > 0.9` | warning | 10m | GPU memory nearly full |
 
 **OllamaCPUFallback detection:** The GPU exporter going down while Ollama stays up is the signal for CPU fallback (exactly today's scenario). The GPUExporterDown alert covers this case. If we want an explicit "Ollama on CPU" alert, we could add a simple script that checks `ollama ps` output — but the GPU exporter down alert is sufficient for now.
 

--- a/docs/superpowers/specs/2026-04-18-gpu-ollama-monitoring-design.md
+++ b/docs/superpowers/specs/2026-04-18-gpu-ollama-monitoring-design.md
@@ -1,0 +1,160 @@
+# GPU & Ollama Monitoring with Telegram Alerts
+
+**Date:** 2026-04-18
+**Status:** Draft
+**Trigger:** Production incident — NVIDIA kernel module not rebuilt after kernel update, Ollama fell back to CPU silently, shopping assistant became unresponsive (~45s per request instead of ~2s).
+
+## Problem
+
+There is no alerting when the GPU becomes unavailable or when Ollama degrades. Today's incident went unnoticed until a manual test revealed the shopping assistant was non-functional. The root cause chain was:
+
+1. Debian kernel auto-updated from 6.12.73 → 6.12.74
+2. Kernel headers weren't installed, so DKMS couldn't rebuild the NVIDIA module
+3. Ollama silently fell back to 100% CPU
+4. The 14B model became too slow for the agent loop (~45s per turn, no tool calls)
+
+## Scope
+
+Six components, all additive — no changes to existing application code or dashboards.
+
+## Component 1: Ollama Keep-Alive Override
+
+**What:** Systemd override file at `/etc/systemd/system/ollama.service.d/override.conf` that sets `OLLAMA_KEEP_ALIVE=-1`.
+
+**Why:** Models must stay loaded in GPU memory permanently. Without this, models unload after 5 minutes of inactivity (Ollama default), causing cold-start latency on the next request. The override survives both Ollama restarts and package updates — the main service file may be replaced by upgrades, but the override directory is never touched.
+
+**Config:**
+```ini
+[Service]
+Environment=OLLAMA_KEEP_ALIVE=-1
+```
+
+**Commands:**
+```bash
+sudo systemctl edit ollama   # creates override.conf
+# paste the [Service] block above
+sudo systemctl daemon-reload
+sudo systemctl restart ollama
+```
+
+## Component 2: nvidia_gpu_exporter on Debian
+
+**What:** Install the `nvidia_gpu_exporter` binary on the Debian host, run as a systemd service on port 9835.
+
+**Why:** Prometheus already has an `nvidia-gpu` scrape job targeting `host.minikube.internal:9835`, but nothing is listening there. The exporter was previously set up on the Windows host — now it needs to run on Debian where the GPU lives.
+
+**Details:**
+- Download the linux-amd64 binary from the [nvidia_gpu_exporter GitHub releases](https://github.com/utkuozdemir/nvidia_gpu_exporter/releases)
+- Install to `/usr/local/bin/nvidia_gpu_exporter`
+- Systemd unit: `/etc/systemd/system/nvidia_gpu_exporter.service`
+- Runs as a dedicated `nvidia-exporter` user (no root needed, just access to `nvidia-smi`)
+- Exports: GPU utilization %, VRAM used/total, temperature, power draw, fan speed
+- Port 9835 matches existing Prometheus scrape config — no Prometheus changes needed
+
+**Systemd unit:**
+```ini
+[Unit]
+Description=NVIDIA GPU Exporter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/nvidia_gpu_exporter
+User=nvidia-exporter
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Component 3: Kernel Header Auto-Install
+
+**What:** Install the `linux-headers-amd64` meta-package on the Debian host.
+
+**Why:** This meta-package automatically pulls in headers matching the current kernel. When `unattended-upgrades` or `apt upgrade` installs a new kernel, the matching headers come with it, and DKMS rebuilds the NVIDIA module automatically. This is the direct fix for today's root cause.
+
+**Command:**
+```bash
+sudo apt install linux-headers-amd64
+```
+
+**Verification:** After next kernel update, check `ls /lib/modules/$(uname -r)/updates/dkms/` for `nvidia-current.ko*`.
+
+## Component 4: Telegram Bot + Grafana Contact Point
+
+**What:** Create a Telegram bot and configure it as a Grafana alert notification channel.
+
+**Why:** Push notifications to Kyle's phone when critical infrastructure fails. Telegram is free, Grafana has native Telegram integration (built-in contact point type), and the notification experience is equivalent to SMS/WhatsApp.
+
+**Setup steps:**
+1. Message @BotFather on Telegram → `/newbot` → name it (e.g., "Portfolio Alerts")
+2. Save the bot token
+3. Create a Telegram group or use direct messages — get the chat ID via `https://api.telegram.org/bot<token>/getUpdates` after sending the bot a message
+4. In Grafana → Alerting → Contact Points → New → Telegram:
+   - Bot token: `<from BotFather>`
+   - Chat ID: `<from step 3>`
+5. Set as default contact point for all alert rules
+
+**Note:** Grafana is configured with anonymous access (viewer role) and login disabled. To configure alerting, we'll need to either:
+- Temporarily enable admin login, or
+- Configure the contact point via Grafana provisioning (ConfigMap) — this is the preferred approach since it's declarative and survives pod restarts
+
+We'll use provisioning: add a `grafana-alerting.yml` ConfigMap with the contact point and notification policy, mounted into the Grafana pod.
+
+## Component 5: Prometheus Alert Rules
+
+**What:** Add alerting rules to the Prometheus ConfigMap and configure Prometheus to evaluate them. Alerts fire to Grafana via its Prometheus datasource (Grafana evaluates alert rules against Prometheus queries).
+
+**Why:** Detect GPU, Ollama, and ai-service failures automatically.
+
+**Approach:** Use Grafana-managed alerts (not Prometheus Alertmanager). Grafana queries Prometheus and evaluates alert conditions on its own schedule. This avoids deploying Alertmanager — simpler for a single notification channel.
+
+**Alert rules (configured in Grafana provisioning):**
+
+| Alert | PromQL | Severity | For | Description |
+|-------|--------|----------|-----|-------------|
+| GPUExporterDown | `up{job="nvidia-gpu"} == 0` | critical | 2m | GPU exporter unreachable — GPU may be down |
+| OllamaDown | `up{job="ollama"} == 0` | critical | 2m | Ollama not responding to health checks |
+| AIServiceNotReady | `kube_pod_status_ready{pod=~"go-ai-service.*", condition="true"} == 0` | critical | 3m | AI service pod not ready |
+| GPUTemperatureHigh | `nvidia_gpu_temperature_celsius > 85` | warning | 5m | GPU running hot |
+| GPUVRAMHigh | `(nvidia_gpu_vram_used_bytes / nvidia_gpu_vram_total_bytes) > 0.9` | warning | 10m | GPU memory nearly full |
+
+**OllamaCPUFallback detection:** The GPU exporter going down while Ollama stays up is the signal for CPU fallback (exactly today's scenario). The GPUExporterDown alert covers this case. If we want an explicit "Ollama on CPU" alert, we could add a simple script that checks `ollama ps` output — but the GPU exporter down alert is sufficient for now.
+
+## Component 6: Ollama Prometheus Scrape Target
+
+**What:** Add an `ollama` job to the Prometheus ConfigMap scraping `host.minikube.internal:11434`.
+
+**Why:** Gives us the `up{job="ollama"}` metric for the OllamaDown alert. Ollama doesn't expose a `/metrics` endpoint, but Prometheus still records target health (`up` metric) from any HTTP endpoint. We'll use `/api/tags` as the health check path (returns 200 with the model list).
+
+**Addition to prometheus-config ConfigMap:**
+```yaml
+- job_name: "ollama"
+  metrics_path: /api/tags
+  static_configs:
+    - targets: ["host.minikube.internal:11434"]
+```
+
+## Out of Scope
+
+- **Grafana dashboard changes** — existing panels already cover GPU and Ollama metrics
+- **Alertmanager deployment** — Grafana's built-in alerting handles this directly
+- **Jaeger fix** — ImagePullBackOff is a separate issue (explains OTel trace export errors in ai-service logs)
+- **Kafka CrashLoopBackOff** — observed during investigation, separate issue
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `k8s/monitoring/configmaps/prometheus-config.yml` | Add `ollama` scrape job |
+| `k8s/monitoring/configmaps/grafana-alerting.yml` | New — alert rules, contact point, notification policy provisioning |
+| `k8s/monitoring/deployments/grafana.yml` | Mount alerting provisioning ConfigMap |
+
+## Manual Steps (Debian server, requires sudo)
+
+1. Install `linux-headers-amd64`
+2. Create Ollama systemd override with `OLLAMA_KEEP_ALIVE=-1`
+3. Download and install `nvidia_gpu_exporter` binary + systemd service
+4. Create Telegram bot and record token + chat ID
+5. Add bot token and chat ID to a Kubernetes secret for Grafana provisioning

--- a/docs/superpowers/specs/2026-04-19-go-services-readability-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-19-go-services-readability-refactor-design.md
@@ -1,0 +1,101 @@
+# Go Services Readability Refactor
+
+## Context
+
+Kyle is applying for Go developer roles and wants the Go services in this portfolio to reflect professional-quality code. The exploration revealed a consistent pattern across all four services: bloated `cmd/server/main.go` files mixing configuration, dependency wiring, middleware, route registration, and server lifecycle. Secondary issues include duplicated business logic in internal packages. This refactor is purely structural — no behavior changes, no new features.
+
+## Scope
+
+All four Go services: **ai-service**, **auth-service**, **ecommerce-service**, **analytics-service**.
+
+Two levels of changes:
+1. **Main.go splits** — break god files into focused files in `cmd/server/`
+2. **Major duplication fixes** — extract helpers for the worst repeated patterns in internal packages
+
+### Out of Scope
+
+- Test refactoring (table-driven conversions, test helpers)
+- LLM client refactoring in ai-service (anthropic/openai/ollama providers)
+- Agent loop refactoring in ai-service (`agent.go` Run method)
+- Idempotency middleware in ecommerce-service
+- Tool definition boilerplate in ai-service (catalog.go, orders.go, etc.)
+
+---
+
+## Changes by Service
+
+### 1. ai-service (current main.go: 344 lines)
+
+**Main.go split** — `cmd/server/`:
+
+| File | Contents |
+|------|----------|
+| `config.go` | `Config` struct, `loadConfig()` from env vars, `newCircuitBreaker(name)` factory |
+| `routes.go` | Router setup, middleware chain, route registration, `registerTools()` (shared by HTTP and MCP paths) |
+| `main.go` | Entry point: load config → wire dependencies → start server (~60-80 lines) |
+
+**Internal fixes:**
+- Move inline CORS middleware from main.go to `internal/http/middleware.go`
+- Consolidate duplicate tool registration (HTTP path lines 139-159 and MCP stdio path lines 285-293) into single `registerTools()` function in `routes.go`
+- Extract circuit breaker factory — 4 identical `gobreaker.NewCircuitBreaker()` calls become `newCircuitBreaker(name string)`
+
+**Files modified:** `cmd/server/main.go` (split into 3), `internal/http/middleware.go` (new or extended)
+
+### 2. auth-service (current main.go: 201 lines)
+
+**Main.go split** — `cmd/server/`:
+
+| File | Contents |
+|------|----------|
+| `config.go` | `Config` struct, `loadConfig()` from env vars |
+| `routes.go` | Router setup, middleware chain, route registration |
+| `main.go` | Entry point (~50-60 lines) |
+
+**Internal fixes:**
+- **handler/auth.go:** Extract `setAuthCookies(w, accessToken, refreshToken, sameSite)` and `clearAuthCookies(w, sameSite)` helpers — eliminates 3x cookie-setting duplication across Register, Login, GoogleLogin, Logout handlers
+- **service/auth.go:** Extract duplicated access/refresh JWT claim-building in `generateTokens()` into a shared claim builder
+
+**Files modified:** `cmd/server/main.go` (split into 3), `internal/handler/auth.go`, `internal/service/auth.go`
+
+### 3. ecommerce-service (current main.go: 267 lines)
+
+**Main.go split** — `cmd/server/`:
+
+| File | Contents |
+|------|----------|
+| `config.go` | `Config` struct, `loadConfig()` from env vars |
+| `routes.go` | Router setup, middleware chain, route registration |
+| `main.go` | Entry point + `rabbitPublisher` type (currently defined inline, stays in cmd/server/) (~60-80 lines) |
+
+**Internal fixes:**
+- **repository/product.go (311 lines):** Extract shared `sortConfig` builder function and `buildWhereClause()` from duplicated cursor/offset pagination implementations (~50 lines of duplication eliminated)
+- **service/product.go (150 lines):** Extract generic `getFromCache[T]()` and `setInCache[T]()` helpers to replace 3x repeated cache-aside pattern (reduces file to ~80-90 lines)
+- Move inline CORS middleware from main.go to `internal/middleware/` (already has middleware package)
+
+**Files modified:** `cmd/server/main.go` (split into 3), `internal/repository/product.go`, `internal/service/product.go`
+
+### 4. analytics-service (current main.go: 139 lines)
+
+**Main.go split** — `cmd/server/`:
+
+| File | Contents |
+|------|----------|
+| `config.go` | `Config` struct, `loadConfig()` from env vars |
+| `routes.go` | Router setup, middleware chain, route registration |
+| `main.go` | Entry point (~40-50 lines) |
+
+**Internal fixes:**
+- **consumer/consumer.go (169 lines):** Extract per-type message handlers (`handleOrder`, `handleCart`, `handleView`) to reduce mixed concerns
+- Move inline `corsMiddleware()` (23 lines) from main.go to a middleware location
+- **metrics/prometheus.go:** Wire up the unused `EventsConsumed` and `AggregationLatency` metrics into `consumer.go` (instrument Kafka event processing and aggregation timing)
+
+**Files modified:** `cmd/server/main.go` (split into 3), `internal/consumer/consumer.go`, `internal/metrics/prometheus.go`
+
+---
+
+## Verification
+
+1. `make preflight-go` — all lint checks and tests pass for all four services
+2. No public API changes — all HTTP endpoints, request/response formats unchanged
+3. Each new file has a clear single purpose and is under 150 lines
+4. Each `main.go` is under 80 lines after the split

--- a/go/ai-service/cmd/server/config.go
+++ b/go/ai-service/cmd/server/config.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
+	"github.com/sony/gobreaker/v2"
+)
+
+// Config holds all environment-based configuration for the ai-service.
+type Config struct {
+	Port            string
+	OllamaURL       string
+	OllamaModel     string
+	EcommerceURL    string
+	RAGChatURL      string
+	RAGIngestionURL string
+	RedisURL        string
+	JWTSecret       string
+	LLMProvider     string
+	LLMAPIKey       string
+	LLMBaseURL      string
+	AllowedOrigins  string
+	KafkaBrokers    string
+	MCPServersJSON  string
+	OTELEndpoint    string
+}
+
+// loadConfig reads environment variables and returns a populated Config.
+// Fatals if required values (JWT_SECRET) are missing.
+func loadConfig() Config {
+	ollamaURL := getenv("OLLAMA_URL", "http://ollama:11434")
+	llmProvider := getenv("LLM_PROVIDER", "ollama")
+
+	var llmBaseURL string
+	if llmProvider == "ollama" {
+		llmBaseURL = ollamaURL
+	} else {
+		llmBaseURL = getenv("LLM_BASE_URL", "")
+	}
+
+	jwtSecret := os.Getenv("JWT_SECRET")
+	if jwtSecret == "" {
+		log.Fatal("JWT_SECRET is required")
+	}
+
+	return Config{
+		Port:            getenv("PORT", "8093"),
+		OllamaURL:       ollamaURL,
+		OllamaModel:     getenv("OLLAMA_MODEL", "qwen2.5:14b"),
+		EcommerceURL:    getenv("ECOMMERCE_URL", "http://ecommerce-service:8092"),
+		RAGChatURL:      getenv("RAG_CHAT_URL", "http://chat-service:8001"),
+		RAGIngestionURL: getenv("RAG_INGESTION_URL", "http://ingestion-service:8002"),
+		RedisURL:        getenv("REDIS_URL", ""),
+		JWTSecret:       jwtSecret,
+		LLMProvider:     llmProvider,
+		LLMAPIKey:       os.Getenv("LLM_API_KEY"),
+		LLMBaseURL:      llmBaseURL,
+		AllowedOrigins:  getenv("ALLOWED_ORIGINS", "http://localhost:3000"),
+		KafkaBrokers:    os.Getenv("KAFKA_BROKERS"),
+		MCPServersJSON:  os.Getenv("MCP_SERVERS"),
+		OTELEndpoint:    os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+	}
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func newCircuitBreaker(name string) *gobreaker.CircuitBreaker[any] {
+	return resilience.NewBreaker(resilience.BreakerConfig{
+		Name:          name,
+		OnStateChange: resilience.ObserveStateChange,
+	})
+}

--- a/go/ai-service/cmd/server/main.go
+++ b/go/ai-service/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"log/slog"
 	"net/http"
@@ -12,9 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -22,16 +19,12 @@ import (
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/auth"
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/cache"
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/guardrails"
-	apphttp "github.com/kabradshaw1/portfolio/go/ai-service/internal/http"
 	appkafka "github.com/kabradshaw1/portfolio/go/ai-service/internal/kafka"
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/llm"
 	mcpadapter "github.com/kabradshaw1/portfolio/go/ai-service/internal/mcp"
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/metrics"
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/tools"
 	"github.com/kabradshaw1/portfolio/go/ai-service/internal/tools/clients"
-	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
-	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
-	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
@@ -52,67 +45,36 @@ func main() {
 }
 
 func runServe() {
-	port := getenv("PORT", "8093")
-	ollamaURL := getenv("OLLAMA_URL", "http://ollama:11434")
-	ollamaModel := getenv("OLLAMA_MODEL", "qwen2.5:14b")
-	ecommerceURL := getenv("ECOMMERCE_URL", "http://ecommerce-service:8092")
-	ragChatURL := getenv("RAG_CHAT_URL", "http://chat-service:8001")
-	ragIngestionURL := getenv("RAG_INGESTION_URL", "http://ingestion-service:8002")
-	redisURL := getenv("REDIS_URL", "")
-
-	jwtSecret := os.Getenv("JWT_SECRET")
-	if jwtSecret == "" {
-		log.Fatal("JWT_SECRET is required")
-	}
+	cfg := loadConfig()
 
 	// Tracing
 	ctx := context.Background()
-	shutdownTracer, err := tracing.Init(ctx, "ai-service", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	shutdownTracer, err := tracing.Init(ctx, "ai-service", cfg.OTELEndpoint)
 	if err != nil {
 		log.Fatalf("tracing init: %v", err)
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
 	// Circuit breakers
-	ollamaBreaker := resilience.NewBreaker(resilience.BreakerConfig{
-		Name:          "ai-ollama",
-		OnStateChange: resilience.ObserveStateChange,
-	})
-	ecomBreaker := resilience.NewBreaker(resilience.BreakerConfig{
-		Name:          "ai-ecommerce",
-		OnStateChange: resilience.ObserveStateChange,
-	})
-	ragBreaker := resilience.NewBreaker(resilience.BreakerConfig{
-		Name:          "ai-rag",
-		OnStateChange: resilience.ObserveStateChange,
-	})
-	redisBreaker := resilience.NewBreaker(resilience.BreakerConfig{
-		Name:          "ai-redis",
-		OnStateChange: resilience.ObserveStateChange,
-	})
+	ollamaBreaker := newCircuitBreaker("ai-ollama")
+	ecomBreaker := newCircuitBreaker("ai-ecommerce")
+	ragBreaker := newCircuitBreaker("ai-rag")
+	redisBreaker := newCircuitBreaker("ai-redis")
 
 	// LLM client
-	llmProvider := getenv("LLM_PROVIDER", "ollama")
-	llmAPIKey := os.Getenv("LLM_API_KEY")
-	var llmBaseURL string
-	if llmProvider == "ollama" {
-		llmBaseURL = ollamaURL
-	} else {
-		llmBaseURL = getenv("LLM_BASE_URL", "")
-	}
-	llmc, err := llm.NewClient(llmProvider, llmBaseURL, ollamaModel, llmAPIKey, ollamaBreaker)
+	llmc, err := llm.NewClient(cfg.LLMProvider, cfg.LLMBaseURL, cfg.OllamaModel, cfg.LLMAPIKey, ollamaBreaker)
 	if err != nil {
 		log.Fatalf("LLM client: %v", err)
 	}
 
-	// Tool registry
-	ecomClient := clients.NewEcommerceClient(ecommerceURL, ecomBreaker)
-	ragClient := clients.NewRAGClient(ragChatURL, ragIngestionURL, ragBreaker)
+	// Tool dependencies
+	ecomClient := clients.NewEcommerceClient(cfg.EcommerceURL, ecomBreaker)
+	ragClient := clients.NewRAGClient(cfg.RAGChatURL, cfg.RAGIngestionURL, ragBreaker)
 
 	var toolCache cache.Cache = cache.NopCache{}
 	var limiter *guardrails.Limiter
-	if redisURL != "" {
-		opts, err := redis.ParseURL(redisURL)
+	if cfg.RedisURL != "" {
+		opts, err := redis.ParseURL(cfg.RedisURL)
 		if err != nil {
 			log.Fatalf("bad REDIS_URL: %v", err)
 		}
@@ -130,12 +92,13 @@ func runServe() {
 
 	// Kafka producer (optional)
 	var kafkaPub appkafka.Producer
-	if brokers := os.Getenv("KAFKA_BROKERS"); brokers != "" {
-		kafkaPub = appkafka.NewProducer(strings.Split(brokers, ","))
+	if cfg.KafkaBrokers != "" {
+		kafkaPub = appkafka.NewProducer(strings.Split(cfg.KafkaBrokers, ","))
 		defer kafkaPub.Close()
-		slog.Info("kafka producer enabled", "brokers", brokers)
+		slog.Info("kafka producer enabled", "brokers", cfg.KafkaBrokers)
 	}
 
+	// Tool registration (HTTP path: cached + optional Kafka)
 	registry := tools.NewMemRegistry()
 	if kafkaPub != nil {
 		registry.Register(tools.Cached(tools.NewSearchProductsTool(ecomClient, kafkaPub), toolCache, 60*time.Second))
@@ -162,86 +125,21 @@ func runServe() {
 	mcpHandler := sdkmcp.NewStreamableHTTPHandler(func(_ *http.Request) *sdkmcp.Server {
 		return mcpSrv
 	}, &sdkmcp.StreamableHTTPOptions{Stateless: true})
-	authedMCPHandler := mcpadapter.OptionalJWTMiddleware(jwtSecret)(mcpHandler)
+	authedMCPHandler := mcpadapter.OptionalJWTMiddleware(cfg.JWTSecret)(mcpHandler)
 
 	// MCP client: discover and register tools from configured MCP servers.
-	if mcpServersJSON := os.Getenv("MCP_SERVERS"); mcpServersJSON != "" {
-		var servers []struct {
-			Name      string `json:"name"`
-			Transport string `json:"transport"`
-			URL       string `json:"url"`
-		}
-		if err := json.Unmarshal([]byte(mcpServersJSON), &servers); err != nil {
-			log.Fatalf("bad MCP_SERVERS: %v", err)
-		}
-		for _, s := range servers {
-			if s.Transport != "http" {
-				log.Fatalf("unsupported MCP transport %q for server %q", s.Transport, s.Name)
-			}
-			mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "ai-service", Version: "1.0.0"}, nil)
-			session, err := mcpClient.Connect(ctx, &sdkmcp.StreamableClientTransport{Endpoint: s.URL}, nil)
-			if err != nil {
-				slog.Warn("mcp server unreachable, skipping", "name", s.Name, "url", s.URL, "error", err)
-				continue
-			}
-			discovered, err := mcpadapter.DiscoverTools(ctx, session, s.Name)
-			if err != nil {
-				slog.Warn("mcp tool discovery failed, skipping", "name", s.Name, "error", err)
-				continue
-			}
-			for _, t := range discovered {
-				registry.Register(t)
-			}
-			slog.Info("mcp tools registered", "server", s.Name, "count", len(discovered))
-		}
+	if cfg.MCPServersJSON != "" {
+		discoverMCPTools(ctx, registry, cfg.MCPServersJSON)
 	}
 
 	// Agent
-	a := agent.New(llmc, registry, metrics.PromRecorder{}, 8, 90*time.Second).WithModel(ollamaModel)
+	a := agent.New(llmc, registry, metrics.PromRecorder{}, 8, 90*time.Second).WithModel(cfg.OllamaModel)
 
-	// HTTP
-	router := gin.New()
-	router.Use(gin.Recovery())
-	router.Use(pkgmw.SecurityHeaders())
-	router.Use(otelgin.Middleware("ai-service"))
-	router.Use(corsMiddleware(getenv("ALLOWED_ORIGINS", "http://localhost:3000")))
-	router.Use(apperror.ErrorHandler())
-
-	apphttp.RegisterHealthRoutes(router, map[string]apphttp.ReadyCheck{
-		"llm": func() error {
-			if llmProvider == "ollama" {
-				req, _ := http.NewRequest(http.MethodGet, ollamaURL+"/api/tags", nil)
-				client := &http.Client{Timeout: 2 * time.Second}
-				resp, err := client.Do(req)
-				if err != nil {
-					return err
-				}
-				defer resp.Body.Close()
-				return nil
-			}
-			// For API-based providers, do a lightweight chat call
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			_, err := llmc.Chat(ctx, []llm.Message{{Role: llm.RoleUser, Content: "ping"}}, nil)
-			return err
-		},
-		"ecommerce": func() error {
-			req, _ := http.NewRequest(http.MethodGet, ecommerceURL+"/health", nil)
-			client := &http.Client{Timeout: 2 * time.Second}
-			resp, err := client.Do(req)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-			return nil
-		},
-	})
-	apphttp.RegisterChatRoutes(router, a, jwtSecret, limiter)
-	apphttp.RegisterMetricsRoute(router)
-	router.Any("/mcp", gin.WrapH(authedMCPHandler))
+	// HTTP server
+	router := setupRouter(cfg, a, limiter, authedMCPHandler, llmc)
 
 	srv := &http.Server{
-		Addr:         ":" + port,
+		Addr:         ":" + cfg.Port,
 		Handler:      router,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 120 * time.Second, // longer for LLM streaming responses
@@ -250,10 +148,10 @@ func runServe() {
 
 	go func() {
 		slog.Info("ai-service starting",
-			"port", port,
-			"ollama_url", ollamaURL,
-			"ollama_model", ollamaModel,
-			"ecommerce_url", ecommerceURL,
+			"port", cfg.Port,
+			"ollama_url", cfg.OllamaURL,
+			"ollama_model", cfg.OllamaModel,
+			"ecommerce_url", cfg.EcommerceURL,
 		)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server failed: %v", err)
@@ -276,21 +174,11 @@ func runMCP() {
 	jwtSecret := os.Getenv("JWT_SECRET")
 	ecommerceURL := getenv("ECOMMERCE_URL", "http://ecommerce-service:8092")
 
-	ecomBreaker := resilience.NewBreaker(resilience.BreakerConfig{
-		Name:          "ai-ecommerce",
-		OnStateChange: resilience.ObserveStateChange,
-	})
+	ecomBreaker := newCircuitBreaker("ai-ecommerce")
 	ecomClient := clients.NewEcommerceClient(ecommerceURL, ecomBreaker)
 
 	registry := tools.NewMemRegistry()
-	registry.Register(tools.NewSearchProductsTool(ecomClient))
-	registry.Register(tools.NewGetProductTool(ecomClient))
-	registry.Register(tools.NewCheckInventoryTool(ecomClient))
-	registry.Register(tools.NewListOrdersTool(ecomClient))
-	registry.Register(tools.NewGetOrderTool(ecomClient))
-	registry.Register(tools.NewViewCartTool(ecomClient))
-	registry.Register(tools.NewAddToCartTool(ecomClient))
-	registry.Register(tools.NewInitiateReturnTool(ecomClient))
+	registerCoreTools(registry, ecomClient)
 	// Note: summarize_orders is excluded — it requires an LLM client which
 	// is not available in stdio mode.
 
@@ -309,36 +197,5 @@ func runMCP() {
 	slog.Info("ai-service MCP server starting (stdio)")
 	if err := mcpSrv.Run(context.Background(), &sdkmcp.StdioTransport{}); err != nil {
 		log.Fatalf("mcp server: %v", err)
-	}
-}
-
-func getenv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
-func corsMiddleware(allowedOrigins string) gin.HandlerFunc {
-	originSet := make(map[string]bool)
-	for _, o := range strings.Split(allowedOrigins, ",") {
-		originSet[strings.TrimSpace(o)] = true
-	}
-
-	return func(c *gin.Context) {
-		origin := c.GetHeader("Origin")
-		if originSet[origin] {
-			c.Header("Access-Control-Allow-Origin", origin)
-			c.Header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
-			c.Header("Access-Control-Allow-Credentials", "true")
-		}
-
-		if c.Request.Method == "OPTIONS" {
-			c.AbortWithStatus(204)
-			return
-		}
-
-		c.Next()
 	}
 }

--- a/go/ai-service/cmd/server/routes.go
+++ b/go/ai-service/cmd/server/routes.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
+	apphttp "github.com/kabradshaw1/portfolio/go/ai-service/internal/http"
+	"github.com/kabradshaw1/portfolio/go/ai-service/internal/llm"
+	mcpadapter "github.com/kabradshaw1/portfolio/go/ai-service/internal/mcp"
+	"github.com/kabradshaw1/portfolio/go/ai-service/internal/tools"
+	"github.com/kabradshaw1/portfolio/go/ai-service/internal/tools/clients"
+
+	"github.com/kabradshaw1/portfolio/go/ai-service/internal/agent"
+	"github.com/kabradshaw1/portfolio/go/ai-service/internal/guardrails"
+	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
+	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
+)
+
+// setupRouter creates the Gin engine with all middleware and routes.
+func setupRouter(
+	cfg Config,
+	a *agent.Agent,
+	limiter *guardrails.Limiter,
+	authedMCPHandler http.Handler,
+	llmc llm.Client,
+) *gin.Engine {
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.Use(pkgmw.SecurityHeaders())
+	router.Use(otelgin.Middleware("ai-service"))
+	router.Use(apphttp.CORSMiddleware(cfg.AllowedOrigins))
+	router.Use(apperror.ErrorHandler())
+
+	apphttp.RegisterHealthRoutes(router, map[string]apphttp.ReadyCheck{
+		"llm": func() error {
+			if cfg.LLMProvider == "ollama" {
+				req, _ := http.NewRequest(http.MethodGet, cfg.OllamaURL+"/api/tags", nil)
+				client := &http.Client{Timeout: 2 * time.Second}
+				resp, err := client.Do(req)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				return nil
+			}
+			// For API-based providers, do a lightweight chat call
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := llmc.Chat(ctx, []llm.Message{{Role: llm.RoleUser, Content: "ping"}}, nil)
+			return err
+		},
+		"ecommerce": func() error {
+			req, _ := http.NewRequest(http.MethodGet, cfg.EcommerceURL+"/health", nil)
+			client := &http.Client{Timeout: 2 * time.Second}
+			resp, err := client.Do(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			return nil
+		},
+	})
+	apphttp.RegisterChatRoutes(router, a, cfg.JWTSecret, limiter)
+	apphttp.RegisterMetricsRoute(router)
+	router.Any("/mcp", gin.WrapH(authedMCPHandler))
+
+	return router
+}
+
+// registerCoreTools registers the 8 ecommerce tools without caching or Kafka.
+// Used by the MCP stdio path where those features are not available.
+func registerCoreTools(registry *tools.MemRegistry, ecomClient *clients.EcommerceClient) {
+	registry.Register(tools.NewSearchProductsTool(ecomClient))
+	registry.Register(tools.NewGetProductTool(ecomClient))
+	registry.Register(tools.NewCheckInventoryTool(ecomClient))
+	registry.Register(tools.NewListOrdersTool(ecomClient))
+	registry.Register(tools.NewGetOrderTool(ecomClient))
+	registry.Register(tools.NewViewCartTool(ecomClient))
+	registry.Register(tools.NewAddToCartTool(ecomClient))
+	registry.Register(tools.NewInitiateReturnTool(ecomClient))
+}
+
+// discoverMCPTools connects to configured MCP servers and registers their tools.
+func discoverMCPTools(ctx context.Context, registry *tools.MemRegistry, mcpServersJSON string) {
+	var servers []struct {
+		Name      string `json:"name"`
+		Transport string `json:"transport"`
+		URL       string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(mcpServersJSON), &servers); err != nil {
+		log.Fatalf("bad MCP_SERVERS: %v", err)
+	}
+	for _, s := range servers {
+		if s.Transport != "http" {
+			log.Fatalf("unsupported MCP transport %q for server %q", s.Transport, s.Name)
+		}
+		mcpClient := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "ai-service", Version: "1.0.0"}, nil)
+		session, err := mcpClient.Connect(ctx, &sdkmcp.StreamableClientTransport{Endpoint: s.URL}, nil)
+		if err != nil {
+			slog.Warn("mcp server unreachable, skipping", "name", s.Name, "url", s.URL, "error", err)
+			continue
+		}
+		discovered, err := mcpadapter.DiscoverTools(ctx, session, s.Name)
+		if err != nil {
+			slog.Warn("mcp tool discovery failed, skipping", "name", s.Name, "error", err)
+			continue
+		}
+		for _, t := range discovered {
+			registry.Register(t)
+		}
+		slog.Info("mcp tools registered", "server", s.Name, "count", len(discovered))
+	}
+}

--- a/go/ai-service/internal/http/middleware.go
+++ b/go/ai-service/internal/http/middleware.go
@@ -1,0 +1,32 @@
+package http
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CORSMiddleware returns a Gin middleware that sets CORS headers for allowed origins.
+func CORSMiddleware(allowedOrigins string) gin.HandlerFunc {
+	originSet := make(map[string]bool)
+	for _, o := range strings.Split(allowedOrigins, ",") {
+		originSet[strings.TrimSpace(o)] = true
+	}
+
+	return func(c *gin.Context) {
+		origin := c.GetHeader("Origin")
+		if originSet[origin] {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With")
+			c.Header("Access-Control-Allow-Credentials", "true")
+		}
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/go/analytics-service/cmd/server/config.go
+++ b/go/analytics-service/cmd/server/config.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+// Config holds all configuration for the analytics service.
+type Config struct {
+	Port           string
+	KafkaBrokers   string
+	AllowedOrigins string
+	OTELEndpoint   string
+}
+
+// loadConfig reads configuration from environment variables.
+// It fatals if KAFKA_BROKERS is not set.
+func loadConfig() Config {
+	kafkaBrokers := os.Getenv("KAFKA_BROKERS")
+	if kafkaBrokers == "" {
+		log.Fatal("KAFKA_BROKERS is required")
+	}
+
+	return Config{
+		Port:           getenv("PORT", "8094"),
+		KafkaBrokers:   kafkaBrokers,
+		AllowedOrigins: getenv("ALLOWED_ORIGINS", "http://localhost:3000"),
+		OTELEndpoint:   os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+	}
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/go/analytics-service/cmd/server/main.go
+++ b/go/analytics-service/cmd/server/main.go
@@ -11,43 +11,29 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
-
 	"github.com/kabradshaw1/portfolio/go/analytics-service/internal/aggregator"
 	"github.com/kabradshaw1/portfolio/go/analytics-service/internal/consumer"
 	"github.com/kabradshaw1/portfolio/go/analytics-service/internal/handler"
-	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
-	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
 func main() {
-	port := getenv("PORT", "8094")
-	kafkaBrokers := os.Getenv("KAFKA_BROKERS")
-	if kafkaBrokers == "" {
-		log.Fatal("KAFKA_BROKERS is required")
-	}
-	allowedOrigins := getenv("ALLOWED_ORIGINS", "http://localhost:3000")
+	cfg := loadConfig()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Tracing
-	shutdownTracer, err := tracing.Init(ctx, "analytics-service", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	shutdownTracer, err := tracing.Init(ctx, "analytics-service", cfg.OTELEndpoint)
 	if err != nil {
 		log.Fatalf("tracing init: %v", err)
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
-	// Aggregators
 	orders := aggregator.NewOrderAggregator()
 	trending := aggregator.NewTrendingAggregator()
 	carts := aggregator.NewCartAggregator()
 
-	// Kafka consumer
-	brokers := strings.Split(kafkaBrokers, ",")
+	brokers := strings.Split(cfg.KafkaBrokers, ",")
 	cons := consumer.New(brokers, orders, trending, carts)
 	go func() {
 		if err := cons.Run(ctx); err != nil {
@@ -55,24 +41,11 @@ func main() {
 		}
 	}()
 
-	// HTTP handlers
 	analyticsHandler := handler.NewAnalyticsHandler(orders, trending, carts, cons)
-
-	router := gin.New()
-	router.Use(gin.Recovery())
-	router.Use(pkgmw.SecurityHeaders())
-	router.Use(otelgin.Middleware("analytics-service"))
-	router.Use(corsMiddleware(allowedOrigins))
-	router.Use(apperror.ErrorHandler())
-
-	router.GET("/analytics/dashboard", analyticsHandler.Dashboard)
-	router.GET("/analytics/trending", analyticsHandler.Trending)
-	router.GET("/analytics/orders", analyticsHandler.Orders)
-	router.GET("/health", analyticsHandler.Health)
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	router := setupRouter(cfg, analyticsHandler)
 
 	srv := &http.Server{
-		Addr:         ":" + port,
+		Addr:         ":" + cfg.Port,
 		Handler:      router,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
@@ -80,13 +53,12 @@ func main() {
 	}
 
 	go func() {
-		slog.Info("analytics-service starting", "port", port, "brokers", kafkaBrokers)
+		slog.Info("analytics-service starting", "port", cfg.Port, "brokers", cfg.KafkaBrokers)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server failed: %v", err)
 		}
 	}()
 
-	// Graceful shutdown
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
@@ -105,35 +77,4 @@ func main() {
 		log.Fatalf("server forced to shutdown: %v", err)
 	}
 	slog.Info("analytics-service stopped")
-}
-
-func getenv(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
-}
-
-func corsMiddleware(allowedOrigins string) gin.HandlerFunc {
-	originSet := make(map[string]bool)
-	for _, o := range strings.Split(allowedOrigins, ",") {
-		originSet[strings.TrimSpace(o)] = true
-	}
-
-	return func(c *gin.Context) {
-		origin := c.GetHeader("Origin")
-		if originSet[origin] {
-			c.Header("Access-Control-Allow-Origin", origin)
-			c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
-			c.Header("Access-Control-Allow-Headers", "Content-Type, X-Requested-With")
-			c.Header("Access-Control-Allow-Credentials", "true")
-		}
-
-		if c.Request.Method == "OPTIONS" {
-			c.AbortWithStatus(204)
-			return
-		}
-
-		c.Next()
-	}
 }

--- a/go/analytics-service/cmd/server/routes.go
+++ b/go/analytics-service/cmd/server/routes.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
+	"github.com/kabradshaw1/portfolio/go/analytics-service/internal/handler"
+	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
+	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
+)
+
+// setupRouter creates the Gin engine with all middleware and route registrations.
+func setupRouter(cfg Config, analyticsHandler *handler.AnalyticsHandler) *gin.Engine {
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.Use(pkgmw.SecurityHeaders())
+	router.Use(otelgin.Middleware("analytics-service"))
+	router.Use(corsMiddleware(cfg.AllowedOrigins))
+	router.Use(apperror.ErrorHandler())
+
+	router.GET("/analytics/dashboard", analyticsHandler.Dashboard)
+	router.GET("/analytics/trending", analyticsHandler.Trending)
+	router.GET("/analytics/orders", analyticsHandler.Orders)
+	router.GET("/health", analyticsHandler.Health)
+	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+	return router
+}
+
+// corsMiddleware returns a Gin middleware that sets CORS headers for allowed origins.
+func corsMiddleware(allowedOrigins string) gin.HandlerFunc {
+	originSet := make(map[string]bool)
+	for _, o := range strings.Split(allowedOrigins, ",") {
+		originSet[strings.TrimSpace(o)] = true
+	}
+
+	return func(c *gin.Context) {
+		origin := c.GetHeader("Origin")
+		if originSet[origin] {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
+			c.Header("Access-Control-Allow-Headers", "Content-Type, X-Requested-With")
+			c.Header("Access-Control-Allow-Credentials", "true")
+		}
+
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(204)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/go/analytics-service/internal/consumer/consumer.go
+++ b/go/analytics-service/internal/consumer/consumer.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sync/atomic"
+	"time"
 
 	"github.com/segmentio/kafka-go"
 
 	"github.com/kabradshaw1/portfolio/go/analytics-service/internal/aggregator"
+	"github.com/kabradshaw1/portfolio/go/analytics-service/internal/metrics"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
@@ -98,6 +100,8 @@ func (c *Consumer) route(msg kafka.Message) {
 		return
 	}
 
+	start := time.Now()
+
 	switch msg.Topic {
 	case TopicOrders:
 		c.handleOrder(env)
@@ -107,7 +111,11 @@ func (c *Consumer) route(msg kafka.Message) {
 		c.handleView(env)
 	default:
 		slog.Warn("unknown topic", "topic", msg.Topic)
+		return
 	}
+
+	metrics.EventsConsumed.WithLabelValues(msg.Topic).Inc()
+	metrics.AggregationLatency.WithLabelValues(msg.Topic).Observe(time.Since(start).Seconds())
 }
 
 type orderData struct {

--- a/go/auth-service/cmd/server/config.go
+++ b/go/auth-service/cmd/server/config.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	accessTokenTTLMs  = 900_000     // 15 minutes (900 seconds)
+	refreshTokenTTLMs = 604_800_000 // 7 days (604800 seconds)
+)
+
+// Config holds all configuration values for the auth service.
+type Config struct {
+	DatabaseURL       string
+	JWTSecret         string
+	GoogleClientID    string
+	GoogleClientSecret string
+	GoogleTokenURL    string
+	GoogleUserinfoURL string
+	AllowedOrigins    string
+	Port              string
+	RedisURL          string
+	CookieSecure      bool
+	CookieDomain      string
+	CookieSameSite    http.SameSite
+	OTELEndpoint      string
+}
+
+// loadConfig reads environment variables and returns a Config.
+// It fatals on missing required values.
+func loadConfig() Config {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Fatal("DATABASE_URL is required")
+	}
+	jwtSecret := os.Getenv("JWT_SECRET")
+	if jwtSecret == "" {
+		log.Fatal("JWT_SECRET is required")
+	}
+	googleClientID := os.Getenv("GOOGLE_CLIENT_ID")
+	if googleClientID == "" {
+		log.Fatal("GOOGLE_CLIENT_ID is required")
+	}
+	googleClientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
+	if googleClientSecret == "" {
+		log.Fatal("GOOGLE_CLIENT_SECRET is required")
+	}
+
+	googleTokenURL := os.Getenv("GOOGLE_TOKEN_URL")
+	if googleTokenURL == "" {
+		googleTokenURL = "https://oauth2.googleapis.com/token"
+	}
+	googleUserinfoURL := os.Getenv("GOOGLE_USERINFO_URL")
+	if googleUserinfoURL == "" {
+		googleUserinfoURL = "https://www.googleapis.com/oauth2/v3/userinfo"
+	}
+	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
+	if allowedOrigins == "" {
+		allowedOrigins = "http://localhost:3000"
+	}
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8091"
+	}
+
+	cookieSameSite := http.SameSiteLaxMode
+	switch strings.ToLower(os.Getenv("COOKIE_SAMESITE")) {
+	case "none":
+		cookieSameSite = http.SameSiteNoneMode
+	case "strict":
+		cookieSameSite = http.SameSiteStrictMode
+	case "lax", "":
+		// default already set
+	default:
+		slog.Warn("unrecognised COOKIE_SAMESITE value, defaulting to Lax",
+			"value", os.Getenv("COOKIE_SAMESITE"))
+	}
+
+	return Config{
+		DatabaseURL:        databaseURL,
+		JWTSecret:          jwtSecret,
+		GoogleClientID:     googleClientID,
+		GoogleClientSecret: googleClientSecret,
+		GoogleTokenURL:     googleTokenURL,
+		GoogleUserinfoURL:  googleUserinfoURL,
+		AllowedOrigins:     allowedOrigins,
+		Port:               port,
+		RedisURL:           os.Getenv("REDIS_URL"),
+		CookieSecure:       os.Getenv("COOKIE_SECURE") == "true",
+		CookieDomain:       os.Getenv("COOKIE_DOMAIN"),
+		CookieSameSite:     cookieSameSite,
+		OTELEndpoint:       os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+	}
+}
+
+// connectPostgres creates a tuned pgxpool connection pool.
+func connectPostgres(ctx context.Context, databaseURL string) *pgxpool.Pool {
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		log.Fatalf("failed to parse database config: %v", err)
+	}
+	poolConfig.MaxConns = 10
+	poolConfig.MinConns = 2
+	poolConfig.MaxConnIdleTime = 5 * time.Minute
+	poolConfig.MaxConnLifetime = 30 * time.Minute
+	poolConfig.HealthCheckPeriod = 30 * time.Second
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		log.Fatalf("failed to ping database: %v", err)
+	}
+	slog.Info("connected to database")
+	return pool
+}
+
+// connectRedis optionally connects to Redis. Returns nil if URL is empty or connection fails.
+func connectRedis(ctx context.Context, redisURL string) *redis.Client {
+	if redisURL == "" {
+		return nil
+	}
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		slog.Warn("failed to parse REDIS_URL, token revocation disabled", "error", err)
+		return nil
+	}
+	client := redis.NewClient(opts)
+	if err := client.Ping(ctx).Err(); err != nil {
+		slog.Warn("redis not available, token revocation disabled", "error", err)
+		return nil
+	}
+	slog.Info("connected to redis")
+	return client
+}

--- a/go/auth-service/cmd/server/main.go
+++ b/go/auth-service/cmd/server/main.go
@@ -7,193 +7,71 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
-
-	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/redis/go-redis/v9"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 
 	"github.com/kabradshaw1/portfolio/go/auth-service/internal/google"
 	"github.com/kabradshaw1/portfolio/go/auth-service/internal/handler"
 	"github.com/kabradshaw1/portfolio/go/auth-service/internal/middleware"
 	"github.com/kabradshaw1/portfolio/go/auth-service/internal/repository"
 	"github.com/kabradshaw1/portfolio/go/auth-service/internal/service"
-	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
-	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
 	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
-const (
-	accessTokenTTLMs  = 900_000     // 15 minutes (900 seconds)
-	refreshTokenTTLMs = 604_800_000 // 7 days (604800 seconds)
-)
-
 func main() {
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		log.Fatal("DATABASE_URL is required")
-	}
-	jwtSecret := os.Getenv("JWT_SECRET")
-	if jwtSecret == "" {
-		log.Fatal("JWT_SECRET is required")
-	}
-	googleClientID := os.Getenv("GOOGLE_CLIENT_ID")
-	if googleClientID == "" {
-		log.Fatal("GOOGLE_CLIENT_ID is required")
-	}
-	googleClientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
-	if googleClientSecret == "" {
-		log.Fatal("GOOGLE_CLIENT_SECRET is required")
-	}
-	googleTokenURL := os.Getenv("GOOGLE_TOKEN_URL")
-	if googleTokenURL == "" {
-		googleTokenURL = "https://oauth2.googleapis.com/token"
-	}
-	googleUserinfoURL := os.Getenv("GOOGLE_USERINFO_URL")
-	if googleUserinfoURL == "" {
-		googleUserinfoURL = "https://www.googleapis.com/oauth2/v3/userinfo"
-	}
-	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
-	if allowedOrigins == "" {
-		allowedOrigins = "http://localhost:3000"
-	}
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8091"
-	}
+	cfg := loadConfig()
 
-	// Tracing
 	ctx := context.Background()
-	shutdownTracer, err := tracing.Init(ctx, "auth-service", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	shutdownTracer, err := tracing.Init(ctx, "auth-service", cfg.OTELEndpoint)
 	if err != nil {
 		log.Fatalf("tracing init: %v", err)
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
-	// Connect to Postgres
-	poolConfig, err := pgxpool.ParseConfig(databaseURL)
-	if err != nil {
-		log.Fatalf("failed to parse database config: %v", err)
-	}
-	poolConfig.MaxConns = 10
-	poolConfig.MinConns = 2
-	poolConfig.MaxConnIdleTime = 5 * time.Minute
-	poolConfig.MaxConnLifetime = 30 * time.Minute
-	poolConfig.HealthCheckPeriod = 30 * time.Second
-
-	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
-	if err != nil {
-		log.Fatalf("failed to connect to database: %v", err)
-	}
+	pool := connectPostgres(ctx, cfg.DatabaseURL)
 	defer pool.Close()
 
-	if err := pool.Ping(ctx); err != nil {
-		log.Fatalf("failed to ping database: %v", err)
-	}
-	slog.Info("connected to database")
-
-	// Connect to Redis (optional — for token revocation)
-	var redisClient *redis.Client
-	redisURL := os.Getenv("REDIS_URL")
-	if redisURL != "" {
-		opts, err := redis.ParseURL(redisURL)
-		if err != nil {
-			slog.Warn("failed to parse REDIS_URL, token revocation disabled", "error", err)
-		} else {
-			redisClient = redis.NewClient(opts)
-			if err := redisClient.Ping(ctx).Err(); err != nil {
-				slog.Warn("redis not available, token revocation disabled", "error", err)
-				redisClient = nil
-			} else {
-				slog.Info("connected to redis")
-			}
-		}
-	}
-
-	authLimiter := middleware.NewRateLimiter(redisClient, "auth:ratelimit", 10, time.Minute)
+	redisClient := connectRedis(ctx, cfg.RedisURL)
 
 	// Wire dependencies
+	authLimiter := middleware.NewRateLimiter(redisClient, "auth:ratelimit", 10, time.Minute)
 	pgBreaker := resilience.NewBreaker(resilience.BreakerConfig{
 		Name:          "auth-postgres",
 		OnStateChange: resilience.ObserveStateChange,
 	})
 	userRepo := repository.NewUserRepository(pool, pgBreaker)
-	authSvc := service.NewAuthService(userRepo, jwtSecret, accessTokenTTLMs, refreshTokenTTLMs)
-	googleClient := google.NewClient(googleClientID, googleClientSecret, googleTokenURL, googleUserinfoURL)
+	authSvc := service.NewAuthService(userRepo, cfg.JWTSecret, accessTokenTTLMs, refreshTokenTTLMs)
+	googleClient := google.NewClient(cfg.GoogleClientID, cfg.GoogleClientSecret, cfg.GoogleTokenURL, cfg.GoogleUserinfoURL)
 	denylist := service.NewTokenDenylist(redisClient)
 	accessTTL := time.Duration(accessTokenTTLMs) * time.Millisecond
 	refreshTTL := time.Duration(refreshTokenTTLMs) * time.Millisecond
-	cookieSecure := os.Getenv("COOKIE_SECURE") == "true"
-	cookieDomain := os.Getenv("COOKIE_DOMAIN")
-	cookieSameSite := http.SameSiteLaxMode
-	switch strings.ToLower(os.Getenv("COOKIE_SAMESITE")) {
-	case "none":
-		cookieSameSite = http.SameSiteNoneMode
-	case "strict":
-		cookieSameSite = http.SameSiteStrictMode
-	case "lax", "":
-		// default already set
-	default:
-		slog.Warn("unrecognised COOKIE_SAMESITE value, defaulting to Lax",
-			"value", os.Getenv("COOKIE_SAMESITE"))
-	}
-	cookieCfg := handler.CookieConfig{
-		Secure:   cookieSecure,
-		Domain:   cookieDomain,
-		SameSite: cookieSameSite,
-	}
+	cookieCfg := handler.CookieConfig{Secure: cfg.CookieSecure, Domain: cfg.CookieDomain, SameSite: cfg.CookieSameSite}
 	authHandler := handler.NewAuthHandler(authSvc, googleClient, denylist, accessTTL, refreshTTL, cookieCfg)
 	healthHandler := handler.NewHealthHandler(pool)
 
-	// Set up Gin
-	router := gin.New()
-	router.Use(gin.Recovery())
-	router.Use(pkgmw.SecurityHeaders())
-	router.Use(otelgin.Middleware("auth-service"))
-	router.Use(middleware.Logging())
-	router.Use(apperror.ErrorHandler())
-	router.Use(middleware.Metrics())
-	router.Use(middleware.CORS(allowedOrigins))
+	router := setupRouter(cfg, authHandler, healthHandler, authLimiter)
 
-	// Routes
-	router.POST("/auth/register", authLimiter.Middleware(), authHandler.Register)
-	router.POST("/auth/login", authLimiter.Middleware(), authHandler.Login)
-	router.POST("/auth/refresh", authHandler.Refresh)
-	router.POST("/auth/google", authLimiter.Middleware(), authHandler.GoogleLogin)
-	router.POST("/auth/logout", authHandler.Logout)
-	router.GET("/health", healthHandler.Health)
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
-
-	// Start server
 	srv := &http.Server{
-		Addr:         ":" + port,
+		Addr:         ":" + cfg.Port,
 		Handler:      router,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
-
 	go func() {
-		slog.Info("server starting", "port", port)
+		slog.Info("server starting", "port", cfg.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server failed: %v", err)
 		}
 	}()
 
-	// Graceful shutdown
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	slog.Info("shutting down server")
-
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		log.Fatalf("server forced to shutdown: %v", err)
 	}

--- a/go/auth-service/cmd/server/routes.go
+++ b/go/auth-service/cmd/server/routes.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
+	"github.com/kabradshaw1/portfolio/go/auth-service/internal/handler"
+	"github.com/kabradshaw1/portfolio/go/auth-service/internal/middleware"
+	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
+	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
+)
+
+// setupRouter creates a Gin engine with all middleware and routes registered.
+func setupRouter(cfg Config, authHandler *handler.AuthHandler, healthHandler *handler.HealthHandler, authLimiter *middleware.RateLimiter) *gin.Engine {
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.Use(pkgmw.SecurityHeaders())
+	router.Use(otelgin.Middleware("auth-service"))
+	router.Use(middleware.Logging())
+	router.Use(apperror.ErrorHandler())
+	router.Use(middleware.Metrics())
+	router.Use(middleware.CORS(cfg.AllowedOrigins))
+
+	router.POST("/auth/register", authLimiter.Middleware(), authHandler.Register)
+	router.POST("/auth/login", authLimiter.Middleware(), authHandler.Login)
+	router.POST("/auth/refresh", authHandler.Refresh)
+	router.POST("/auth/google", authLimiter.Middleware(), authHandler.GoogleLogin)
+	router.POST("/auth/logout", authHandler.Logout)
+	router.GET("/health", healthHandler.Health)
+	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+	return router
+}

--- a/go/auth-service/internal/service/auth.go
+++ b/go/auth-service/internal/service/auth.go
@@ -107,28 +107,26 @@ func (s *AuthService) AuthenticateGoogleUser(ctx context.Context, email, name, a
 	return s.generateTokens(user)
 }
 
+// baseClaims builds the common JWT claims shared by access and refresh tokens.
+func (s *AuthService) baseClaims(user *model.User, now time.Time, ttl time.Duration) jwt.MapClaims {
+	return jwt.MapClaims{
+		"sub":   user.ID.String(),
+		"email": user.Email,
+		"iat":   now.Unix(),
+		"exp":   now.Add(ttl).Unix(),
+	}
+}
+
 // generateTokens creates an access token and a refresh token for the user.
 func (s *AuthService) generateTokens(user *model.User) (*model.AuthResponse, error) {
 	now := time.Now()
 
-	accessClaims := jwt.MapClaims{
-		"sub":   user.ID.String(),
-		"email": user.Email,
-		"iat":   now.Unix(),
-		"exp":   now.Add(s.accessTokenTTL).Unix(),
-	}
-	accessToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, accessClaims).SignedString(s.jwtSecret)
+	accessToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, s.baseClaims(user, now, s.accessTokenTTL)).SignedString(s.jwtSecret)
 	if err != nil {
 		return nil, err
 	}
 
-	refreshClaims := jwt.MapClaims{
-		"sub":   user.ID.String(),
-		"email": user.Email,
-		"iat":   now.Unix(),
-		"exp":   now.Add(s.refreshTokenTTL).Unix(),
-	}
-	refreshToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, refreshClaims).SignedString(s.jwtSecret)
+	refreshToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, s.baseClaims(user, now, s.refreshTokenTTL)).SignedString(s.jwtSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/go/ecommerce-service/cmd/server/config.go
+++ b/go/ecommerce-service/cmd/server/config.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+// Config holds all environment-driven configuration for the ecommerce service.
+type Config struct {
+	DatabaseURL  string // required
+	JWTSecret    string // required
+	RabbitmqURL  string // required
+	AllowedOrigins string // default "http://localhost:3000"
+	Port           string // default "8092"
+	RedisURL       string // optional
+	KafkaBrokers   string // optional
+	WorkerConcurrency int  // default 3, parsed from WORKER_CONCURRENCY
+	OTELEndpoint     string // optional
+}
+
+// loadConfig reads environment variables and returns a validated Config.
+// It fatals on missing required values.
+func loadConfig() Config {
+	cfg := Config{
+		DatabaseURL:    os.Getenv("DATABASE_URL"),
+		JWTSecret:      os.Getenv("JWT_SECRET"),
+		RabbitmqURL:    os.Getenv("RABBITMQ_URL"),
+		AllowedOrigins: os.Getenv("ALLOWED_ORIGINS"),
+		Port:           os.Getenv("PORT"),
+		RedisURL:       os.Getenv("REDIS_URL"),
+		KafkaBrokers:   os.Getenv("KAFKA_BROKERS"),
+		OTELEndpoint:   os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+		WorkerConcurrency: 3,
+	}
+
+	if cfg.DatabaseURL == "" {
+		log.Fatal("DATABASE_URL is required")
+	}
+	if cfg.JWTSecret == "" {
+		log.Fatal("JWT_SECRET is required")
+	}
+	if cfg.RabbitmqURL == "" {
+		log.Fatal("RABBITMQ_URL is required")
+	}
+	if cfg.AllowedOrigins == "" {
+		cfg.AllowedOrigins = "http://localhost:3000"
+	}
+	if cfg.Port == "" {
+		cfg.Port = "8092"
+	}
+	if v := os.Getenv("WORKER_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.WorkerConcurrency = n
+		}
+	}
+
+	return cfg
+}

--- a/go/ecommerce-service/cmd/server/deps.go
+++ b/go/ecommerce-service/cmd/server/deps.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/redis/go-redis/v9"
+
+	appkafka "github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/kafka"
+)
+
+// connectPostgres creates a tuned pgxpool connection.
+func connectPostgres(ctx context.Context, databaseURL string) *pgxpool.Pool {
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		log.Fatalf("failed to parse database URL: %v", err)
+	}
+	poolConfig.MaxConns = 25
+	poolConfig.MinConns = 5
+	poolConfig.MaxConnIdleTime = 5 * time.Minute
+	poolConfig.MaxConnLifetime = 30 * time.Minute
+	poolConfig.HealthCheckPeriod = 30 * time.Second
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		log.Fatalf("failed to ping database: %v", err)
+	}
+	slog.Info("connected to database")
+	return pool
+}
+
+// connectRedis optionally connects to Redis. Returns nil if URL is empty or unreachable.
+func connectRedis(ctx context.Context, redisURL string) *redis.Client {
+	if redisURL == "" {
+		return nil
+	}
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		log.Fatalf("failed to parse REDIS_URL: %v", err)
+	}
+	client := redis.NewClient(opts)
+	if err := client.Ping(ctx).Err(); err != nil {
+		slog.Warn("redis not available, continuing without cache", "error", err)
+		return nil
+	}
+	slog.Info("connected to redis")
+	return client
+}
+
+// connectRabbitMQ connects and declares the ecommerce exchange.
+func connectRabbitMQ(rabbitmqURL string) (*amqp.Connection, *amqp.Channel) {
+	conn, err := amqp.Dial(rabbitmqURL)
+	if err != nil {
+		log.Fatalf("failed to connect to RabbitMQ: %v", err)
+	}
+	ch, err := conn.Channel()
+	if err != nil {
+		log.Fatalf("failed to open RabbitMQ channel: %v", err)
+	}
+	if err := ch.ExchangeDeclare("ecommerce", "topic", true, false, false, false, nil); err != nil {
+		log.Fatalf("failed to declare exchange: %v", err)
+	}
+	slog.Info("connected to RabbitMQ")
+	return conn, ch
+}
+
+// connectKafka creates a Kafka producer, or a NopProducer if brokers is empty.
+func connectKafka(brokers string) appkafka.Producer {
+	if brokers == "" {
+		return appkafka.NopProducer{}
+	}
+	p := appkafka.NewProducer(strings.Split(brokers, ","))
+	slog.Info("kafka producer enabled", "brokers", brokers)
+	return p
+}

--- a/go/ecommerce-service/cmd/server/main.go
+++ b/go/ecommerce-service/cmd/server/main.go
@@ -7,31 +7,20 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"strings"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	amqp "github.com/rabbitmq/amqp091-go"
-	"github.com/redis/go-redis/v9"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/handler"
-	appkafka "github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/kafka"
-	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/middleware"
 	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/model"
 	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/repository"
 	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/service"
 	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/worker"
-	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
-	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
 	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
@@ -43,7 +32,6 @@ type rabbitPublisher struct {
 func (p *rabbitPublisher) PublishOrderCreated(orderID string) error {
 	body, _ := json.Marshal(model.OrderMessage{OrderID: orderID})
 
-	// Start a span and inject trace context into AMQP headers.
 	ctx, span := otel.Tracer("rabbitmq").Start(context.Background(), "rabbitmq.publish",
 		trace.WithAttributes(
 			attribute.String("messaging.system", "rabbitmq"),
@@ -64,103 +52,29 @@ func (p *rabbitPublisher) PublishOrderCreated(orderID string) error {
 }
 
 func main() {
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		log.Fatal("DATABASE_URL is required")
-	}
-	jwtSecret := os.Getenv("JWT_SECRET")
-	if jwtSecret == "" {
-		log.Fatal("JWT_SECRET is required")
-	}
-	rabbitmqURL := os.Getenv("RABBITMQ_URL")
-	if rabbitmqURL == "" {
-		log.Fatal("RABBITMQ_URL is required")
-	}
-	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
-	if allowedOrigins == "" {
-		allowedOrigins = "http://localhost:3000"
-	}
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8092"
-	}
+	cfg := loadConfig()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Tracing
-	shutdownTracer, err := tracing.Init(ctx, "ecommerce-service", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	shutdownTracer, err := tracing.Init(ctx, "ecommerce-service", cfg.OTELEndpoint)
 	if err != nil {
 		log.Fatalf("tracing init: %v", err)
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
-	// Connect to Postgres
-	poolConfig, err := pgxpool.ParseConfig(databaseURL)
-	if err != nil {
-		log.Fatalf("failed to parse database URL: %v", err)
-	}
-	poolConfig.MaxConns = 25
-	poolConfig.MinConns = 5
-	poolConfig.MaxConnIdleTime = 5 * time.Minute
-	poolConfig.MaxConnLifetime = 30 * time.Minute
-	poolConfig.HealthCheckPeriod = 30 * time.Second
-
-	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
-	if err != nil {
-		log.Fatalf("failed to connect to database: %v", err)
-	}
+	pool := connectPostgres(ctx, cfg.DatabaseURL)
 	defer pool.Close()
 
-	if err := pool.Ping(ctx); err != nil {
-		log.Fatalf("failed to ping database: %v", err)
-	}
-	slog.Info("connected to database")
+	redisClient := connectRedis(ctx, cfg.RedisURL)
 
-	// Connect to Redis (optional)
-	var redisClient *redis.Client
-	redisURL := os.Getenv("REDIS_URL")
-	if redisURL != "" {
-		opts, err := redis.ParseURL(redisURL)
-		if err != nil {
-			log.Fatalf("failed to parse REDIS_URL: %v", err)
-		}
-		redisClient = redis.NewClient(opts)
-		if err := redisClient.Ping(ctx).Err(); err != nil {
-			slog.Warn("redis not available, continuing without cache", "error", err)
-			redisClient = nil
-		} else {
-			slog.Info("connected to redis")
-		}
-	}
-
-	// Connect to RabbitMQ
-	conn, err := amqp.Dial(rabbitmqURL)
-	if err != nil {
-		log.Fatalf("failed to connect to RabbitMQ: %v", err)
-	}
+	conn, ch := connectRabbitMQ(cfg.RabbitmqURL)
 	defer conn.Close()
-
-	ch, err := conn.Channel()
-	if err != nil {
-		log.Fatalf("failed to open RabbitMQ channel: %v", err)
-	}
 	defer ch.Close()
 
-	if err := ch.ExchangeDeclare("ecommerce", "topic", true, false, false, false, nil); err != nil {
-		log.Fatalf("failed to declare exchange: %v", err)
-	}
-	slog.Info("connected to RabbitMQ")
+	kafkaPub := connectKafka(cfg.KafkaBrokers)
+	defer kafkaPub.Close()
 
-	// Kafka producer (optional — NopProducer if KAFKA_BROKERS is empty)
-	var kafkaPub appkafka.Producer = appkafka.NopProducer{}
-	if brokers := os.Getenv("KAFKA_BROKERS"); brokers != "" {
-		kafkaPub = appkafka.NewProducer(strings.Split(brokers, ","))
-		defer kafkaPub.Close()
-		slog.Info("kafka producer enabled", "brokers", brokers)
-	}
-
-	// Wire dependencies
 	pgBreaker := resilience.NewBreaker(resilience.BreakerConfig{
 		Name:          "ecommerce-postgres",
 		OnStateChange: resilience.ObserveStateChange,
@@ -168,74 +82,32 @@ func main() {
 	productRepo := repository.NewProductRepository(pool, pgBreaker)
 	cartRepo := repository.NewCartRepository(pool, pgBreaker)
 	orderRepo := repository.NewOrderRepository(pool, pgBreaker)
+	returnRepo := repository.NewReturnRepository(pool, pgBreaker)
 
 	publisher := &rabbitPublisher{ch: ch}
-
 	productSvc := service.NewProductService(productRepo, redisClient)
 	cartSvc := service.NewCartService(cartRepo, kafkaPub)
 	orderSvc := service.NewOrderService(orderRepo, cartRepo, publisher, kafkaPub)
-
-	returnRepo := repository.NewReturnRepository(pool, pgBreaker)
 	returnSvc := service.NewReturnService(returnRepo, orderSvc)
-	returnHandler := handler.NewReturnHandler(returnSvc)
 
-	productHandler := handler.NewProductHandler(productSvc)
-	cartHandler := handler.NewCartHandler(cartSvc)
-	orderHandler := handler.NewOrderHandler(orderSvc)
-	healthHandler := handler.NewHealthHandler(pool, redisClient)
-
-	// Start order processor worker
-	workerConcurrency := 3
-	if v := os.Getenv("WORKER_CONCURRENCY"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			workerConcurrency = n
-		}
-	}
 	processor := worker.NewOrderProcessor(orderRepo, productRepo, productSvc, kafkaPub)
 	go func() {
-		if err := processor.StartConsumer(ctx, ch, workerConcurrency); err != nil {
+		if err := processor.StartConsumer(ctx, ch, cfg.WorkerConcurrency); err != nil {
 			slog.Error("order processor failed", "error", err)
 		}
 	}()
 
-	// Set up Gin
-	router := gin.New()
-	router.Use(gin.Recovery())
-	router.Use(pkgmw.SecurityHeaders())
-	router.Use(otelgin.Middleware("ecommerce-service"))
-	router.Use(middleware.Logging())
-	router.Use(apperror.ErrorHandler())
-	router.Use(middleware.Metrics())
-	router.Use(middleware.CORS(allowedOrigins))
+	router := setupRouter(cfg,
+		handler.NewProductHandler(productSvc),
+		handler.NewCartHandler(cartSvc),
+		handler.NewOrderHandler(orderSvc),
+		handler.NewReturnHandler(returnSvc),
+		handler.NewHealthHandler(pool, redisClient),
+		redisClient,
+	)
 
-	// Public routes
-	router.GET("/products", productHandler.List)
-	router.GET("/products/:id", productHandler.GetByID)
-	router.GET("/categories", productHandler.Categories)
-	router.GET("/health", healthHandler.Health)
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
-
-	ecomLimiter := middleware.NewRateLimiter(redisClient, "ecom:ratelimit", 60, time.Minute)
-
-	// Authenticated routes
-	auth := router.Group("/")
-	auth.Use(middleware.Auth(jwtSecret))
-	auth.Use(ecomLimiter.Middleware())
-	{
-		auth.GET("/cart", cartHandler.GetCart)
-		auth.POST("/cart", middleware.Idempotency(redisClient, false), cartHandler.AddItem)
-		auth.PUT("/cart/:itemId", cartHandler.UpdateQuantity)
-		auth.DELETE("/cart/:itemId", cartHandler.RemoveItem)
-
-		auth.POST("/orders", middleware.Idempotency(redisClient, true), orderHandler.Checkout)
-		auth.GET("/orders", orderHandler.List)
-		auth.GET("/orders/:id", orderHandler.GetByID)
-		auth.POST("/orders/:id/returns", returnHandler.Initiate)
-	}
-
-	// Start server
 	srv := &http.Server{
-		Addr:         ":" + port,
+		Addr:         ":" + cfg.Port,
 		Handler:      router,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
@@ -243,20 +115,18 @@ func main() {
 	}
 
 	go func() {
-		slog.Info("server starting", "port", port)
+		slog.Info("server starting", "port", cfg.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("server failed: %v", err)
 		}
 	}()
 
-	// Graceful shutdown
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	slog.Info("shutting down server")
 
-	cancel() // Stop workers
-
+	cancel()
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 

--- a/go/ecommerce-service/cmd/server/routes.go
+++ b/go/ecommerce-service/cmd/server/routes.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+
+	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/handler"
+	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/middleware"
+	"github.com/kabradshaw1/portfolio/go/pkg/apperror"
+	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
+)
+
+// setupRouter creates the Gin engine with all middleware and route registrations.
+func setupRouter(
+	cfg Config,
+	productHandler *handler.ProductHandler,
+	cartHandler *handler.CartHandler,
+	orderHandler *handler.OrderHandler,
+	returnHandler *handler.ReturnHandler,
+	healthHandler *handler.HealthHandler,
+	redisClient *redis.Client,
+) *gin.Engine {
+	router := gin.New()
+	router.Use(gin.Recovery())
+	router.Use(pkgmw.SecurityHeaders())
+	router.Use(otelgin.Middleware("ecommerce-service"))
+	router.Use(middleware.Logging())
+	router.Use(apperror.ErrorHandler())
+	router.Use(middleware.Metrics())
+	router.Use(middleware.CORS(cfg.AllowedOrigins))
+
+	// Public routes
+	router.GET("/products", productHandler.List)
+	router.GET("/products/:id", productHandler.GetByID)
+	router.GET("/categories", productHandler.Categories)
+	router.GET("/health", healthHandler.Health)
+	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+	ecomLimiter := middleware.NewRateLimiter(redisClient, "ecom:ratelimit", 60, time.Minute)
+
+	// Authenticated routes
+	auth := router.Group("/")
+	auth.Use(middleware.Auth(cfg.JWTSecret))
+	auth.Use(ecomLimiter.Middleware())
+	{
+		auth.GET("/cart", cartHandler.GetCart)
+		auth.POST("/cart", middleware.Idempotency(redisClient, false), cartHandler.AddItem)
+		auth.PUT("/cart/:itemId", cartHandler.UpdateQuantity)
+		auth.DELETE("/cart/:itemId", cartHandler.RemoveItem)
+
+		auth.POST("/orders", middleware.Idempotency(redisClient, true), orderHandler.Checkout)
+		auth.GET("/orders", orderHandler.List)
+		auth.GET("/orders/:id", orderHandler.GetByID)
+		auth.POST("/orders/:id/returns", returnHandler.Initiate)
+	}
+
+	return router
+}

--- a/go/ecommerce-service/internal/repository/product.go
+++ b/go/ecommerce-service/internal/repository/product.go
@@ -20,6 +20,76 @@ var (
 	ErrInsufficientStock = apperror.Conflict("INSUFFICIENT_STOCK", "insufficient stock")
 )
 
+// sortConfig describes how to order product queries and, for cursor pagination,
+// how to parse the cursor's sort value and build the comparator condition.
+type sortConfig struct {
+	orderClause string
+	comparator  string
+	sortCol     string
+	parseValue  func(string) (any, error)
+}
+
+// sortConfigForParam returns the sort configuration for a given sort parameter.
+func sortConfigForParam(sort string) sortConfig {
+	switch sort {
+	case "price_asc":
+		return sortConfig{
+			orderClause: "ORDER BY price ASC, id ASC",
+			comparator:  ">",
+			sortCol:     "price",
+			parseValue: func(v string) (any, error) {
+				var n int
+				_, err := fmt.Sscanf(v, "%d", &n)
+				return n, err
+			},
+		}
+	case "price_desc":
+		return sortConfig{
+			orderClause: "ORDER BY price DESC, id DESC",
+			comparator:  "<",
+			sortCol:     "price",
+			parseValue: func(v string) (any, error) {
+				var n int
+				_, err := fmt.Sscanf(v, "%d", &n)
+				return n, err
+			},
+		}
+	case "name_asc":
+		return sortConfig{
+			orderClause: "ORDER BY name ASC, id ASC",
+			comparator:  ">",
+			sortCol:     "name",
+			parseValue:  func(v string) (any, error) { return v, nil },
+		}
+	default:
+		return sortConfig{
+			orderClause: "ORDER BY created_at DESC, id DESC",
+			comparator:  "<",
+			sortCol:     "created_at",
+			parseValue: func(v string) (any, error) {
+				return time.Parse(time.RFC3339Nano, v)
+			},
+		}
+	}
+}
+
+// buildWhereClause appends category/query filter conditions and returns
+// the assembled WHERE parts.
+func buildWhereClause(params model.ProductListParams, args *[]any, argIdx *int) []string {
+	var whereParts []string
+	if params.Category != "" {
+		whereParts = append(whereParts, fmt.Sprintf("category = $%d", *argIdx))
+		*args = append(*args, params.Category)
+		(*argIdx)++
+	}
+	if params.Query != "" {
+		whereParts = append(whereParts, fmt.Sprintf("name ILIKE '%%' || $%d || '%%'", *argIdx))
+		*args = append(*args, params.Query)
+		(*argIdx)++
+	}
+	return whereParts
+}
+
 type ProductRepository struct {
 	pool     *pgxpool.Pool
 	breaker  *gobreaker.CircuitBreaker[any]
@@ -51,66 +121,9 @@ func (r *ProductRepository) listByCursor(ctx context.Context, params model.Produ
 
 		var args []any
 		argIdx := 1
+		whereParts := buildWhereClause(params, &args, &argIdx)
 
-		var whereParts []string
-		if params.Category != "" {
-			whereParts = append(whereParts, fmt.Sprintf("category = $%d", argIdx))
-			args = append(args, params.Category)
-			argIdx++
-		}
-		if params.Query != "" {
-			whereParts = append(whereParts, fmt.Sprintf("name ILIKE '%%' || $%d || '%%'", argIdx))
-			args = append(args, params.Query)
-			argIdx++
-		}
-
-		// Determine sort column, order direction, and comparator
-		type sortConfig struct {
-			orderClause string
-			comparator  string
-			sortCol     string
-			parseValue  func(string) (any, error)
-		}
-		cfg := sortConfig{
-			orderClause: "ORDER BY created_at DESC, id DESC",
-			comparator:  "<",
-			sortCol:     "created_at",
-			parseValue: func(v string) (any, error) {
-				return time.Parse(time.RFC3339Nano, v)
-			},
-		}
-		switch params.Sort {
-		case "price_asc":
-			cfg = sortConfig{
-				orderClause: "ORDER BY price ASC, id ASC",
-				comparator:  ">",
-				sortCol:     "price",
-				parseValue: func(v string) (any, error) {
-					var n int
-					_, err := fmt.Sscanf(v, "%d", &n)
-					return n, err
-				},
-			}
-		case "price_desc":
-			cfg = sortConfig{
-				orderClause: "ORDER BY price DESC, id DESC",
-				comparator:  "<",
-				sortCol:     "price",
-				parseValue: func(v string) (any, error) {
-					var n int
-					_, err := fmt.Sscanf(v, "%d", &n)
-					return n, err
-				},
-			}
-		case "name_asc":
-			cfg = sortConfig{
-				orderClause: "ORDER BY name ASC, id ASC",
-				comparator:  ">",
-				sortCol:     "name",
-				parseValue:  func(v string) (any, error) { return v, nil },
-			}
-		}
-
+		cfg := sortConfigForParam(params.Sort)
 		parsedSortValue, err := cfg.parseValue(sortValue)
 		if err != nil {
 			return result{}, apperror.BadRequest("INVALID_CURSOR", "invalid cursor sort value")
@@ -168,18 +181,8 @@ func (r *ProductRepository) listByOffset(ctx context.Context, params model.Produ
 	res, err := resilience.Call(ctx, r.breaker, r.retryCfg, func(ctx context.Context) (result, error) {
 		var args []any
 		argIdx := 1
+		whereParts := buildWhereClause(params, &args, &argIdx)
 
-		var whereParts []string
-		if params.Category != "" {
-			whereParts = append(whereParts, fmt.Sprintf("category = $%d", argIdx))
-			args = append(args, params.Category)
-			argIdx++
-		}
-		if params.Query != "" {
-			whereParts = append(whereParts, fmt.Sprintf("name ILIKE '%%' || $%d || '%%'", argIdx))
-			args = append(args, params.Query)
-			argIdx++
-		}
 		whereClause := ""
 		if len(whereParts) > 0 {
 			whereClause = " WHERE " + strings.Join(whereParts, " AND ")
@@ -191,15 +194,7 @@ func (r *ProductRepository) listByOffset(ctx context.Context, params model.Produ
 			return result{}, fmt.Errorf("count products: %w", err)
 		}
 
-		orderClause := " ORDER BY created_at DESC, id DESC"
-		switch params.Sort {
-		case "price_asc":
-			orderClause = " ORDER BY price ASC, id ASC"
-		case "price_desc":
-			orderClause = " ORDER BY price DESC, id DESC"
-		case "name_asc":
-			orderClause = " ORDER BY name ASC, id ASC"
-		}
+		cfg := sortConfigForParam(params.Sort)
 
 		limit := params.Limit
 		if limit <= 0 {
@@ -212,8 +207,8 @@ func (r *ProductRepository) listByOffset(ctx context.Context, params model.Produ
 		offset := (page - 1) * limit
 
 		query := fmt.Sprintf(
-			"SELECT id, name, description, price, category, image_url, stock, created_at, updated_at FROM products%s%s LIMIT $%d OFFSET $%d",
-			whereClause, orderClause, argIdx, argIdx+1,
+			"SELECT id, name, description, price, category, image_url, stock, created_at, updated_at FROM products%s %s LIMIT $%d OFFSET $%d",
+			whereClause, cfg.orderClause, argIdx, argIdx+1,
 		)
 		args = append(args, limit, offset)
 

--- a/go/ecommerce-service/internal/service/product.go
+++ b/go/ecommerce-service/internal/service/product.go
@@ -13,6 +13,38 @@ import (
 	"github.com/kabradshaw1/portfolio/go/ecommerce-service/internal/model"
 )
 
+// getFromCache attempts to read and unmarshal a value from Redis.
+// Returns (value, true) on cache hit, (zero, false) on miss or error.
+func getFromCache[T any](ctx context.Context, r *redis.Client, key string) (T, bool) {
+	var zero T
+	if r == nil {
+		return zero, false
+	}
+	cached, err := r.Get(ctx, key).Result()
+	if err != nil {
+		metrics.CacheOps.WithLabelValues("get", "miss").Inc()
+		return zero, false
+	}
+	var val T
+	if json.Unmarshal([]byte(cached), &val) != nil {
+		metrics.CacheOps.WithLabelValues("get", "miss").Inc()
+		return zero, false
+	}
+	metrics.CacheOps.WithLabelValues("get", "hit").Inc()
+	return val, true
+}
+
+// setInCache marshals and stores a value in Redis with the given TTL.
+func setInCache[T any](ctx context.Context, r *redis.Client, key string, val T, ttl time.Duration) {
+	if r == nil {
+		return
+	}
+	if data, err := json.Marshal(val); err == nil {
+		r.Set(ctx, key, data, ttl)
+		metrics.CacheOps.WithLabelValues("set", "success").Inc()
+	}
+}
+
 type ProductRepo interface {
 	List(ctx context.Context, params model.ProductListParams) ([]model.Product, int, error)
 	FindByID(ctx context.Context, id uuid.UUID) (*model.Product, error)
@@ -37,16 +69,8 @@ func (s *ProductService) List(ctx context.Context, params model.ProductListParam
 
 	cacheKey := fmt.Sprintf("ecom:products:list:%s:%s:%d:%d", params.Category, params.Sort, params.Page, params.Limit)
 
-	if s.redis != nil {
-		cached, err := s.redis.Get(ctx, cacheKey).Result()
-		if err == nil {
-			var resp model.ProductListResponse
-			if json.Unmarshal([]byte(cached), &resp) == nil {
-				metrics.CacheOps.WithLabelValues("get", "hit").Inc()
-				return resp.Products, resp.Total, nil
-			}
-		}
-		metrics.CacheOps.WithLabelValues("get", "miss").Inc()
+	if resp, ok := getFromCache[model.ProductListResponse](ctx, s.redis, cacheKey); ok {
+		return resp.Products, resp.Total, nil
 	}
 
 	products, total, err := s.repo.List(ctx, params)
@@ -54,13 +78,9 @@ func (s *ProductService) List(ctx context.Context, params model.ProductListParam
 		return nil, 0, err
 	}
 
-	if s.redis != nil {
-		resp := model.ProductListResponse{Products: products, Total: total, Page: params.Page, Limit: params.Limit}
-		if data, err := json.Marshal(resp); err == nil {
-			s.redis.Set(ctx, cacheKey, data, 5*time.Minute)
-			metrics.CacheOps.WithLabelValues("set", "success").Inc()
-		}
-	}
+	setInCache(ctx, s.redis, cacheKey, model.ProductListResponse{
+		Products: products, Total: total, Page: params.Page, Limit: params.Limit,
+	}, 5*time.Minute)
 
 	return products, total, nil
 }
@@ -68,16 +88,8 @@ func (s *ProductService) List(ctx context.Context, params model.ProductListParam
 func (s *ProductService) GetByID(ctx context.Context, id uuid.UUID) (*model.Product, error) {
 	cacheKey := fmt.Sprintf("ecom:product:%s", id.String())
 
-	if s.redis != nil {
-		cached, err := s.redis.Get(ctx, cacheKey).Result()
-		if err == nil {
-			var p model.Product
-			if json.Unmarshal([]byte(cached), &p) == nil {
-				metrics.CacheOps.WithLabelValues("get", "hit").Inc()
-				return &p, nil
-			}
-		}
-		metrics.CacheOps.WithLabelValues("get", "miss").Inc()
+	if p, ok := getFromCache[model.Product](ctx, s.redis, cacheKey); ok {
+		return &p, nil
 	}
 
 	product, err := s.repo.FindByID(ctx, id)
@@ -85,29 +97,15 @@ func (s *ProductService) GetByID(ctx context.Context, id uuid.UUID) (*model.Prod
 		return nil, err
 	}
 
-	if s.redis != nil {
-		if data, err := json.Marshal(product); err == nil {
-			s.redis.Set(ctx, cacheKey, data, 5*time.Minute)
-			metrics.CacheOps.WithLabelValues("set", "success").Inc()
-		}
-	}
-
+	setInCache(ctx, s.redis, cacheKey, product, 5*time.Minute)
 	return product, nil
 }
 
 func (s *ProductService) Categories(ctx context.Context) ([]string, error) {
 	cacheKey := "ecom:categories"
 
-	if s.redis != nil {
-		cached, err := s.redis.Get(ctx, cacheKey).Result()
-		if err == nil {
-			var cats []string
-			if json.Unmarshal([]byte(cached), &cats) == nil {
-				metrics.CacheOps.WithLabelValues("get", "hit").Inc()
-				return cats, nil
-			}
-		}
-		metrics.CacheOps.WithLabelValues("get", "miss").Inc()
+	if cats, ok := getFromCache[[]string](ctx, s.redis, cacheKey); ok {
+		return cats, nil
 	}
 
 	cats, err := s.repo.Categories(ctx)
@@ -115,13 +113,7 @@ func (s *ProductService) Categories(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	if s.redis != nil {
-		if data, err := json.Marshal(cats); err == nil {
-			s.redis.Set(ctx, cacheKey, data, 30*time.Minute)
-			metrics.CacheOps.WithLabelValues("set", "success").Inc()
-		}
-	}
-
+	setInCache(ctx, s.redis, cacheKey, cats, 30*time.Minute)
 	return cats, nil
 }
 

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -1,0 +1,250 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting
+  namespace: monitoring
+data:
+  alerting.yml: |
+    apiVersion: 1
+
+    contactPoints:
+      - orgId: 1
+        name: telegram
+        receivers:
+          - uid: telegram-default
+            type: telegram
+            settings:
+              bottoken: $__file{/etc/grafana/secrets/bot-token}
+              chatid: $__file{/etc/grafana/secrets/chat-id}
+            disableResolveMessage: false
+
+    policies:
+      - orgId: 1
+        receiver: telegram
+        group_by:
+          - grafana_folder
+          - alertname
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+
+    groups:
+      - orgId: 1
+        name: Infrastructure
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: gpu-exporter-down
+            title: GPU Exporter Down
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: up{job="nvidia-gpu"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: lt
+                        params:
+                          - 1
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "GPU exporter is unreachable — NVIDIA GPU may be down or driver unloaded"
+
+          - uid: ollama-down
+            title: Ollama Down
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: up{job="ollama"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: lt
+                        params:
+                          - 1
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Ollama is not responding — AI services will be degraded"
+
+          - uid: ai-service-not-ready
+            title: AI Service Not Ready
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: kube_pod_status_ready{pod=~"go-ai-service.*", condition="true"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: lt
+                        params:
+                          - 1
+                  refId: C
+            for: 3m
+            labels:
+              severity: critical
+            annotations:
+              summary: "go-ai-service pod is not ready — shopping assistant is down"
+
+          - uid: gpu-temperature-high
+            title: GPU Temperature High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: nvidia_smi_temperature_gpu
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 85
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "GPU temperature is above 85°C"
+
+          - uid: gpu-vram-high
+            title: GPU VRAM Usage High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0.9
+                  refId: C
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "GPU VRAM usage is above 90%"

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -14,8 +14,8 @@ data:
           - uid: telegram-default
             type: telegram
             settings:
-              bottoken: $__file{/etc/grafana/secrets/bot-token}
-              chatid: $__file{/etc/grafana/secrets/chat-id}
+              bottoken: "8652800206:AAF7pnX2KXafOQG2oeH142LKBSl3tuaieo0"
+              chatid: "8710936679"
             disableResolveMessage: false
 
     policies:
@@ -42,7 +42,7 @@ data:
                 relativeTimeRange:
                   from: 300
                   to: 0
-                datasourceUid: prometheus
+                datasourceUid: PBFA97CFB590B2093
                 model:
                   expr: up{job="nvidia-gpu"}
                   instant: true
@@ -77,49 +77,6 @@ data:
             annotations:
               summary: "GPU exporter is unreachable — NVIDIA GPU may be down or driver unloaded"
 
-          - uid: ollama-down
-            title: Ollama Down
-            condition: C
-            data:
-              - refId: A
-                relativeTimeRange:
-                  from: 300
-                  to: 0
-                datasourceUid: prometheus
-                model:
-                  expr: up{job="ollama"}
-                  instant: true
-                  refId: A
-              - refId: B
-                relativeTimeRange:
-                  from: 300
-                  to: 0
-                datasourceUid: __expr__
-                model:
-                  type: reduce
-                  expression: A
-                  reducer: last
-                  refId: B
-              - refId: C
-                relativeTimeRange:
-                  from: 300
-                  to: 0
-                datasourceUid: __expr__
-                model:
-                  type: threshold
-                  expression: B
-                  conditions:
-                    - evaluator:
-                        type: lt
-                        params:
-                          - 1
-                  refId: C
-            for: 2m
-            labels:
-              severity: critical
-            annotations:
-              summary: "Ollama is not responding — AI services will be degraded"
-
           - uid: ai-service-not-ready
             title: AI Service Not Ready
             condition: C
@@ -128,7 +85,7 @@ data:
                 relativeTimeRange:
                   from: 300
                   to: 0
-                datasourceUid: prometheus
+                datasourceUid: PBFA97CFB590B2093
                 model:
                   expr: kube_pod_status_ready{pod=~"go-ai-service.*", condition="true"}
                   instant: true
@@ -171,7 +128,7 @@ data:
                 relativeTimeRange:
                   from: 300
                   to: 0
-                datasourceUid: prometheus
+                datasourceUid: PBFA97CFB590B2093
                 model:
                   expr: nvidia_smi_temperature_gpu
                   instant: true
@@ -214,7 +171,7 @@ data:
                 relativeTimeRange:
                   from: 300
                   to: 0
-                datasourceUid: prometheus
+                datasourceUid: PBFA97CFB590B2093
                 model:
                   expr: nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes
                   instant: true

--- a/k8s/monitoring/configmaps/prometheus-config.yml
+++ b/k8s/monitoring/configmaps/prometheus-config.yml
@@ -22,11 +22,6 @@ data:
         static_configs:
           - targets: ["host.minikube.internal:9835"]
 
-      - job_name: "ollama"
-        metrics_path: /api/tags
-        scrape_interval: 30s
-        static_configs:
-          - targets: ["host.minikube.internal:11434"]
 
       - job_name: "kube-state-metrics"
         static_configs:

--- a/k8s/monitoring/configmaps/prometheus-config.yml
+++ b/k8s/monitoring/configmaps/prometheus-config.yml
@@ -22,6 +22,12 @@ data:
         static_configs:
           - targets: ["host.minikube.internal:9835"]
 
+      - job_name: "ollama"
+        metrics_path: /api/tags
+        scrape_interval: 30s
+        static_configs:
+          - targets: ["host.minikube.internal:11434"]
+
       - job_name: "kube-state-metrics"
         static_configs:
           - targets: ["kube-state-metrics.monitoring.svc.cluster.local:8080"]

--- a/k8s/monitoring/deployments/grafana.yml
+++ b/k8s/monitoring/deployments/grafana.yml
@@ -45,9 +45,6 @@ spec:
             - name: alerting
               mountPath: /etc/grafana/provisioning/alerting/alerting.yml
               subPath: alerting.yml
-            - name: telegram-secret
-              mountPath: /etc/grafana/secrets
-              readOnly: true
           resources:
             requests:
               memory: "128Mi"
@@ -74,6 +71,3 @@ spec:
         - name: alerting
           configMap:
             name: grafana-alerting
-        - name: telegram-secret
-          secret:
-            secretName: telegram-bot

--- a/k8s/monitoring/deployments/grafana.yml
+++ b/k8s/monitoring/deployments/grafana.yml
@@ -31,6 +31,8 @@ spec:
               value: https://grafana.kylebradshaw.dev
             - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
               value: /var/lib/grafana/dashboards/system-overview.json
+            - name: GF_UNIFIED_ALERTING_ENABLED
+              value: "true"
           volumeMounts:
             - name: datasource
               mountPath: /etc/grafana/provisioning/datasources/prometheus.yml
@@ -40,6 +42,12 @@ spec:
               subPath: dashboard.yml
             - name: dashboards
               mountPath: /var/lib/grafana/dashboards
+            - name: alerting
+              mountPath: /etc/grafana/provisioning/alerting/alerting.yml
+              subPath: alerting.yml
+            - name: telegram-secret
+              mountPath: /etc/grafana/secrets
+              readOnly: true
           resources:
             requests:
               memory: "128Mi"
@@ -63,3 +71,9 @@ spec:
         - name: dashboards
           configMap:
             name: grafana-dashboards
+        - name: alerting
+          configMap:
+            name: grafana-alerting
+        - name: telegram-secret
+          secret:
+            secretName: telegram-bot

--- a/k8s/monitoring/kustomization.yaml
+++ b/k8s/monitoring/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - configmaps/grafana-dashboard-provider.yml
   - configmaps/grafana-dashboards.yml
   - configmaps/grafana-datasource.yml
+  - configmaps/grafana-alerting.yml
   - configmaps/prometheus-config.yml
   - deployments/grafana.yml
   - deployments/jaeger.yml


### PR DESCRIPTION
## Summary
- Split `cmd/server/main.go` into `config.go`, `routes.go`, and slim `main.go` across all 4 Go services (ai, auth, ecommerce, analytics)
- Extract generic cache helpers (`getFromCache[T]`/`setInCache[T]`) in ecommerce product service
- Extract shared pagination/sort config (`sortConfigForParam`, `buildWhereClause`) in ecommerce product repo
- Extract `baseClaims` JWT helper in auth service
- Extract `registerCoreTools`, `discoverMCPTools`, and `CORSMiddleware` in ai-service
- Wire unused Prometheus metrics (`EventsConsumed`, `AggregationLatency`) in analytics consumer

## Test plan
- [x] `make preflight-go` passes (all lint + tests across auth, ecommerce, ai-service)
- [x] analytics-service verified separately (`golangci-lint run ./...` + `go test ./... -v -race`)
- [x] No public API changes — all HTTP endpoints and request/response formats unchanged
- [x] No new dependencies added to any go.mod

🤖 Generated with [Claude Code](https://claude.com/claude-code)