### PR TITLE
fix(security): move Telegram bot token to K8s Secret

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,11 @@
 title = "gitleaks config"
 
+[[rules]]
+id = "telegram-bot-token"
+description = "Telegram Bot Token"
+regex = '''[0-9]{8,10}:[A-Za-z0-9_-]{35}'''
+keywords = ["telegram", "bottoken", "bot_token"]
+
 [allowlist]
 paths = [
     '''\.env\.example''',

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -83,6 +83,11 @@ kubectl wait --for=condition=available --timeout=120s deployment/qdrant -n ai-se
 
 # --- Deploy monitoring (same for both environments) ---
 echo "==> Deploying monitoring..."
+if [ -f "$SCRIPT_DIR/monitoring/secrets/grafana-secrets.yml" ]; then
+  kubectl apply -f "$SCRIPT_DIR/monitoring/secrets/grafana-secrets.yml"
+else
+  echo "    WARN: grafana-secrets.yml not found — Telegram alerts will not work"
+fi
 kubectl apply -k "$SCRIPT_DIR/monitoring"
 
 # --- Deploy java-tasks ---

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -14,7 +14,7 @@ data:
           - uid: telegram-default
             type: telegram
             settings:
-              bottoken: "8652800206:AAF7pnX2KXafOQG2oeH142LKBSl3tuaieo0"
+              bottoken: "$__env{TELEGRAM_BOT_TOKEN}"
               chatid: "8710936679"
             disableResolveMessage: false
 

--- a/k8s/monitoring/deployments/grafana.yml
+++ b/k8s/monitoring/deployments/grafana.yml
@@ -33,6 +33,12 @@ spec:
               value: /var/lib/grafana/dashboards/system-overview.json
             - name: GF_UNIFIED_ALERTING_ENABLED
               value: "true"
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-secrets
+                  key: TELEGRAM_BOT_TOKEN
+                  optional: true
           volumeMounts:
             - name: datasource
               mountPath: /etc/grafana/provisioning/datasources/prometheus.yml

--- a/k8s/monitoring/secrets/grafana-secrets.yml.template
+++ b/k8s/monitoring/secrets/grafana-secrets.yml.template
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-secrets
+  namespace: monitoring
+type: Opaque
+stringData:
+  TELEGRAM_BOT_TOKEN: "<your-rotated-telegram-bot-token>"


### PR DESCRIPTION
## Summary
- Remove hardcoded Telegram bot token from `k8s/monitoring/configmaps/grafana-alerting.yml`
- Use Grafana's `$__env{TELEGRAM_BOT_TOKEN}` syntax to read from environment variable
- Inject token via K8s Secret (`grafana-secrets`) → env var in Grafana deployment
- Add `grafana-secrets.yml.template` for setting up the secret on the Debian server
- Update `k8s/deploy.sh` to apply monitoring secrets before kustomize deploy
- Add custom Gitleaks rule to detect Telegram bot token patterns (`[0-9]{8,10}:[A-Za-z0-9_-]{35}`)

## Action required before deploy
1. **Rotate the Telegram bot token** — the old one is in git history and compromised. Talk to @BotFather on Telegram to revoke and regenerate.
2. **Create `k8s/monitoring/secrets/grafana-secrets.yml`** on the Debian server from the template with the new token.

## Test plan
- [ ] Verify Gitleaks CI job still passes (token removed from config)
- [ ] After deploy: confirm Grafana starts and Telegram alerts work with new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)