### PR TITLE
feat: full-stack observability (Loki, alerts, SLOs, Kafka monitoring, correlation)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.6
     hooks:

--- a/docs/adr/observability/01-three-pillars.md
+++ b/docs/adr/observability/01-three-pillars.md
@@ -1,0 +1,23 @@
+# The Three Pillars of Observability
+
+## Metrics, Logs, and Traces
+
+Observability in distributed systems rests on three complementary signal types: metrics, logs, and traces. Each answers a different question, and understanding when to reach for which one is fundamental to operating production systems.
+
+**Metrics** are numeric measurements aggregated over time. In this project, Prometheus scrapes metrics from every service: `http_requests_total` counts every HTTP request (a counter that only goes up), `kafka_consumer_lag` tracks how far behind the analytics consumer is (a gauge that fluctuates), and `go_goroutines` shows concurrency pressure in Go services. Metrics are cheap to store, fast to query, and the foundation of alerting.
+
+**Logs** are discrete events with context -- an error message, a stack trace, the input that caused a failure. This project's Go services emit structured JSON logs with consistent fields (`level`, `msg`, `traceID`) which Promtail ships to Loki. A well-formed JSON log line can be filtered with `{namespace="go-ecommerce"} | json | level="error"` in LogQL, while unstructured logs require fragile regex matching.
+
+**Traces** are the distributed equivalent of a stack trace. A single trace represents one end-to-end operation decomposed into spans -- individual units of work with start times, durations, and parent-child relationships. When a request enters the ecommerce service, passes through Redis, publishes to Kafka, and gets consumed by analytics, OpenTelemetry connects all operations into a single trace visible in Jaeger.
+
+## Monitoring vs Observability
+
+Monitoring asks predefined questions: "Is the service up? Is error rate acceptable?" You set thresholds, and dashboards go green or red. Observability is the ability to ask new questions you did not anticipate. When a user reports that checkout is slow but only on Tuesdays, you need to slice metrics by time, grep logs for the specific flow, and trace requests through the service chain. You could not have written an alert for that scenario in advance.
+
+## When to Reach for Each Pillar
+
+The practical workflow follows a consistent pattern. Metrics are for detection: a Grafana alert fires because `rate(http_requests_total{status=~"5.."}[5m])` spiked. You know something is wrong, but not what. Logs are for investigation: filter Loki by namespace and error level to find the actual error messages. Traces are for distributed path analysis: when the error message says "upstream timeout," the trace shows which upstream, how long it waited, and what that upstream was doing at the time.
+
+## Limitations of the Model
+
+The "three pillars" framing is useful but imperfect. The pillars overlap: a metric can encode the same information as a count of log lines, and a trace is essentially a structured log with parent references. The real power is correlation -- connecting a metric spike to the log lines that caused it to the traces that show where it happened. Grafana serves as the unified UI because it displays Prometheus metrics, Loki logs, and Jaeger traces in a single dashboard, with derived fields that link traceIDs in log lines directly to trace views.

--- a/docs/adr/observability/02-prometheus-and-metrics.md
+++ b/docs/adr/observability/02-prometheus-and-metrics.md
@@ -1,0 +1,33 @@
+# Metrics with Prometheus
+
+## Pull vs Push
+
+Prometheus uses a pull model: it scrapes HTTP endpoints on a schedule rather than waiting for services to push data. This design simplifies the service side (just expose `/metrics`, no client library configuration for destinations), eliminates the need for push infrastructure (message queues, aggregation servers), and makes service discovery the central concern rather than routing. If a target disappears, Prometheus notices immediately because the scrape fails -- you get a free "is it up?" signal from the `up` metric.
+
+This project's Prometheus scrapes every 15 seconds. Some targets use static configuration -- the NVIDIA GPU exporter at `host.minikube.internal:9835` and the node-exporter at port 9100 are fixed addresses. Application services use Kubernetes service discovery: the `k8s-pods` job watches pod annotations, and any pod with `prometheus.io/scrape: "true"` gets scraped automatically. The port and path come from `prometheus.io/port` and `prometheus.io/path` annotations on the pod spec. When a new Go service deploys, it starts getting scraped with zero Prometheus configuration changes.
+
+## The Four Metric Types
+
+**Counters** only go up. `http_requests_total` is the canonical example -- it counts every HTTP request since the process started. The raw value is rarely useful; you apply `rate()` to get requests per second. The alert rule `sum(rate(http_requests_total{service="go-ecommerce-service",status=~"5.."}[5m])) / sum(rate(http_requests_total{service="go-ecommerce-service"}[5m])) * 100` calculates the 5xx error percentage over a 5-minute window. Counters reset to zero when the process restarts, and `rate()` handles this automatically.
+
+**Gauges** can go up or down. `kafka_consumer_lag` is a gauge: the number of unconsumed messages fluctuates as producers write and consumers read. `go_goroutines` is another -- it reflects the current goroutine count, which changes constantly. Unlike counters, gauges are meaningful as raw values. The alert for Kafka consumer lag simply checks `kafka_consumer_lag > 1000`.
+
+**Histograms** pre-bucket observations into configurable ranges. `http_request_duration_seconds_bucket` records how many requests fell into each latency bucket (e.g., under 100ms, under 250ms, under 500ms). The key function is `histogram_quantile()`, which estimates percentiles from bucket data. This project's AI service latency alert uses:
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_seconds_bucket{service="go-ai-service"}[5m])) by (le)
+)
+```
+
+This calculates the p95 latency -- the threshold below which 95% of requests complete. The `le` label (less-than-or-equal) identifies the bucket boundaries.
+
+**Summaries** calculate quantiles on the client side. They are almost never the right choice because they cannot be aggregated across instances. If you have three replicas each reporting their own p99, you cannot combine them into a meaningful cluster-wide p99. Histograms can, because the raw bucket counts are additive. Use histograms.
+
+## Infrastructure Metrics
+
+Beyond application metrics, two exporters provide infrastructure visibility. **kube-state-metrics** queries the Kubernetes API to expose object-level metrics: `kube_pod_status_ready` (is the pod serving traffic?), `kube_deployment_spec_replicas` minus `kube_deployment_status_replicas_available` (are any replicas missing?), and `kube_pod_container_status_terminated_reason{reason="OOMKilled"}` (did a container run out of memory?). These power the Kubernetes Health alert group. **node-exporter** exposes machine-level metrics from the Debian server: CPU utilization, memory usage, disk I/O, and network throughput. Together, they answer infrastructure questions that application metrics cannot -- the application does not know it was OOM-killed, but kube-state-metrics does.
+
+## PromQL in Practice
+
+The queries in this project's alert rules demonstrate the core PromQL patterns. `rate()` over a counter gives per-second throughput. `increase()` gives the total change in a window -- `increase(kube_pod_container_status_restarts_total[30m]) > 3` detects restart storms. Division of two `rate()` calls gives a ratio (error rate). `histogram_quantile()` with `sum by (le)` gives latency percentiles. These four patterns cover the vast majority of real-world Prometheus usage.

--- a/docs/adr/observability/03-loki-and-logs.md
+++ b/docs/adr/observability/03-loki-and-logs.md
@@ -1,0 +1,45 @@
+# Log Aggregation with Loki
+
+## Why Centralized Logging Matters
+
+The motivation for Loki was concrete: when a service got OOM-killed on the Debian server, diagnosing it required SSH-ing in and running `kubectl logs`, hoping the pod had not been rescheduled (losing its logs). With 12+ services across multiple namespaces, checking logs one pod at a time is not sustainable. Loki centralizes all logs into a single queryable store accessible from Grafana alongside metrics and traces.
+
+## Architecture
+
+Loki's full architecture has three components: distributors accept log streams, ingesters batch and compress them, and a storage backend persists chunks. This project uses single-binary mode, collapsing all three into one process with `replication_factor: 1`, in-memory ring, and filesystem storage. A 7-day retention period (`retention_period: 168h`) keeps disk usage bounded.
+
+## Label-Based Indexing
+
+Loki's fundamental design tradeoff sets it apart from Elasticsearch/ELK. ELK indexes every word in every log line, building an inverted index that makes full-text search fast but storage and compute expensive. Loki indexes only the labels attached to each log stream -- `namespace`, `pod`, `app`, `level` -- and stores the log content as compressed chunks. Searching within chunks requires decompressing and scanning (essentially grep), which is slower for ad-hoc text searches but dramatically cheaper in storage and memory. For a single-node Minikube cluster with limited resources, Loki's approach is the pragmatic choice.
+
+## LogQL
+
+LogQL queries start with a stream selector and optionally add pipeline stages. The simplest query selects by labels:
+
+```logql
+{namespace="go-ecommerce"}
+```
+
+This returns all log lines from the go-ecommerce namespace. Adding a JSON parsing stage and a filter narrows the results:
+
+```logql
+{namespace="go-ecommerce"} | json | level="error"
+```
+
+The `| json` stage parses each line as JSON and extracts fields. The `| level="error"` stage filters to only error-level entries. LogQL also supports metric queries, turning logs into time series:
+
+```logql
+rate({namespace="go-ecommerce"} | json | level="error" [5m])
+```
+
+This calculates the per-second rate of error logs over a 5-minute window. The ability to derive metrics from logs means you do not need a Prometheus counter for every error path if the error is already logged.
+
+## Promtail
+
+Promtail is the agent that discovers, tails, and ships logs to Loki. It runs as a DaemonSet (one instance per node) and mounts `/var/log/pods` as a hostPath volume, giving it access to every container's log files. Kubernetes service discovery (`kubernetes_sd_configs` with `role: pod`) tells it which pods exist and provides metadata for labeling.
+
+The pipeline stages in this project's Promtail configuration handle log parsing in sequence. First, `cri: {}` strips the CRI container runtime's timestamp and stream prefix from each line. Then `json` extracts the `level`, `msg`, and `traceID` fields from the JSON payload. The `labels` stage promotes `level` to a Loki label, making it indexable (so `| level="error"` is a fast label filter, not a slow content scan). Finally, `output` replaces the raw log line with just the `msg` field, reducing storage and improving readability.
+
+## Structured Logging
+
+The pipeline stages above only work if log output is consistently structured. All Go services use `slog` with a JSON handler and all Java services use Logback's `JsonLayout`. Consistent field names (`level`, `msg`, `traceID`) across services mean one Promtail configuration handles all services identically.

--- a/docs/adr/observability/04-jaeger-and-traces.md
+++ b/docs/adr/observability/04-jaeger-and-traces.md
@@ -1,0 +1,41 @@
+# Distributed Tracing with Jaeger and OpenTelemetry
+
+## Spans and Traces
+
+A span represents a single unit of work: an HTTP handler processing a request, a Redis GET, a Kafka message publish. Each span records a start time, duration, status, key-value tags, and a reference to its parent span. A trace is a tree of spans sharing a common traceID. The root span is typically the initial HTTP request; child spans represent downstream operations triggered by that request. Together, the spans in a trace reconstruct the full path of an operation through the system.
+
+Consider a user placing an order. The root span covers the HTTP handler. Child spans cover the PostgreSQL query, Redis cache invalidation, and Kafka publish. The analytics consumer creates its own span linked to the same trace. Jaeger displays this as a timeline showing which operation took the most time.
+
+## Context Propagation
+
+For traces to span services, the traceID must travel with the request. The W3C `traceparent` header format (`00-<traceID>-<spanID>-<flags>`) is the standard. The `otelhttp` transport injects this header into outbound HTTP requests; the receiving service's `otelgin` middleware extracts it and creates a child span. No application code is required for HTTP propagation.
+
+## This Project's OTel Setup
+
+Tracing initialization lives in `go/pkg/tracing/tracing.go`. The `Init` function creates an OTLP gRPC exporter pointing at Jaeger's collector on port 4317, sets up a `TracerProvider` with the service name, and registers the W3C TraceContext propagator. If `OTEL_EXPORTER_OTLP_ENDPOINT` is empty, tracing is disabled (no-op).
+
+Auto-instrumentation covers HTTP in both directions: `otelgin` creates spans for incoming requests, `otelhttp.NewTransport` propagates context on outgoing calls. For non-HTTP operations, services create manual spans -- Redis uses a `RedisSpan` helper, and the ai-service's agent loop creates parent-child spans for each tool call.
+
+## Kafka Trace Propagation
+
+HTTP propagation relies on request-response pairs where headers flow naturally. Kafka is asynchronous: the producer writes a message and moves on, the consumer reads it later. There are no HTTP headers. The solution in `go/pkg/tracing/kafka.go` is a `kafkaHeaderCarrier` adapter that implements OpenTelemetry's `TextMapCarrier` interface over Kafka message headers.
+
+When the ecommerce service publishes an order event:
+
+```go
+tracing.InjectKafka(ctx, &msg.Headers)
+```
+
+This writes the `traceparent` and `tracestate` headers into the Kafka message. When the analytics consumer reads the message:
+
+```go
+ctx = tracing.ExtractKafka(ctx, msg.Headers)
+```
+
+This reconstructs the span context, and any spans created with this context become children of the original trace. The result is that a single user request can be traced from the initial HTTP call through the ecommerce handler, into Kafka, and through the analytics consumer's processing -- all visible as one connected trace in Jaeger.
+
+## When Tracing Helps vs When It Is Noise
+
+Tracing excels at latency debugging: if p95 spikes, a trace shows whether the bottleneck is the database, a downstream call, or the service itself. It also reveals dependency topology and per-hop latency.
+
+Tracing becomes noise in high-volume batch processing. Creating a span per record in a 10,000-item job produces overwhelming data. Sampling helps, but tracing is fundamentally designed for request-response workflows with clear start and end points.

--- a/docs/adr/observability/05-alerting-and-slos.md
+++ b/docs/adr/observability/05-alerting-and-slos.md
@@ -1,0 +1,27 @@
+# Alerting Philosophy and SLOs
+
+## Symptom-Based vs Cause-Based Alerting
+
+Cause-based alerting fires on underlying conditions: "disk is 80% full," "CPU is above 90%." These alerts are easy to write but generate noise -- high CPU during a batch job is fine, and each false positive erodes trust.
+
+Symptom-based alerting fires on user-visible impact: "error rate exceeds 5%," "p95 latency is above 2 seconds." These correlate directly with degraded experience. The practical approach combines both: symptom-based for paging, cause-based for dashboard visibility.
+
+## The RED Method
+
+For request-driven services, the RED method provides a standard framework: Rate (requests per second), Errors (failed requests as a percentage), and Duration (latency distribution at p50, p95, p99). These map directly to user experience. The Go services expose all three through `http_requests_total` (counter, split by status code) and `http_request_duration_seconds_bucket` (histogram).
+
+## SLIs, SLOs, and SLAs
+
+An **SLI** (Service Level Indicator) is the measurement: "percentage of requests returning non-5xx." An **SLO** (Service Level Objective) is the target: "99% of requests should succeed." An **SLA** (Service Level Agreement) is a contractual commitment with consequences for breach.
+
+This project's SLOs reflect each service's nature. The AI service targets 5% error rate because LLM calls are inherently unreliable (Ollama timeouts, model loading delays). The ecommerce and Java gateway services target 2% as transaction-oriented services where reliability matters more. Latency targets follow similar logic: 30 seconds at p95 for AI (inference is slow), 2 seconds for ecommerce (CRUD should be fast).
+
+## Alert Fatigue
+
+The `for` field specifies how long a condition must persist before firing. GPU temperature uses `for: 5m` (brief spikes during model loading are normal), OOM kill uses `for: 0s` (always significant), and pod restart storm uses `for: 5m` (distinguishes rolling updates from crash loops).
+
+This project uses `severity: critical` for immediate-attention conditions (OOM kills, node pressure) and `severity: warning` for non-emergencies (elevated error rates, Kafka lag).
+
+## Alert Hierarchy
+
+The alert groups in this project are ordered by scope: Infrastructure alerts (node pressure, disk pressure) indicate environment-level problems affecting all services. Kubernetes Health alerts (OOM kills, restart storms, unavailable replicas) indicate platform-level issues. Application SLO alerts (error rates, latency) indicate service-level degradation. Streaming Analytics alerts (Kafka consumer lag) indicate data pipeline health. This ordering provides a natural triage path: if infrastructure alerts fire alongside application alerts, fix the infrastructure first.

--- a/docs/adr/observability/06-correlation.md
+++ b/docs/adr/observability/06-correlation.md
@@ -1,0 +1,38 @@
+# Connecting the Pillars
+
+## The Observability Workflow
+
+The real value of an observability stack is moving between metrics, logs, and traces in a single investigation. Detection (metrics trigger an alert), investigation (logs reveal error details), and root cause analysis (traces show the distributed path) form the canonical workflow.
+
+## A Concrete Scenario
+
+A Telegram notification arrives: "Go ecommerce service error rate is above 2%." You open the Observability Overview dashboard and see the spike in the metrics row. Scrolling to the logs row, you filter:
+
+```logql
+{namespace="go-ecommerce"} | json | level="error"
+```
+
+The logs show repeated `"msg":"redis timeout","traceID":"a1b2c3d4e5f6..."`. Clicking the traceID opens the trace in Jaeger: root span is `POST /orders` (5.2s total), PostgreSQL query succeeds (12ms), Redis cache write times out (5.1s), and the Kafka publish never executes because the handler returned early.
+
+Checking the Kubernetes Health section reveals the Redis pod crossed 85% memory and was OOM-killed 15 minutes ago. The restart caused connection timeouts until the new pod was ready. Root cause chain: Redis memory pressure caused OOM kill, causing timeouts, causing the error rate spike.
+
+## How Correlation Works Technically
+
+The link from logs to traces requires deliberate plumbing. The `LogHandler` in `go/pkg/tracing/logging.go` wraps `slog.Handler` and adds a `traceID` attribute when a span is active:
+
+```go
+sc := trace.SpanContextFromContext(ctx)
+if sc.HasTraceID() {
+    r.AddAttrs(slog.String("traceID", sc.TraceID().String()))
+}
+```
+
+Promtail extracts the traceID from JSON and ships it to Loki. Grafana's Loki datasource defines a derived field: a regex matches `"traceID":"([a-f0-9]+)"` and turns each match into a clickable Jaeger link. The full chain: Go injects traceID into slog, Promtail ships it to Loki, Grafana renders it as a trace link.
+
+## Kafka's Observability Challenge
+
+HTTP calls have natural trace correlation, but Kafka decouples producers and consumers in time. Without explicit propagation, the consumer's work appears as an isolated trace. The solution is `InjectKafka` and `ExtractKafka` in `go/pkg/tracing/kafka.go`: the producer injects W3C trace context into Kafka message headers, and the consumer extracts it, creating linked spans. An order placed via HTTP can be traced through the ecommerce service, into Kafka, and through the analytics consumer -- even though those services never communicate directly.
+
+## The Unknown Unknowns Argument
+
+The interview answer to "why all three?" is straightforward. Metrics tell you something is wrong. Logs tell you what happened. Traces tell you where. Metrics without logs leave you guessing about the error message. Logs without traces leave you guessing which service in a chain is responsible. The platform's job is to make all three correlated, so the path from "something is wrong" to "here is the root cause" is as short as possible.

--- a/docs/superpowers/plans/2026-04-19-observability-full-stack.md
+++ b/docs/superpowers/plans/2026-04-19-observability-full-stack.md
@@ -1,0 +1,1703 @@
+# Full-Stack Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a comprehensive observability stack completing the three pillars (metrics, logs, traces), adding K8s health and SLO alerts, Kafka consumer lag monitoring, a correlation dashboard, and learning documentation.
+
+**Architecture:** Deploy Loki + Promtail for log aggregation alongside existing Prometheus + Grafana + Jaeger. Add traceID to Go service logs for log-to-trace correlation. Expose Kafka consumer lag as Prometheus metrics. All alerts route to existing Telegram contact point.
+
+**Tech Stack:** Loki 3.0, Promtail 3.0, Grafana alerting YAML, Prometheus client_golang, segmentio/kafka-go, Go slog, Spring Boot Logback
+
+---
+
+## File Structure
+
+### New files (K8s monitoring)
+- `k8s/monitoring/statefulsets/loki.yml` — Loki StatefulSet (single-binary mode)
+- `k8s/monitoring/configmaps/loki-config.yml` — Loki storage and retention config
+- `k8s/monitoring/configmaps/promtail-config.yml` — Promtail scrape and pipeline config
+- `k8s/monitoring/daemonsets/promtail.yml` — Promtail DaemonSet
+- `k8s/monitoring/services/loki.yml` — Loki ClusterIP service
+- `k8s/monitoring/pvc/loki-data.yml` — Loki persistent volume claim
+- `k8s/monitoring/rbac/promtail-clusterrole.yml` — Promtail RBAC for pod log access
+- `k8s/monitoring/rbac/promtail-clusterrolebinding.yml` — Promtail RBAC binding
+- `k8s/monitoring/rbac/promtail-serviceaccount.yml` — Promtail service account
+
+### Modified files (K8s monitoring)
+- `k8s/monitoring/kustomization.yaml` — Add all new resources
+- `k8s/monitoring/configmaps/grafana-datasource.yml` — Add Loki datasource with Jaeger derived fields
+- `k8s/monitoring/configmaps/grafana-alerting.yml` — Add K8s Health + Application SLOs + Kafka alert groups
+- `k8s/monitoring/configmaps/grafana-dashboards.yml` — Add Streaming Analytics panels + Observability Overview dashboard
+- `k8s/monitoring/deployments/grafana.yml` — Mount Loki datasource file
+
+### Modified files (Go services)
+- `go/pkg/tracing/logging.go` — New: slog handler wrapper that injects traceID
+- `go/ecommerce-service/internal/middleware/logging.go` — Add traceID extraction from OTel span context
+- `go/ecommerce-service/cmd/server/main.go` — Configure slog with traceID handler
+- `go/ai-service/cmd/server/main.go` — Configure slog with traceID handler
+- `go/analytics-service/cmd/server/main.go` — Configure slog with traceID handler
+- `go/auth-service/cmd/server/main.go` — Configure slog with traceID handler
+- `go/analytics-service/internal/metrics/prometheus.go` — Add Kafka consumer lag gauge
+- `go/analytics-service/internal/consumer/consumer.go` — Record lag metrics from reader stats
+
+### New files (Java services)
+- `java/task-service/src/main/resources/logback-spring.xml` — JSON structured logging with traceID
+- `java/activity-service/src/main/resources/logback-spring.xml` — Same
+- `java/notification-service/src/main/resources/logback-spring.xml` — Same
+- `java/gateway-service/src/main/resources/logback-spring.xml` — Same
+
+### New files (Learning docs)
+- `docs/adr/observability/01-three-pillars.md`
+- `docs/adr/observability/02-prometheus-and-metrics.md`
+- `docs/adr/observability/03-loki-and-logs.md`
+- `docs/adr/observability/04-jaeger-and-traces.md`
+- `docs/adr/observability/05-alerting-and-slos.md`
+- `docs/adr/observability/06-correlation.md`
+
+---
+
+## Task 1: Deploy Loki
+
+**Files:**
+- Create: `k8s/monitoring/configmaps/loki-config.yml`
+- Create: `k8s/monitoring/statefulsets/loki.yml`
+- Create: `k8s/monitoring/services/loki.yml`
+- Create: `k8s/monitoring/pvc/loki-data.yml`
+- Modify: `k8s/monitoring/kustomization.yaml`
+
+- [ ] **Step 1: Create Loki config ConfigMap**
+
+```yaml
+# k8s/monitoring/configmaps/loki-config.yml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: monitoring
+data:
+  loki.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+      log_level: warn
+
+    common:
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      retention_period: 168h
+      max_query_series: 500
+      max_query_parallelism: 2
+
+    compactor:
+      working_directory: /loki/compactor
+      compaction_interval: 10m
+      retention_enabled: true
+      retention_delete_delay: 2h
+      delete_request_store: filesystem
+```
+
+- [ ] **Step 2: Create Loki PVC**
+
+```yaml
+# k8s/monitoring/pvc/loki-data.yml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+- [ ] **Step 3: Create Loki StatefulSet**
+
+```yaml
+# k8s/monitoring/statefulsets/loki.yml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  replicas: 1
+  serviceName: loki
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.0.0
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - containerPort: 3100
+              name: http
+            - containerPort: 9096
+              name: grpc
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: loki-data
+```
+
+- [ ] **Step 4: Create Loki service**
+
+```yaml
+# k8s/monitoring/services/loki.yml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100
+      name: http
+  type: ClusterIP
+```
+
+- [ ] **Step 5: Add resources to kustomization.yaml**
+
+Add to `k8s/monitoring/kustomization.yaml` resources list:
+
+```yaml
+  - pvc/loki-data.yml
+  - configmaps/loki-config.yml
+  - statefulsets/loki.yml
+  - services/loki.yml
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/loki-config.yml k8s/monitoring/statefulsets/loki.yml k8s/monitoring/services/loki.yml k8s/monitoring/pvc/loki-data.yml k8s/monitoring/kustomization.yaml
+git commit -m "feat(monitoring): add Loki deployment for log aggregation"
+```
+
+---
+
+## Task 2: Deploy Promtail
+
+**Files:**
+- Create: `k8s/monitoring/rbac/promtail-serviceaccount.yml`
+- Create: `k8s/monitoring/rbac/promtail-clusterrole.yml`
+- Create: `k8s/monitoring/rbac/promtail-clusterrolebinding.yml`
+- Create: `k8s/monitoring/configmaps/promtail-config.yml`
+- Create: `k8s/monitoring/daemonsets/promtail.yml`
+- Modify: `k8s/monitoring/kustomization.yaml`
+
+- [ ] **Step 1: Create Promtail RBAC**
+
+```yaml
+# k8s/monitoring/rbac/promtail-serviceaccount.yml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: monitoring
+```
+
+```yaml
+# k8s/monitoring/rbac/promtail-clusterrole.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "services", "endpoints", "pods"]
+    verbs: ["get", "watch", "list"]
+```
+
+```yaml
+# k8s/monitoring/rbac/promtail-clusterrolebinding.yml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: monitoring
+```
+
+- [ ] **Step 2: Create Promtail config**
+
+```yaml
+# k8s/monitoring/configmaps/promtail-config.yml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: monitoring
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 3101
+      grpc_listen_port: 0
+      log_level: warn
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        pipeline_stages:
+          - cri: {}
+          - json:
+              expressions:
+                level: level
+                msg: msg
+                traceID: traceID
+          - labels:
+              level:
+          - output:
+              source: msg
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_container_name]
+            target_label: container
+```
+
+- [ ] **Step 3: Create Promtail DaemonSet**
+
+```yaml
+# k8s/monitoring/daemonsets/promtail.yml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.0.0
+          args:
+            - -config.file=/etc/promtail/promtail.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: pods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: pods
+          hostPath:
+            path: /var/log/pods
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
+```
+
+- [ ] **Step 4: Add resources to kustomization.yaml**
+
+Add to `k8s/monitoring/kustomization.yaml`:
+
+```yaml
+  - rbac/promtail-serviceaccount.yml
+  - rbac/promtail-clusterrole.yml
+  - rbac/promtail-clusterrolebinding.yml
+  - configmaps/promtail-config.yml
+  - daemonsets/promtail.yml
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add k8s/monitoring/rbac/promtail-serviceaccount.yml k8s/monitoring/rbac/promtail-clusterrole.yml k8s/monitoring/rbac/promtail-clusterrolebinding.yml k8s/monitoring/configmaps/promtail-config.yml k8s/monitoring/daemonsets/promtail.yml k8s/monitoring/kustomization.yaml
+git commit -m "feat(monitoring): add Promtail DaemonSet for container log collection"
+```
+
+---
+
+## Task 3: Add Loki Datasource to Grafana
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-datasource.yml`
+- Modify: `k8s/monitoring/deployments/grafana.yml`
+
+- [ ] **Step 1: Add Loki and Jaeger datasources to grafana-datasource.yml**
+
+Replace the contents of `k8s/monitoring/configmaps/grafana-datasource.yml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  namespace: monitoring
+data:
+  datasources.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus.monitoring.svc.cluster.local:9090
+        isDefault: true
+        editable: false
+        uid: PBFA97CFB590B2093
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.monitoring.svc.cluster.local:3100
+        editable: false
+        uid: loki
+        jsonData:
+          derivedFields:
+            - datasourceUid: jaeger
+              matcherRegex: '"traceID":"([a-f0-9]+)"'
+              name: TraceID
+              url: "$${__value.raw}"
+              urlDisplayLabel: View Trace
+      - name: Jaeger
+        type: jaeger
+        access: proxy
+        url: http://jaeger.monitoring.svc.cluster.local:16686
+        editable: false
+        uid: jaeger
+```
+
+- [ ] **Step 2: Update Grafana deployment volume mount**
+
+The datasource file key changed from `prometheus.yml` to `datasources.yml`. Update the volume mount in `k8s/monitoring/deployments/grafana.yml`:
+
+Change:
+```yaml
+            - name: datasource
+              mountPath: /etc/grafana/provisioning/datasources/prometheus.yml
+              subPath: prometheus.yml
+```
+To:
+```yaml
+            - name: datasource
+              mountPath: /etc/grafana/provisioning/datasources/datasources.yml
+              subPath: datasources.yml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-datasource.yml k8s/monitoring/deployments/grafana.yml
+git commit -m "feat(monitoring): add Loki and Jaeger datasources to Grafana with trace correlation"
+```
+
+---
+
+## Task 4: Add Kubernetes Health Alert Rules
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-alerting.yml`
+
+- [ ] **Step 1: Add Kubernetes Health alert group**
+
+Add a new group after the existing "Infrastructure" group in `k8s/monitoring/configmaps/grafana-alerting.yml`. Insert before the final closing of the `groups:` list. Each rule follows the same 3-query pattern (A: PromQL, B: reduce/last, C: threshold) as the existing rules.
+
+```yaml
+      - orgId: 1
+        name: Kubernetes Health
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: container-oom-killed
+            title: Container OOM Killed
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kube_pod_container_status_terminated_reason{reason="OOMKilled"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 0s
+            labels:
+              severity: critical
+            annotations:
+              summary: "Container {{ $labels.container }} in pod {{ $labels.pod }} was OOM killed"
+
+          - uid: pod-restart-storm
+            title: Pod Restart Storm
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: increase(kube_pod_container_status_restarts_total[30m])
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 3
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Pod {{ $labels.pod }} has restarted more than 3 times in 30 minutes"
+
+          - uid: container-memory-high
+            title: Container Memory High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    max by (pod, container, namespace) (
+                      container_memory_working_set_bytes{container!=""}
+                      / on(pod, container, namespace)
+                      kube_pod_container_resource_limits{resource="memory"}
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0.85
+                  refId: C
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }} is using >85% of memory limit"
+
+          - uid: node-memory-pressure
+            title: Node Memory Pressure
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kube_node_status_condition{condition="MemoryPressure",status="true"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Node {{ $labels.node }} is under memory pressure"
+
+          - uid: node-disk-pressure
+            title: Node Disk Pressure
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kube_node_status_condition{condition="DiskPressure",status="true"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Node {{ $labels.node }} is under disk pressure"
+
+          - uid: deployment-replicas-unavailable
+            title: Deployment Replicas Unavailable
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    kube_deployment_spec_replicas
+                    - kube_deployment_status_replicas_available
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Deployment {{ $labels.deployment }} in {{ $labels.namespace }} has unavailable replicas"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-alerting.yml
+git commit -m "feat(monitoring): add Kubernetes health alert rules (OOM, restarts, memory/disk pressure)"
+```
+
+---
+
+## Task 5: Add Application SLO Alert Rules
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-alerting.yml`
+
+- [ ] **Step 1: Add Application SLOs alert group**
+
+Add after the Kubernetes Health group in `grafana-alerting.yml`:
+
+```yaml
+      - orgId: 1
+        name: Application SLOs
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: go-ai-error-rate
+            title: Go AI Service Error Rate High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    sum(rate(http_requests_total{service="go-ai-service",status=~"5.."}[5m]))
+                    / sum(rate(http_requests_total{service="go-ai-service"}[5m]))
+                    * 100
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 5
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go AI service error rate is above 5%"
+
+          - uid: go-ecommerce-error-rate
+            title: Go Ecommerce Error Rate High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    sum(rate(http_requests_total{service="go-ecommerce-service",status=~"5.."}[5m]))
+                    / sum(rate(http_requests_total{service="go-ecommerce-service"}[5m]))
+                    * 100
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 2
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go ecommerce service error rate is above 2%"
+
+          - uid: java-gateway-error-rate
+            title: Java Gateway Error Rate High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    sum(rate(http_server_requests_seconds_count{namespace="java-tasks",status=~"5.."}[5m]))
+                    / sum(rate(http_server_requests_seconds_count{namespace="java-tasks"}[5m]))
+                    * 100
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 2
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Java gateway error rate is above 2%"
+
+          - uid: go-ai-latency-high
+            title: Go AI Service Latency High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    histogram_quantile(0.95,
+                      sum(rate(http_request_duration_seconds_bucket{service="go-ai-service"}[5m])) by (le)
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 30
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go AI service p95 latency is above 30s"
+
+          - uid: go-ecommerce-latency-high
+            title: Go Ecommerce Latency High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    histogram_quantile(0.95,
+                      sum(rate(http_request_duration_seconds_bucket{service="go-ecommerce-service"}[5m])) by (le)
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 2
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go ecommerce service p95 latency is above 2s"
+
+          - uid: java-gateway-latency-high
+            title: Java Gateway Latency High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    histogram_quantile(0.95,
+                      sum(rate(http_server_requests_seconds_bucket{namespace="java-tasks"}[5m])) by (le)
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 3
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Java gateway p95 latency is above 3s"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-alerting.yml
+git commit -m "feat(monitoring): add application SLO alert rules (error rate + latency)"
+```
+
+---
+
+## Task 6: Add TraceID to Go Service Logs
+
+**Files:**
+- Create: `go/pkg/tracing/logging.go`
+- Modify: `go/ecommerce-service/internal/middleware/logging.go`
+- Modify: `go/ecommerce-service/cmd/server/main.go`
+- Modify: `go/ai-service/cmd/server/main.go`
+- Modify: `go/analytics-service/cmd/server/main.go`
+- Modify: `go/auth-service/cmd/server/main.go`
+
+- [ ] **Step 1: Create tracing/logging.go in go/pkg**
+
+This handler wrapper extracts the traceID from the OTel span context and adds it to every slog record.
+
+```go
+// go/pkg/tracing/logging.go
+package tracing
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// LogHandler wraps an slog.Handler to inject traceID from OpenTelemetry span context.
+type LogHandler struct {
+	slog.Handler
+}
+
+// NewLogHandler creates a handler that adds traceID to log records when a span is active.
+func NewLogHandler(h slog.Handler) *LogHandler {
+	return &LogHandler{Handler: h}
+}
+
+// Handle adds the traceID attribute if a valid span context exists.
+func (h *LogHandler) Handle(ctx context.Context, r slog.Record) error {
+	sc := trace.SpanContextFromContext(ctx)
+	if sc.HasTraceID() {
+		r.AddAttrs(slog.String("traceID", sc.TraceID().String()))
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+// WithAttrs returns a new LogHandler wrapping the inner handler's WithAttrs.
+func (h *LogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &LogHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+// WithGroup returns a new LogHandler wrapping the inner handler's WithGroup.
+func (h *LogHandler) WithGroup(name string) slog.Handler {
+	return &LogHandler{Handler: h.Handler.WithGroup(name)}
+}
+```
+
+- [ ] **Step 2: Run `go mod tidy` in go/pkg**
+
+```bash
+cd go/pkg && go mod tidy
+```
+
+Verify `go.opentelemetry.io/otel/trace` is already in go.mod (it should be since tracing.go uses it).
+
+- [ ] **Step 3: Add traceID to ecommerce logging middleware**
+
+Modify `go/ecommerce-service/internal/middleware/logging.go` — add traceID from OTel span context:
+
+```go
+package middleware
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Logging() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := uuid.New().String()
+		c.Set("requestId", requestID)
+		c.Header("X-Request-ID", requestID)
+		start := time.Now()
+		c.Next()
+		latency := time.Since(start)
+
+		attrs := []any{
+			"requestId", requestID,
+			"method", c.Request.Method,
+			"path", c.Request.URL.Path,
+			"status", c.Writer.Status(),
+			"latency", latency.String(),
+			"ip", c.ClientIP(),
+			"userId", c.GetString("userId"),
+		}
+
+		sc := trace.SpanContextFromContext(c.Request.Context())
+		if sc.HasTraceID() {
+			attrs = append(attrs, "traceID", sc.TraceID().String())
+		}
+
+		slog.InfoContext(c.Request.Context(), "request", attrs...)
+	}
+}
+```
+
+- [ ] **Step 4: Configure slog with traceID handler in each service main.go**
+
+For each of the four Go services, add the traceID-aware log handler after OTel init. Add this after the tracing init block and before the server/consumer setup:
+
+```go
+// Set up structured JSON logging with traceID injection.
+slog.SetDefault(slog.New(
+    tracing.NewLogHandler(slog.NewJSONHandler(os.Stdout, nil)),
+))
+```
+
+Add the import `"github.com/kabradshaw1/portfolio/go/pkg/tracing"` and `"os"` if not already present.
+
+Files to modify:
+- `go/ecommerce-service/cmd/server/main.go`
+- `go/ai-service/cmd/server/main.go`
+- `go/analytics-service/cmd/server/main.go`
+- `go/auth-service/cmd/server/main.go`
+
+- [ ] **Step 5: Run go mod tidy in all service directories**
+
+```bash
+cd go/pkg && go mod tidy
+cd go/ecommerce-service && go mod tidy
+cd go/ai-service && go mod tidy
+cd go/analytics-service && go mod tidy
+cd go/auth-service && go mod tidy
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+make preflight-go
+```
+
+Expected: All lint and tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go/pkg/tracing/logging.go go/ecommerce-service/internal/middleware/logging.go go/ecommerce-service/cmd/server/main.go go/ai-service/cmd/server/main.go go/analytics-service/cmd/server/main.go go/auth-service/cmd/server/main.go
+git commit -m "feat(go): add traceID injection to structured logs for Loki-Jaeger correlation"
+```
+
+---
+
+## Task 7: Add Structured JSON Logging to Java Services
+
+**Files:**
+- Create: `java/task-service/src/main/resources/logback-spring.xml`
+- Create: `java/activity-service/src/main/resources/logback-spring.xml`
+- Create: `java/notification-service/src/main/resources/logback-spring.xml`
+- Create: `java/gateway-service/src/main/resources/logback-spring.xml`
+
+- [ ] **Step 1: Add logstash-logback-encoder dependency**
+
+Add to `java/build.gradle` (root project) or each service's `build.gradle` in the `dependencies` block:
+
+```groovy
+implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+```
+
+Check the existing build.gradle structure to determine whether dependencies are declared at root or per-service level.
+
+- [ ] **Step 2: Create logback-spring.xml for each Java service**
+
+Create the same file in all four services. This configures JSON output with Spring's traceID (Micrometer Tracing / Spring Boot default MDC):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <message>msg</message>
+                <level>level</level>
+                <logger>logger</logger>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON" />
+    </root>
+
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
+</configuration>
+```
+
+Files:
+- `java/task-service/src/main/resources/logback-spring.xml`
+- `java/activity-service/src/main/resources/logback-spring.xml`
+- `java/notification-service/src/main/resources/logback-spring.xml`
+- `java/gateway-service/src/main/resources/logback-spring.xml`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add java/*/src/main/resources/logback-spring.xml java/build.gradle
+git commit -m "feat(java): add structured JSON logging with logback for Loki ingestion"
+```
+
+---
+
+## Task 8: Add Kafka Consumer Lag Metrics
+
+**Files:**
+- Modify: `go/analytics-service/internal/metrics/prometheus.go`
+- Modify: `go/analytics-service/internal/consumer/consumer.go`
+
+- [ ] **Step 1: Add lag gauge to prometheus.go**
+
+Add the following metric to `go/analytics-service/internal/metrics/prometheus.go`:
+
+```go
+// ConsumerLag tracks how far behind the consumer is per topic.
+ConsumerLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+    Name: "kafka_consumer_lag",
+    Help: "Number of messages the consumer is behind per topic.",
+}, []string{"topic"})
+
+// ConsumerErrors counts Kafka read errors.
+ConsumerErrors = promauto.NewCounter(prometheus.CounterOpts{
+    Name: "kafka_consumer_errors_total",
+    Help: "Total Kafka consumer read errors.",
+})
+```
+
+- [ ] **Step 2: Record lag metrics in consumer.go**
+
+Add a method to `Consumer` that reads stats from the kafka.Reader and publishes them, then call it periodically. Add a goroutine in `Run()`:
+
+In `consumer.go`, add after the `c.connected.Store(true)` line inside the fetch loop:
+
+```go
+// Record consumer lag from reader stats.
+stats := c.reader.Stats()
+for _, topicStats := range []struct {
+    topic string
+    lag   int64
+}{
+    {TopicOrders, stats.Lag},
+    {TopicCart, stats.Lag},
+    {TopicViews, stats.Lag},
+} {
+    metrics.ConsumerLag.WithLabelValues(topicStats.topic).Set(float64(topicStats.lag))
+}
+```
+
+Note: `kafka.Reader.Stats()` returns aggregate stats when using consumer groups. The `Lag` field represents total lag across all assigned partitions. Since we have a single consumer with 3 group topics, we record the aggregate lag. For per-topic lag, we'd need separate readers — this is sufficient for alerting.
+
+Simplify to just record the aggregate:
+
+```go
+stats := c.reader.Stats()
+metrics.ConsumerLag.WithLabelValues("aggregate").Set(float64(stats.Lag))
+```
+
+Also increment error counter on fetch errors — add in the error branch:
+
+```go
+metrics.ConsumerErrors.Inc()
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd go/analytics-service && go test ./... -race -v
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/analytics-service/internal/metrics/prometheus.go go/analytics-service/internal/consumer/consumer.go
+git commit -m "feat(analytics): expose Kafka consumer lag as Prometheus metrics"
+```
+
+---
+
+## Task 9: Add Kafka Lag Alert Rule
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-alerting.yml`
+
+- [ ] **Step 1: Add Streaming Analytics alert group**
+
+Add after the Application SLOs group:
+
+```yaml
+      - orgId: 1
+        name: Streaming Analytics
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: kafka-consumer-lag-high
+            title: Kafka Consumer Lag High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kafka_consumer_lag
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 1000
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Kafka consumer lag is above 1000 messages"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-alerting.yml
+git commit -m "feat(monitoring): add Kafka consumer lag alert rule"
+```
+
+---
+
+## Task 10: Add Streaming Analytics Dashboard Panels
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-dashboards.yml`
+
+- [ ] **Step 1: Add Streaming Analytics row to go-services.json**
+
+In `k8s/monitoring/configmaps/grafana-dashboards.yml`, locate the go-services.json dashboard section. After the last panel in the "AI Service Agent" row (around line 1490), add a new row and 3 panels:
+
+**Row panel:**
+```json
+{
+  "collapsed": false,
+  "gridPos": { "h": 1, "w": 24, "x": 0, "y": 35 },
+  "id": 22,
+  "title": "Streaming Analytics",
+  "type": "row"
+}
+```
+
+**Panel 1 — Consumer Lag:**
+```json
+{
+  "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+  "fieldConfig": { "defaults": { "unit": "short" } },
+  "gridPos": { "h": 6, "w": 8, "x": 0, "y": 36 },
+  "id": 23,
+  "title": "Kafka Consumer Lag",
+  "type": "timeseries",
+  "targets": [
+    {
+      "expr": "kafka_consumer_lag",
+      "legendFormat": "{{ topic }}",
+      "refId": "A"
+    }
+  ]
+}
+```
+
+**Panel 2 — Consumption Rate:**
+```json
+{
+  "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+  "fieldConfig": { "defaults": { "unit": "ops" } },
+  "gridPos": { "h": 6, "w": 8, "x": 8, "y": 36 },
+  "id": 24,
+  "title": "Events Consumed Rate",
+  "type": "timeseries",
+  "targets": [
+    {
+      "expr": "sum(rate(analytics_events_consumed_total[5m])) by (topic)",
+      "legendFormat": "{{ topic }}",
+      "refId": "A"
+    }
+  ]
+}
+```
+
+**Panel 3 — Consumer Errors:**
+```json
+{
+  "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+  "fieldConfig": { "defaults": { "unit": "short" } },
+  "gridPos": { "h": 6, "w": 8, "x": 16, "y": 36 },
+  "id": 25,
+  "title": "Consumer Errors",
+  "type": "stat",
+  "targets": [
+    {
+      "expr": "increase(kafka_consumer_errors_total[1h])",
+      "legendFormat": "errors",
+      "refId": "A"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-dashboards.yml
+git commit -m "feat(monitoring): add Streaming Analytics panels to Go services dashboard"
+```
+
+---
+
+## Task 11: Create Observability Overview Correlation Dashboard
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-dashboards.yml`
+
+- [ ] **Step 1: Add observability-overview.json dashboard**
+
+In `k8s/monitoring/configmaps/grafana-dashboards.yml`, add a new key under `data:`:
+
+```yaml
+  observability-overview.json: |
+```
+
+The dashboard JSON has 3 rows:
+
+**Row 1 — Service Health (Prometheus):** Error rate and p95 latency panels per service stack, using the same metrics as the SLO alerts.
+
+**Row 2 — Logs (Loki):** A logs panel querying Loki filtered by namespace, showing error/warn level logs. Template variable `$namespace` lets you switch between namespaces.
+
+**Row 3 — Recent Traces (Jaeger):** A table panel showing recent traces from the Jaeger datasource.
+
+The full dashboard JSON should include:
+- `templating.list` with a `namespace` variable (values: `go-ecommerce`, `java-tasks`, `ai-services`)
+- Time range linked panels (clicking a time range on row 1 filters rows 2 and 3)
+- Loki panel targets using `{namespace="$namespace"} | json | level=~"error|warn"`
+- Dashboard uid: `observability-overview`
+- Dashboard title: `Observability Overview`
+
+Construct the complete JSON following the same format as the existing dashboards in the ConfigMap (annotations, editable, panels array, templating, time, etc.).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-dashboards.yml
+git commit -m "feat(monitoring): add Observability Overview correlation dashboard"
+```
+
+---
+
+## Task 12: Write Learning Documentation
+
+**Files:**
+- Create: `docs/adr/observability/01-three-pillars.md`
+- Create: `docs/adr/observability/02-prometheus-and-metrics.md`
+- Create: `docs/adr/observability/03-loki-and-logs.md`
+- Create: `docs/adr/observability/04-jaeger-and-traces.md`
+- Create: `docs/adr/observability/05-alerting-and-slos.md`
+- Create: `docs/adr/observability/06-correlation.md`
+
+- [ ] **Step 1: Write 01-three-pillars.md**
+
+Cover:
+- What are metrics, logs, and traces — with concrete examples from this project
+- Monitoring vs observability — the difference between "is it up?" and "why is it slow?"
+- When to reach for each pillar: metrics for detection, logs for investigation, traces for distributed path analysis
+- The "three pillars" model and its limitations (they overlap, correlation is what makes them powerful)
+- Reference: this project's stack (Prometheus for metrics, Loki for logs, Jaeger for traces, Grafana as the unified UI)
+
+- [ ] **Step 2: Write 02-prometheus-and-metrics.md**
+
+Cover:
+- Pull vs push model — why Prometheus scrapes targets instead of receiving pushes
+- The four metric types with examples from this project:
+  - Counter: `http_requests_total`, `analytics_events_consumed_total`
+  - Gauge: `kafka_consumer_lag`, `go_goroutines`
+  - Histogram: `http_request_duration_seconds_bucket` — explain how buckets work
+  - Summary: when to use vs histogram (hint: almost never)
+- PromQL basics using actual queries from our dashboards/alerts
+- Infrastructure metrics: what kube-state-metrics and node-exporter provide
+- How Prometheus discovers scrape targets (static config vs kubernetes_sd_configs)
+
+- [ ] **Step 3: Write 03-loki-and-logs.md**
+
+Cover:
+- Why centralized logging matters (the OOM kill that started this project — you had to SSH in to see it)
+- Loki architecture: distributor → ingester → storage, but in single-binary mode it's all one process
+- Label-based indexing vs ELK full-text indexing — trade-offs (Loki: cheap storage, slow grep; ELK: fast search, expensive storage)
+- LogQL query language with examples: `{namespace="go-ecommerce"} | json | level="error"`, rate queries
+- Promtail: how it discovers and tails pod logs, pipeline stages for parsing JSON
+- Structured logging: why JSON logs with consistent field names (level, msg, traceID) matter
+
+- [ ] **Step 4: Write 04-jaeger-and-traces.md**
+
+Cover:
+- What a span is (unit of work with start time, duration, tags, parent)
+- What a trace is (tree of spans sharing a traceID)
+- Context propagation: W3C traceparent header, how traceID flows across HTTP calls
+- This project's setup: Go SDK + otelgin middleware + otelhttp client transport
+- Kafka trace propagation: `InjectKafka`/`ExtractKafka` in `go/pkg/tracing/kafka.go` — how traceID survives async message passing
+- The request flow: HTTP request → gateway → ecommerce → Kafka message → analytics-service, all sharing one traceID
+- When tracing helps (latency debugging, dependency mapping) vs when it's noise (high-volume background jobs)
+
+- [ ] **Step 5: Write 05-alerting-and-slos.md**
+
+Cover:
+- Symptom-based vs cause-based alerting — "error rate is high" vs "disk is 80% full"
+- Why symptom-based wins (fewer alerts, catches unknown unknowns)
+- The RED method: Rate, Errors, Duration — the standard for request-driven services
+- What an SLO is: a target for user-facing reliability (e.g., "99.9% of requests succeed")
+- SLI vs SLO vs SLA — the measurement, the target, the contract
+- This project's SLOs: why 5% error rate for AI service (LLM failures are expected) vs 2% for ecommerce (reliability critical)
+- Alert fatigue: why pending periods matter, why not everything should be critical
+- Our alert hierarchy: Infrastructure (node pressure) → Kubernetes Health (OOM, restarts) → Application SLOs (error rate, latency) → Streaming (Kafka lag)
+
+- [ ] **Step 6: Write 06-correlation.md**
+
+Cover:
+- The observability workflow: alert fires → metrics dashboard → logs → traces
+- Walk through a concrete scenario using this project:
+  1. Telegram alert: "Go ecommerce error rate above 2%"
+  2. Open Grafana Observability Overview dashboard, see the spike in the metrics row
+  3. Scroll to logs row, filter by `level="error"`, see the error messages
+  4. Find a log line with `traceID`, click it
+  5. Jaeger shows the full trace: HTTP request → ecommerce handler → Redis timeout → circuit breaker trip
+  6. Root cause identified: Redis was restarting
+- How the correlation works technically: Promtail extracts traceID → Grafana derived fields → Jaeger link
+- Kafka's observability challenge: producer and consumer are decoupled in time, but traceID bridges them
+- The "unknown unknowns" argument: metrics tell you something is wrong, logs tell you what, traces tell you where
+
+- [ ] **Step 7: Commit all docs**
+
+```bash
+git add docs/adr/observability/
+git commit -m "docs: add observability learning guides (three pillars, Prometheus, Loki, Jaeger, SLOs, correlation)"
+```
+
+---
+
+## Task 13: Deploy and Verify
+
+- [ ] **Step 1: Run preflight checks**
+
+```bash
+make preflight-go
+```
+
+Expected: All Go lint and tests pass.
+
+- [ ] **Step 2: Push feature branch**
+
+```bash
+git push -u origin agent/feat-observability-full-stack
+```
+
+- [ ] **Step 3: Watch CI**
+
+Monitor the GitHub Actions run. Wait for all checks to complete.
+
+- [ ] **Step 4: If CI passes, create PR to qa**
+
+```bash
+gh pr create --base qa --title "feat: full-stack observability (Loki, alerts, SLOs, Kafka monitoring, correlation)" --body "$(cat <<'EOF'
+## Summary
+- Deploy Loki + Promtail for centralized log aggregation
+- Add 6 Kubernetes health alerts (OOM, restarts, memory/disk pressure, stuck deployments)
+- Add 6 application SLO alerts (error rate + p95 latency for Go AI, Go ecommerce, Java gateway)
+- Add Kafka consumer lag metrics and alerting
+- Add traceID to Go service logs for log-to-trace correlation
+- Add structured JSON logging to Java services
+- Create Observability Overview correlation dashboard (metrics → logs → traces)
+- Add 6 learning docs covering observability fundamentals
+
+## Test plan
+- [ ] Verify Loki and Promtail pods are running in monitoring namespace
+- [ ] Query `{namespace="go-ecommerce"}` in Grafana Explore with Loki datasource
+- [ ] Verify all alert rules appear in Grafana Alerting UI
+- [ ] Check Go services dashboard has Streaming Analytics row
+- [ ] Open Observability Overview dashboard, verify 3 rows render
+- [ ] Click a traceID in logs panel, verify Jaeger trace opens
+- [ ] Review learning docs in docs/adr/observability/
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: If CI fails, debug and fix**
+
+Check the specific failure, fix it, push, and re-run from step 3.

--- a/docs/superpowers/specs/2026-04-19-observability-full-stack-design.md
+++ b/docs/superpowers/specs/2026-04-19-observability-full-stack-design.md
@@ -1,0 +1,234 @@
+# Full-Stack Observability Design
+
+## Context
+
+Java services on the Debian server were getting OOM-killed with no alerting in place to catch it. The immediate fix (JVM heap caps + increased memory limits) is deployed, but it exposed significant observability gaps: no log aggregation, no K8s health alerts beyond GPU/AI-service, no application SLOs, no Kafka pipeline monitoring, and no way to correlate between metrics, logs, and traces.
+
+This spec designs a comprehensive observability stack that:
+1. Fills the operational gaps so issues like OOM kills are caught immediately
+2. Adds the missing pillar (logs via Loki) to complete the metrics/logs/traces trifecta
+3. Introduces application-level SLOs using the RED method
+4. Monitors the Kafka streaming analytics pipeline
+5. Connects all three pillars through a correlation dashboard
+6. Includes learning documentation covering observability fundamentals
+
+**Primary goal:** Portfolio showcase demonstrating distributed systems observability, with learning docs to build deep understanding for interviews.
+
+---
+
+## Section 1: Loki Log Aggregation
+
+### Problem
+Container logs are only accessible via `kubectl logs` over SSH. No centralized search, no persistence after pod restarts, no correlation with metrics or traces.
+
+### Components
+
+**Loki** (single-binary mode)
+- Deployed as a StatefulSet in `monitoring` namespace
+- PVC for log persistence (matching Prometheus's retention model)
+- Single-binary mode is appropriate for a single-node Minikube cluster
+
+**Promtail** (DaemonSet)
+- Runs on every node, tails container logs from `/var/log/pods/`
+- Adds Kubernetes labels: namespace, pod, container
+- Parses structured JSON logs from Go services to extract `level`, `msg`, `traceID`
+- Ships logs to Loki
+
+**Grafana datasource**
+- Add Loki as a datasource alongside Prometheus
+- Configure derived fields to turn `traceID` values into clickable Jaeger links
+
+### Why Loki
+Loki indexes only labels (namespace, pod, level), not full text. This makes it lightweight for a single-node cluster. Built by the Grafana team, so correlation with Prometheus metrics is native. ELK would be overkill for this scale.
+
+### Files
+- `k8s/monitoring/statefulsets/loki.yml` — Loki StatefulSet
+- `k8s/monitoring/daemonsets/promtail.yml` — Promtail DaemonSet
+- `k8s/monitoring/configmaps/promtail-config.yml` — Promtail pipeline config
+- `k8s/monitoring/configmaps/loki-config.yml` — Loki storage/retention config
+- `k8s/monitoring/services/loki.yml` — Loki ClusterIP service
+- `k8s/monitoring/configmaps/grafana-datasource.yml` — Add Loki datasource
+- `k8s/monitoring/pvc/loki-data.yml` — Loki PVC
+- `k8s/monitoring/kustomization.yaml` — Add new resources
+
+---
+
+## Section 2: Kubernetes Health Alerts
+
+### Problem
+Only 4 alert rules exist (GPU exporter down, AI service not ready, GPU temp, GPU VRAM). No alerts for OOM kills, pod restart storms, node pressure, or stuck deployments.
+
+### New Alert Rules
+
+Added to `k8s/monitoring/configmaps/grafana-alerting.yml` as a new "Kubernetes Health" alert group:
+
+| Alert | PromQL | Severity | Pending |
+|-------|--------|----------|---------|
+| Container OOM Killed | `kube_pod_container_status_terminated_reason{reason="OOMKilled"} > 0` | critical | 0s |
+| Pod Restart Storm | `increase(kube_pod_container_status_restarts_total[30m]) > 3` | warning | 5m |
+| Container Memory High | `container_memory_working_set_bytes{container!=""} / on(pod,container,namespace) kube_pod_container_resource_limits{resource="memory"} > 0.85` | warning | 10m |
+| Node Memory Pressure | `kube_node_status_condition{condition="MemoryPressure",status="true"} == 1` | critical | 2m |
+| Node Disk Pressure | `kube_node_status_condition{condition="DiskPressure",status="true"} == 1` | critical | 2m |
+| Deployment Replicas Unavailable | `kube_deployment_status_replicas_available < kube_deployment_spec_replicas` | warning | 5m |
+
+All route to the existing Telegram contact point.
+
+### Files
+- `k8s/monitoring/configmaps/grafana-alerting.yml` — Add "Kubernetes Health" alert group
+
+---
+
+## Section 3: Application SLOs
+
+### Problem
+Infrastructure alerts tell you something broke. SLOs tell you the user experience is degrading before anything crashes. No application-level alerting exists today.
+
+### Approach
+Use the RED method (Rate, Errors, Duration) — the standard for request-driven services.
+
+### SLO Definitions
+
+| Service | SLI | SLO Target | Alert Threshold |
+|---------|-----|------------|-----------------|
+| Go AI service | HTTP 5xx rate | < 5% over 5m | > 5% for 5m |
+| Go ecommerce | HTTP 5xx rate | < 2% over 5m | > 2% for 5m |
+| Java gateway | HTTP 5xx rate | < 2% over 5m | > 2% for 5m |
+| Go AI service | p95 latency | < 30s | > 30s for 5m |
+| Go ecommerce | p95 latency | < 2s | > 2s for 5m |
+| Java gateway | p95 latency | < 3s | > 3s for 5m |
+
+These are percentage-over-window SLOs (not burn-rate). Simple and explainable — burn-rate can be layered on later.
+
+### Metric Names
+- **Go services:** `http_requests_total` (counter with `status` label), `http_request_duration_seconds_bucket` (histogram)
+- **Java services:** `http_server_requests_seconds_count` (Actuator counter with `status` tag), `http_server_requests_seconds_bucket` (histogram)
+
+SLO alert PromQL must use the correct metric name per service stack.
+
+### Files
+- `k8s/monitoring/configmaps/grafana-alerting.yml` — Add "Application SLOs" alert group
+
+---
+
+## Section 4: Kafka Consumer Lag Monitoring
+
+### Problem
+The ecommerce → Kafka → analytics-service pipeline is invisible. If the consumer falls behind or stops, events pile up silently.
+
+### Approach
+The `segmentio/kafka-go` reader exposes stats programmatically. Add Prometheus metrics to the analytics-service:
+
+- `kafka_consumer_lag` — messages behind per topic/partition
+- `kafka_consumer_messages_total` — total consumed per topic
+- `kafka_consumer_errors_total` — read errors
+
+### Alert
+
+| Alert | Condition | Severity | Pending |
+|-------|-----------|----------|---------|
+| Kafka Consumer Lag High | `kafka_consumer_lag > 1000` | warning | 5m |
+
+### Dashboard
+Add a "Streaming Analytics" row to the Go services Grafana dashboard: consumer lag over time per topic, consumption rate, error rate.
+
+### Files
+- `go/analytics-service/internal/consumer/metrics.go` — Prometheus metrics registration
+- `go/analytics-service/internal/consumer/consumer.go` — Export reader stats as metrics
+- `k8s/monitoring/configmaps/grafana-alerting.yml` — Add Kafka lag alert
+- `k8s/monitoring/configmaps/grafana-dashboards.yml` — Add streaming analytics panels to Go services dashboard
+
+---
+
+## Section 5: Correlation Dashboard
+
+### Problem
+Metrics, logs, and traces exist in separate views. The real value of observability is connecting them — seeing an error rate spike, clicking through to the logs, and following a traceID into the full request trace.
+
+### Dashboard: "Observability Overview"
+
+A single Grafana dashboard with three linked rows:
+
+1. **Service Health (Prometheus)** — Error rate and p95 latency per service using SLO metrics. Clicking a time range filters the rows below.
+2. **Logs (Loki)** — Filtered by namespace, showing error/warn logs for the selected window. Log lines with traceID are clickable links.
+3. **Trace Links (Jaeger)** — Clicking a traceID from logs opens the Jaeger trace view showing the full request path, including Kafka message hops.
+
+### How Correlation Works
+- Promtail extracts `traceID` from structured JSON logs as a label
+- Grafana derived fields on the Loki datasource turn traceID values into Jaeger datasource links
+- This creates the metrics -> logs -> traces drill-down flow
+
+### Files
+- `k8s/monitoring/configmaps/grafana-dashboards.yml` — Add "Observability Overview" dashboard JSON
+- `k8s/monitoring/configmaps/grafana-datasource.yml` — Add derived fields to Loki datasource config
+
+---
+
+## Section 6: Learning Documentation
+
+### Location
+`docs/adr/observability/` — markdown guides building from fundamentals to this implementation.
+
+### Documents
+
+1. **`01-three-pillars.md`** — The Three Pillars of Observability
+   - Metrics, logs, traces: what each answers
+   - When to reach for each one
+   - Monitoring vs observability
+
+2. **`02-prometheus-and-metrics.md`** — Metrics with Prometheus
+   - Pull model, metric types (counter/gauge/histogram/summary)
+   - PromQL with examples from this project's actual queries
+   - How kube-state-metrics and node-exporter work
+
+3. **`03-loki-and-logs.md`** — Log Aggregation with Loki
+   - Why centralized logging matters in distributed systems
+   - Loki's label indexing vs ELK's full-text indexing
+   - LogQL basics with project examples
+   - Structured logging and JSON log parsing
+
+4. **`04-jaeger-and-traces.md`** — Distributed Tracing with Jaeger and OpenTelemetry
+   - Spans, traces, context propagation
+   - This project's OTel setup and Kafka header propagation
+   - Request flow: gateway -> ecommerce -> Kafka -> analytics with trace context
+
+5. **`05-alerting-and-slos.md`** — Alerting Philosophy and SLOs
+   - Symptom-based vs cause-based alerting
+   - RED method for request-driven services
+   - SLO concepts: targets, SLIs, what breach means
+   - This project's specific SLOs and rationale
+
+6. **`06-correlation.md`** — Connecting the Pillars
+   - The observability workflow: alert -> metrics -> logs -> traces
+   - How traceID ties everything together
+   - Correlation dashboard walkthrough
+   - Kafka async observability challenges
+
+---
+
+## Verification
+
+### Loki
+- `kubectl get pods -n monitoring` — Loki and Promtail pods running
+- Grafana Explore: query `{namespace="java-tasks"}` returns recent logs
+- Grafana Explore: query `{namespace="go-ecommerce"} | json | level="error"` parses structured logs
+
+### K8s Health Alerts
+- Verify alerts appear in Grafana Alerting UI under "Kubernetes Health" group
+- Test OOM alert: deploy a pod with artificially low memory limit, confirm Telegram notification
+
+### Application SLOs
+- Verify alerts appear under "Application SLOs" group
+- Send requests to services, confirm metrics feed the alert rules
+
+### Kafka Monitoring
+- `kubectl exec -n go-ecommerce deploy/analytics-service -- wget -qO- localhost:8084/metrics | grep kafka_consumer_lag` — metric is exposed
+- Check Go services dashboard has the new streaming analytics panels
+
+### Correlation Dashboard
+- Open "Observability Overview" dashboard
+- Click a time range on the metrics panel, confirm logs panel filters
+- Find a log line with traceID, click it, confirm Jaeger trace opens
+
+### Learning Docs
+- All 6 documents exist in `docs/adr/observability/`
+- Each references actual project code, queries, and configurations

--- a/go/ai-service/cmd/server/main.go
+++ b/go/ai-service/cmd/server/main.go
@@ -55,6 +55,10 @@ func runServe() {
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
+	slog.SetDefault(slog.New(
+		tracing.NewLogHandler(slog.NewJSONHandler(os.Stdout, nil)),
+	))
+
 	// Circuit breakers
 	ollamaBreaker := newCircuitBreaker("ai-ollama")
 	ecomBreaker := newCircuitBreaker("ai-ecommerce")

--- a/go/analytics-service/cmd/server/main.go
+++ b/go/analytics-service/cmd/server/main.go
@@ -29,6 +29,10 @@ func main() {
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
+	slog.SetDefault(slog.New(
+		tracing.NewLogHandler(slog.NewJSONHandler(os.Stdout, nil)),
+	))
+
 	orders := aggregator.NewOrderAggregator()
 	trending := aggregator.NewTrendingAggregator()
 	carts := aggregator.NewCartAggregator()

--- a/go/analytics-service/internal/consumer/consumer.go
+++ b/go/analytics-service/internal/consumer/consumer.go
@@ -65,10 +65,15 @@ func (c *Consumer) Run(ctx context.Context) error {
 				return nil // shutting down
 			}
 			slog.Error("kafka fetch error", "error", err)
+			metrics.ConsumerErrors.Inc()
 			continue
 		}
 
 		c.connected.Store(true)
+
+		// Record consumer lag from reader stats.
+		stats := c.reader.Stats()
+		metrics.ConsumerLag.Set(float64(stats.Lag))
 
 		// Extract trace context from Kafka headers.
 		msgCtx := tracing.ExtractKafka(ctx, msg.Headers)

--- a/go/analytics-service/internal/metrics/prometheus.go
+++ b/go/analytics-service/internal/metrics/prometheus.go
@@ -18,4 +18,16 @@ var (
 		Help:    "Histogram of aggregation update latency.",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"aggregator"})
+
+	// ConsumerLag tracks how far behind the consumer is.
+	ConsumerLag = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "kafka_consumer_lag",
+		Help: "Number of messages the consumer is behind.",
+	})
+
+	// ConsumerErrors counts Kafka consumer read errors.
+	ConsumerErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "kafka_consumer_errors_total",
+		Help: "Total Kafka consumer read errors.",
+	})
 )

--- a/go/auth-service/cmd/server/main.go
+++ b/go/auth-service/cmd/server/main.go
@@ -29,6 +29,10 @@ func main() {
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
+	slog.SetDefault(slog.New(
+		tracing.NewLogHandler(slog.NewJSONHandler(os.Stdout, nil)),
+	))
+
 	pool := connectPostgres(ctx, cfg.DatabaseURL)
 	defer pool.Close()
 

--- a/go/ecommerce-service/cmd/server/main.go
+++ b/go/ecommerce-service/cmd/server/main.go
@@ -63,6 +63,10 @@ func main() {
 	}
 	defer func() { _ = shutdownTracer(ctx) }()
 
+	slog.SetDefault(slog.New(
+		tracing.NewLogHandler(slog.NewJSONHandler(os.Stdout, nil)),
+	))
+
 	pool := connectPostgres(ctx, cfg.DatabaseURL)
 	defer pool.Close()
 

--- a/go/ecommerce-service/internal/middleware/logging.go
+++ b/go/ecommerce-service/internal/middleware/logging.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func Logging() gin.HandlerFunc {
@@ -16,7 +17,8 @@ func Logging() gin.HandlerFunc {
 		start := time.Now()
 		c.Next()
 		latency := time.Since(start)
-		slog.Info("request",
+
+		attrs := []any{
 			"requestId", requestID,
 			"method", c.Request.Method,
 			"path", c.Request.URL.Path,
@@ -24,6 +26,13 @@ func Logging() gin.HandlerFunc {
 			"latency", latency.String(),
 			"ip", c.ClientIP(),
 			"userId", c.GetString("userId"),
-		)
+		}
+
+		sc := trace.SpanContextFromContext(c.Request.Context())
+		if sc.HasTraceID() {
+			attrs = append(attrs, "traceID", sc.TraceID().String())
+		}
+
+		slog.InfoContext(c.Request.Context(), "request", attrs...)
 	}
 }

--- a/go/pkg/tracing/logging.go
+++ b/go/pkg/tracing/logging.go
@@ -1,0 +1,37 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// LogHandler wraps an slog.Handler to inject traceID from OpenTelemetry span context.
+type LogHandler struct {
+	slog.Handler
+}
+
+// NewLogHandler creates a handler that adds traceID to log records when a span is active.
+func NewLogHandler(h slog.Handler) *LogHandler {
+	return &LogHandler{Handler: h}
+}
+
+// Handle adds the traceID attribute if a valid span context exists.
+func (h *LogHandler) Handle(ctx context.Context, r slog.Record) error {
+	sc := trace.SpanContextFromContext(ctx)
+	if sc.HasTraceID() {
+		r.AddAttrs(slog.String("traceID", sc.TraceID().String()))
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+// WithAttrs returns a new LogHandler wrapping the inner handler's WithAttrs.
+func (h *LogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &LogHandler{Handler: h.Handler.WithAttrs(attrs)}
+}
+
+// WithGroup returns a new LogHandler wrapping the inner handler's WithGroup.
+func (h *LogHandler) WithGroup(name string) slog.Handler {
+	return &LogHandler{Handler: h.Handler.WithGroup(name)}
+}

--- a/java/activity-service/Dockerfile
+++ b/java/activity-service/Dockerfile
@@ -8,4 +8,4 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 EXPOSE 8082
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx512m", "-jar", "app.jar"]

--- a/java/activity-service/src/main/resources/logback-spring.xml
+++ b/java/activity-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <message>msg</message>
+                <level>level</level>
+                <logger>logger</logger>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON" />
+    </root>
+
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
+</configuration>

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -29,6 +29,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
         runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+        implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
 

--- a/java/gateway-service/Dockerfile
+++ b/java/gateway-service/Dockerfile
@@ -8,4 +8,4 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx512m", "-jar", "app.jar"]

--- a/java/gateway-service/src/main/resources/logback-spring.xml
+++ b/java/gateway-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <message>msg</message>
+                <level>level</level>
+                <logger>logger</logger>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON" />
+    </root>
+
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
+</configuration>

--- a/java/k8s/deployments/activity-service.yml
+++ b/java/k8s/deployments/activity-service.yml
@@ -35,7 +35,7 @@ spec:
               memory: "256Mi"
               cpu: "200m"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"
               cpu: "500m"
           readinessProbe:
             httpGet:

--- a/java/k8s/deployments/gateway-service.yml
+++ b/java/k8s/deployments/gateway-service.yml
@@ -41,7 +41,7 @@ spec:
               memory: "256Mi"
               cpu: "200m"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"
               cpu: "500m"
           readinessProbe:
             httpGet:

--- a/java/k8s/deployments/notification-service.yml
+++ b/java/k8s/deployments/notification-service.yml
@@ -35,7 +35,7 @@ spec:
               memory: "256Mi"
               cpu: "200m"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"
               cpu: "500m"
           readinessProbe:
             httpGet:

--- a/java/k8s/deployments/task-service.yml
+++ b/java/k8s/deployments/task-service.yml
@@ -56,7 +56,7 @@ spec:
               memory: "256Mi"
               cpu: "200m"
             limits:
-              memory: "512Mi"
+              memory: "768Mi"
               cpu: "500m"
           readinessProbe:
             httpGet:

--- a/java/notification-service/Dockerfile
+++ b/java/notification-service/Dockerfile
@@ -8,4 +8,4 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 EXPOSE 8083
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx512m", "-jar", "app.jar"]

--- a/java/notification-service/src/main/resources/logback-spring.xml
+++ b/java/notification-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <message>msg</message>
+                <level>level</level>
+                <logger>logger</logger>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON" />
+    </root>
+
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
+</configuration>

--- a/java/task-service/Dockerfile
+++ b/java/task-service/Dockerfile
@@ -8,4 +8,4 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 
 EXPOSE 8081
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xmx512m", "-jar", "app.jar"]

--- a/java/task-service/src/main/resources/logback-spring.xml
+++ b/java/task-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <message>msg</message>
+                <level>level</level>
+                <logger>logger</logger>
+            </fieldNames>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="JSON" />
+    </root>
+
+    <logger name="org.springframework" level="WARN" />
+    <logger name="org.hibernate" level="WARN" />
+</configuration>

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -756,3 +756,51 @@ data:
               severity: warning
             annotations:
               summary: "Java gateway p95 latency is above 3s"
+
+      - orgId: 1
+        name: Streaming Analytics
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: kafka-consumer-lag-high
+            title: Kafka Consumer Lag High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kafka_consumer_lag
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 1000
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Kafka consumer lag is above 1000 messages"

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -475,3 +475,284 @@ data:
               severity: warning
             annotations:
               summary: "Deployment {{ $labels.deployment }} in {{ $labels.namespace }} has unavailable replicas"
+
+      - orgId: 1
+        name: Application SLOs
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: go-ai-error-rate
+            title: Go AI Service Error Rate High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    sum(rate(http_requests_total{service="go-ai-service",status=~"5.."}[5m]))
+                    / sum(rate(http_requests_total{service="go-ai-service"}[5m]))
+                    * 100
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 5
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go AI service error rate is above 5%"
+
+          - uid: go-ecommerce-error-rate
+            title: Go Ecommerce Error Rate High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    sum(rate(http_requests_total{service="go-ecommerce-service",status=~"5.."}[5m]))
+                    / sum(rate(http_requests_total{service="go-ecommerce-service"}[5m]))
+                    * 100
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 2
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go ecommerce service error rate is above 2%"
+
+          - uid: java-gateway-error-rate
+            title: Java Gateway Error Rate High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    sum(rate(http_server_requests_seconds_count{namespace="java-tasks",status=~"5.."}[5m]))
+                    / sum(rate(http_server_requests_seconds_count{namespace="java-tasks"}[5m]))
+                    * 100
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 2
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Java gateway error rate is above 2%"
+
+          - uid: go-ai-latency-high
+            title: Go AI Service Latency High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    histogram_quantile(0.95,
+                      sum(rate(http_request_duration_seconds_bucket{service="go-ai-service"}[5m])) by (le)
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 30
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go AI service p95 latency is above 30s"
+
+          - uid: go-ecommerce-latency-high
+            title: Go Ecommerce Latency High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    histogram_quantile(0.95,
+                      sum(rate(http_request_duration_seconds_bucket{service="go-ecommerce-service"}[5m])) by (le)
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 2
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Go ecommerce service p95 latency is above 2s"
+
+          - uid: java-gateway-latency-high
+            title: Java Gateway Latency High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    histogram_quantile(0.95,
+                      sum(rate(http_server_requests_seconds_bucket{namespace="java-tasks"}[5m])) by (le)
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 3
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Java gateway p95 latency is above 3s"

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -205,3 +205,273 @@ data:
               severity: warning
             annotations:
               summary: "GPU VRAM usage is above 90%"
+
+      - orgId: 1
+        name: Kubernetes Health
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: container-oom-killed
+            title: Container OOM Killed
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kube_pod_container_status_terminated_reason{reason="OOMKilled"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 0s
+            labels:
+              severity: critical
+            annotations:
+              summary: "Container {{ $labels.container }} in pod {{ $labels.pod }} was OOM killed"
+
+          - uid: pod-restart-storm
+            title: Pod Restart Storm
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: increase(kube_pod_container_status_restarts_total[30m])
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 1800
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 3
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Pod {{ $labels.pod }} has restarted more than 3 times in 30 minutes"
+
+          - uid: container-memory-high
+            title: Container Memory High
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    max by (pod, container, namespace) (
+                      container_memory_working_set_bytes{container!=""}
+                      / on(pod, container, namespace)
+                      kube_pod_container_resource_limits{resource="memory"}
+                    )
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0.85
+                  refId: C
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Container {{ $labels.container }} in {{ $labels.namespace }}/{{ $labels.pod }} is using >85% of memory limit"
+
+          - uid: node-memory-pressure
+            title: Node Memory Pressure
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kube_node_status_condition{condition="MemoryPressure",status="true"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Node {{ $labels.node }} is under memory pressure"
+
+          - uid: node-disk-pressure
+            title: Node Disk Pressure
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: kube_node_status_condition{condition="DiskPressure",status="true"}
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Node {{ $labels.node }} is under disk pressure"
+
+          - uid: deployment-replicas-unavailable
+            title: Deployment Replicas Unavailable
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    kube_deployment_spec_replicas
+                    - kube_deployment_status_replicas_available
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Deployment {{ $labels.deployment }} in {{ $labels.namespace }} has unavailable replicas"

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -1487,6 +1487,111 @@ data:
               "placement": "bottom"
             }
           }
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 22,
+          "title": "Streaming Analytics",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 36
+          },
+          "id": 23,
+          "title": "Kafka Consumer Lag",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "kafka_consumer_lag",
+              "legendFormat": "lag",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "color": {
+                "mode": "palette-classic"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 36
+          },
+          "id": 24,
+          "title": "Events Consumed Rate",
+          "type": "timeseries",
+          "targets": [
+            {
+              "expr": "sum(rate(analytics_events_consumed_total[5m])) by (topic)",
+              "legendFormat": "{{ topic }}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 36
+          },
+          "id": 25,
+          "title": "Consumer Errors",
+          "type": "stat",
+          "targets": [
+            {
+              "expr": "increase(kafka_consumer_errors_total[1h])",
+              "legendFormat": "errors",
+              "refId": "A"
+            }
+          ]
         }
       ],
       "schemaVersion": 39,

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -3020,3 +3020,246 @@ data:
       "uid": "system-overview",
       "version": 1
     }
+  observability-overview.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "title": "Service Health",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "panels": []
+        },
+        {
+          "title": "Error Rate by Service",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m])) * 100",
+              "legendFormat": "error %",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "title": "P95 Latency",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 3,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, service))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "title": "Application Logs",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "id": 4,
+          "panels": []
+        },
+        {
+          "title": "Logs",
+          "type": "logs",
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 5,
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"$namespace\"} | json | level=~\"error|warn\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": false,
+            "enableLogDetails": true,
+            "sortOrder": "Descending",
+            "dedupStrategy": "none"
+          }
+        },
+        {
+          "title": "Traces",
+          "type": "row",
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 6,
+          "panels": []
+        },
+        {
+          "title": "Recent Error Traces",
+          "type": "table",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+          "id": 7,
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "targets": [
+            {
+              "expr": "{namespace=\"$namespace\"} | json | level=\"error\" | line_format \"{{.traceID}}\"",
+              "refId": "A"
+            }
+          ],
+          "options": {
+            "showHeader": true,
+            "sortBy": []
+          },
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [
+        "observability",
+        "overview"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": true,
+              "text": "go-ecommerce",
+              "value": "go-ecommerce"
+            },
+            "name": "namespace",
+            "options": [
+              {
+                "selected": true,
+                "text": "go-ecommerce",
+                "value": "go-ecommerce"
+              },
+              {
+                "selected": false,
+                "text": "java-tasks",
+                "value": "java-tasks"
+              },
+              {
+                "selected": false,
+                "text": "ai-services",
+                "value": "ai-services"
+              }
+            ],
+            "query": "go-ecommerce,java-tasks,ai-services",
+            "type": "custom"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Observability Overview",
+      "uid": "observability-overview",
+      "version": 1
+    }

--- a/k8s/monitoring/configmaps/grafana-datasource.yml
+++ b/k8s/monitoring/configmaps/grafana-datasource.yml
@@ -4,7 +4,7 @@ metadata:
   name: grafana-datasource
   namespace: monitoring
 data:
-  prometheus.yml: |
+  datasources.yml: |
     apiVersion: 1
     datasources:
       - name: Prometheus
@@ -13,3 +13,23 @@ data:
         url: http://prometheus.monitoring.svc.cluster.local:9090
         isDefault: true
         editable: false
+        uid: PBFA97CFB590B2093
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.monitoring.svc.cluster.local:3100
+        editable: false
+        uid: loki
+        jsonData:
+          derivedFields:
+            - datasourceUid: jaeger
+              matcherRegex: '"traceID":"([a-f0-9]+)"'
+              name: TraceID
+              url: "$${__value.raw}"
+              urlDisplayLabel: View Trace
+      - name: Jaeger
+        type: jaeger
+        access: proxy
+        url: http://jaeger.monitoring.svc.cluster.local:16686
+        editable: false
+        uid: jaeger

--- a/k8s/monitoring/configmaps/loki-config.yml
+++ b/k8s/monitoring/configmaps/loki-config.yml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: monitoring
+data:
+  loki.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+      log_level: warn
+
+    common:
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        instance_addr: 127.0.0.1
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: "2024-01-01"
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      retention_period: 168h
+      max_query_series: 500
+      max_query_parallelism: 2
+
+    compactor:
+      working_directory: /loki/compactor
+      compaction_interval: 10m
+      retention_enabled: true
+      retention_delete_delay: 2h
+      delete_request_store: filesystem

--- a/k8s/monitoring/configmaps/promtail-config.yml
+++ b/k8s/monitoring/configmaps/promtail-config.yml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: monitoring
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 3101
+      grpc_listen_port: 0
+      log_level: warn
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+        pipeline_stages:
+          - cri: {}
+          - json:
+              expressions:
+                level: level
+                msg: msg
+                traceID: traceID
+          - labels:
+              level:
+          - output:
+              source: msg
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: app
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+          - source_labels: [__meta_kubernetes_container_name]
+            target_label: container

--- a/k8s/monitoring/daemonsets/promtail.yml
+++ b/k8s/monitoring/daemonsets/promtail.yml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      containers:
+        - name: promtail
+          image: grafana/promtail:3.0.0
+          args:
+            - -config.file=/etc/promtail/promtail.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/promtail
+            - name: pods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: promtail-config
+        - name: pods
+          hostPath:
+            path: /var/log/pods
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/k8s/monitoring/deployments/grafana.yml
+++ b/k8s/monitoring/deployments/grafana.yml
@@ -36,13 +36,13 @@ spec:
             - name: TELEGRAM_BOT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: grafana-secrets
-                  key: TELEGRAM_BOT_TOKEN
+                  name: telegram-bot
+                  key: bot-token
                   optional: true
           volumeMounts:
             - name: datasource
-              mountPath: /etc/grafana/provisioning/datasources/prometheus.yml
-              subPath: prometheus.yml
+              mountPath: /etc/grafana/provisioning/datasources/datasources.yml
+              subPath: datasources.yml
             - name: dashboard-provider
               mountPath: /etc/grafana/provisioning/dashboards/dashboard.yml
               subPath: dashboard.yml

--- a/k8s/monitoring/kustomization.yaml
+++ b/k8s/monitoring/kustomization.yaml
@@ -10,16 +10,20 @@ resources:
   - rbac/prometheus-clusterrolebinding.yml
   - rbac/prometheus-serviceaccount.yml
   - pvc/prometheus-data.yml
+  - pvc/loki-data.yml
   - configmaps/grafana-dashboard-provider.yml
   - configmaps/grafana-dashboards.yml
   - configmaps/grafana-datasource.yml
   - configmaps/grafana-alerting.yml
+  - configmaps/loki-config.yml
   - configmaps/prometheus-config.yml
   - deployments/grafana.yml
   - deployments/jaeger.yml
   - deployments/kube-state-metrics.yml
   - deployments/prometheus.yml
+  - statefulsets/loki.yml
   - daemonsets/node-exporter.yml
+  - services/loki.yml
   - services/grafana.yml
   - services/jaeger.yml
   - services/kube-state-metrics.yml

--- a/k8s/monitoring/kustomization.yaml
+++ b/k8s/monitoring/kustomization.yaml
@@ -9,6 +9,9 @@ resources:
   - rbac/prometheus-clusterrole.yml
   - rbac/prometheus-clusterrolebinding.yml
   - rbac/prometheus-serviceaccount.yml
+  - rbac/promtail-clusterrole.yml
+  - rbac/promtail-clusterrolebinding.yml
+  - rbac/promtail-serviceaccount.yml
   - pvc/prometheus-data.yml
   - pvc/loki-data.yml
   - configmaps/grafana-dashboard-provider.yml
@@ -16,6 +19,7 @@ resources:
   - configmaps/grafana-datasource.yml
   - configmaps/grafana-alerting.yml
   - configmaps/loki-config.yml
+  - configmaps/promtail-config.yml
   - configmaps/prometheus-config.yml
   - deployments/grafana.yml
   - deployments/jaeger.yml
@@ -23,6 +27,7 @@ resources:
   - deployments/prometheus.yml
   - statefulsets/loki.yml
   - daemonsets/node-exporter.yml
+  - daemonsets/promtail.yml
   - services/loki.yml
   - services/grafana.yml
   - services/jaeger.yml

--- a/k8s/monitoring/pvc/loki-data.yml
+++ b/k8s/monitoring/pvc/loki-data.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/k8s/monitoring/rbac/promtail-clusterrole.yml
+++ b/k8s/monitoring/rbac/promtail-clusterrole.yml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/proxy", "services", "endpoints", "pods"]
+    verbs: ["get", "watch", "list"]

--- a/k8s/monitoring/rbac/promtail-clusterrolebinding.yml
+++ b/k8s/monitoring/rbac/promtail-clusterrolebinding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: monitoring

--- a/k8s/monitoring/rbac/promtail-serviceaccount.yml
+++ b/k8s/monitoring/rbac/promtail-serviceaccount.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: monitoring

--- a/k8s/monitoring/services/loki.yml
+++ b/k8s/monitoring/services/loki.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  selector:
+    app: loki
+  ports:
+    - port: 3100
+      targetPort: 3100
+      name: http
+  type: ClusterIP

--- a/k8s/monitoring/statefulsets/loki.yml
+++ b/k8s/monitoring/statefulsets/loki.yml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  replicas: 1
+  serviceName: loki
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.0.0
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - containerPort: 3100
+              name: http
+            - containerPort: 9096
+              name: grpc
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: loki-data


### PR DESCRIPTION
## Summary
- Deploy Loki + Promtail for centralized log aggregation (completes the three pillars)
- Add 6 Kubernetes health alerts (OOM kill, pod restarts, memory/disk pressure, stuck deployments)
- Add 6 application SLO alerts using RED method (error rate + p95 latency for Go AI, Go ecommerce, Java gateway)
- Add Kafka consumer lag Prometheus metrics and alerting
- Add traceID to Go service logs for log-to-trace correlation via Loki derived fields
- Add structured JSON logging to Java services via logstash-logback-encoder
- Create Observability Overview correlation dashboard (metrics → logs → traces drill-down)
- Add Streaming Analytics panels (consumer lag, consumption rate, errors) to Go services dashboard
- Write 6 learning guides covering observability fundamentals (three pillars, Prometheus, Loki, Jaeger, SLOs, correlation)

## Test plan
- [ ] Verify Loki and Promtail pods are running in monitoring namespace
- [ ] Query `{namespace="go-ecommerce"}` in Grafana Explore with Loki datasource
- [ ] Verify all 16 alert rules appear in Grafana Alerting UI (4 existing + 6 K8s + 6 SLO)
- [ ] Check Go services dashboard has new Streaming Analytics row
- [ ] Open Observability Overview dashboard, verify 3 rows render
- [ ] Click a traceID in logs panel, verify Jaeger trace opens
- [ ] Verify `kafka_consumer_lag` metric is exposed on analytics-service /metrics
- [ ] Review learning docs in docs/adr/observability/

🤖 Generated with [Claude Code](https://claude.com/claude-code)