### PR TITLE
feat: add Observability portfolio page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Portfolio project for a Gen AI Engineer job application — demonstrating RAG ar
 
 - **Python:** FastAPI microservices (ingestion, chat, debug), LangChain text splitters, Qdrant vector DB
 - **Java:** Spring Boot microservices (task, activity, notification, gateway), PostgreSQL, MongoDB, Redis, RabbitMQ, GraphQL
-- **Go:** Auth, ecommerce, and AI agent services, PostgreSQL, Redis, RabbitMQ, shared `go/pkg/` module (see `go/CLAUDE.md`)
+- **Go:** Auth, ecommerce, AI agent, and analytics services, PostgreSQL, Redis, RabbitMQ, Kafka, shared `go/pkg/` module (see `go/CLAUDE.md`)
 - **AI/ML:** Ollama (Qwen 2.5 14B for chat/debug, nomic-embed-text for embeddings)
 - **Frontend:** Next.js + TypeScript + shadcn/ui, Apollo Client (GraphQL)
 - **Testing:** pytest, JUnit, Go test/benchmarks, Playwright (E2E)
@@ -23,7 +23,7 @@ Portfolio project for a Gen AI Engineer job application — demonstrating RAG ar
   - `ai-services` namespace: Python AI services + Qdrant
   - `java-tasks` namespace: Java microservices + databases
   - `go-ecommerce` namespace: Go auth + ecommerce services
-  - `monitoring` namespace: Prometheus + Grafana
+  - `monitoring` namespace: Prometheus, Grafana, Loki, Promtail, Jaeger, kube-state-metrics, node-exporter
   - `ai-services-qa` namespace: QA copies of Python AI services (shared Qdrant with prod)
   - `java-tasks-qa` namespace: QA copies of Java services (shared infra with prod)
   - `go-ecommerce-qa` namespace: QA copies of Go services (shared infra with prod)
@@ -96,6 +96,7 @@ go/                         # Go microservices
 ├── auth-service/           # JWT auth (register, login, refresh), PostgreSQL
 ├── ecommerce-service/      # Products, cart, orders, Redis caching, RabbitMQ worker pool
 ├── ai-service/             # Agent loop over Ollama tool-calling, 9 tools wrapping ecommerce
+├── analytics-service/      # Kafka consumer — streaming analytics (orders, cart, views)
 ├── k8s/                    # Go-specific K8s manifests
 frontend/                   # Next.js + shadcn/ui
 ├── src/app/                # Pages: ai/ (rag, debug), java/ (tasks), go/ (ecommerce)
@@ -105,9 +106,9 @@ frontend/                   # Next.js + shadcn/ui
 nginx/                      # Reverse proxy — path-based routing to all backend stacks
 k8s/                        # Kubernetes manifests — production deployment (Minikube)
 ├── ai-services/            # Python AI services + Qdrant
-├── monitoring/             # Prometheus + Grafana
+├── monitoring/             # Full observability stack (see Monitoring section below)
 ├── deploy.sh               # Unified deploy script for all namespaces
-monitoring/                 # Prometheus + Grafana config files
+monitoring/                 # Local Docker Compose Prometheus + Grafana config files
 docs/adr/                   # Architecture Decision Records
 ├── document-qa/            # 7 notebooks (Python/FastAPI, RAG pipeline)
 ├── document-debugger/      # 3 notebooks (code-aware chunking, agent loop, tools)
@@ -130,6 +131,53 @@ The Go ai-service (`go/ai-service/`) is the MCP gateway for all AI functionality
 - **Frontend integration:** POST /chat with SSE streaming. Frontend client in `frontend/src/lib/ai-service.ts` parses event types.
 - **Roadmap (Q2 2026, issue #75):** Phase 1: architecture doc → Phase 2: unified AI assistant UI (#77) → Phase 3: Loki log aggregation (#78) → Phase 4a-c: RAG eval harness, hybrid search, cross-encoder re-ranking (#79-#81).
 
+## Monitoring & Observability
+
+Three pillars deployed in the `monitoring` namespace (`k8s/monitoring/`):
+
+- **Metrics (Prometheus):** Scrapes kube-state-metrics, node-exporter, GPU exporter, and all app pods via `prometheus.io/scrape` annotations. 15s scrape interval, 15-day retention, 8GB max storage.
+- **Logs (Loki + Promtail):** Loki (single-binary, StatefulSet with 5Gi PVC) stores logs. Promtail (DaemonSet) tails `/var/log/pods/`, parses JSON logs, extracts `level` and `traceID` labels, ships to Loki. Go services emit structured JSON via `slog` + `tracing.NewLogHandler()`. Java services use `logstash-logback-encoder` for JSON output.
+- **Traces (Jaeger):** OTLP gRPC collector on port 4317. Go services use OTel SDK with `otelgin` middleware. Trace context propagates across HTTP (W3C traceparent), Kafka headers (`go/pkg/tracing/kafka.go`), and RabbitMQ headers.
+- **Correlation:** Loki datasource has derived fields that turn `traceID` in log lines into clickable Jaeger links. The "Observability Overview" dashboard shows metrics → logs → traces drill-down.
+
+**Grafana dashboards** (5 total, embedded in `k8s/monitoring/configmaps/grafana-dashboards.yml`):
+- `system-overview.json` — GPU, system, RAG pipeline
+- `go-services.json` — RED metrics, Go runtime, ecommerce, cache, AI agent, streaming analytics
+- `kubernetes.json` — Pod status, restarts, deployment replicas
+- `ai-pipeline.json` — Ollama, RAG, embeddings, vector search
+- `observability-overview.json` — Correlation dashboard (metrics/logs/traces)
+
+**Alert rules** (4 groups in `k8s/monitoring/configmaps/grafana-alerting.yml`, all → Telegram):
+- Infrastructure: GPU exporter down, AI service not ready, GPU temp, GPU VRAM
+- Kubernetes Health: OOM killed, pod restart storm, container memory high, node memory/disk pressure, deployment replicas unavailable
+- Application SLOs: Error rate + p95 latency for Go AI (5%/30s), Go ecommerce (2%/2s), Java gateway (2%/3s)
+- Streaming Analytics: Kafka consumer lag > 1000
+
+**Datasources** (`k8s/monitoring/configmaps/grafana-datasource.yml`):
+- Prometheus: uid `PBFA97CFB590B2093` (referenced by all alert rules — do not change)
+- Loki: uid `loki`
+- Jaeger: uid `jaeger`
+
+**Minikube:** Allocated 16Gi memory (cannot increase without `minikube delete` which wipes all cluster state). Currently sufficient.
+
+## Kafka Streaming Analytics
+
+The Go analytics-service (`go/analytics-service/`, port 8094) consumes events from Kafka:
+
+- **Broker:** Apache Kafka 3.7.0 (KRaft mode, no Zookeeper), StatefulSet in `go-ecommerce` namespace
+- **Topics:** `ecommerce.orders`, `ecommerce.cart`, `ecommerce.views`
+- **Producers:** ecommerce-service (orders, cart events), ai-service (product view events, optional)
+- **Consumer:** analytics-service, consumer group `analytics-group`, aggregates into order/cart/trending metrics
+- **Library:** `segmentio/kafka-go` v0.4.50
+- **Prometheus metrics:** `analytics_events_consumed_total`, `analytics_aggregation_latency_seconds`, `kafka_consumer_lag`, `kafka_consumer_errors_total`
+- **Trace propagation:** W3C trace context in Kafka message headers via `go/pkg/tracing/kafka.go`
+
+## Java Service Resource Limits
+
+Java services use `-Xmx512m` heap cap (set in Dockerfiles) with 768Mi container memory limits. Without the heap cap, JVM auto-sizing can cause OOM kills. If adding a new Java service, always include `-Xmx512m` in the `ENTRYPOINT`.
+
+**`make preflight-java` fails on Mac** — requires JDK 21 which is not installed locally. Java compilation and tests run correctly in CI (Debian server has JDK 21). This is a known limitation of the local dev setup.
+
 ## Kyle's Background
 
 - Strong in Go and TypeScript (full-stack web apps)
@@ -150,6 +198,7 @@ Current ADRs:
 - `docs/adr/document-qa/` — 7 Jupyter notebooks covering the ingestion and chat services
 - `docs/adr/document-debugger/` — 3 Jupyter notebooks covering the debug assistant
 - `docs/adr/java-task-management/` — 7 markdown lessons covering the Java microservices stack
+- `docs/adr/observability/` — 6 markdown guides (three pillars, Prometheus, Loki, Jaeger, SLOs, correlation)
 - Standalone markdown ADRs for CI/CD, deployment architecture, K8s migration, analytics, auth, etc.
 
 ## Branching & Workflow

--- a/docs/superpowers/specs/2026-04-19-observability-frontend-page-design.md
+++ b/docs/superpowers/specs/2026-04-19-observability-frontend-page-design.md
@@ -1,0 +1,99 @@
+# Observability Frontend Page Design
+
+## Context
+
+The portfolio just shipped a full observability stack: Loki + Promtail for log aggregation, 16 Grafana alert rules across 4 groups, application SLOs, Kafka consumer lag monitoring, traceID log injection, and a correlation dashboard. None of this is visible in the frontend. The portfolio already has dedicated pages for AWS, CI/CD, and Security — observability deserves the same treatment.
+
+**Goal:** Add a new top-level `/observability` page that showcases the three-pillar observability architecture for hiring managers. Narrative + diagrams, no data fetching.
+
+---
+
+## Page Structure
+
+### 1. Hero
+- Title: "Observability"
+- One paragraph: production monitoring across three pillars (metrics, logs, traces) with automated alerting and cross-pillar correlation. Every service in this portfolio is instrumented.
+
+### 2. Architecture Diagram (Mermaid)
+Flowchart showing the full data flow:
+- **Top:** Application services (Go, Java, Python) emit metrics, logs, and traces
+- **Middle:** Collection layer — Prometheus scrapes metrics, Promtail ships logs, OTel SDK exports traces
+- **Bottom:** Backend storage — Prometheus TSDB, Loki, Jaeger
+- **Output:** Grafana (dashboards + alerting) → Telegram notifications
+
+### 3. Metrics Section (Prometheus)
+- Color accent: orange (border-left)
+- Pull-based model, 15s scrape interval
+- Infrastructure: kube-state-metrics, node-exporter, GPU exporter
+- Application: pod annotations for auto-discovery
+- Example metrics shown as inline code badges: `http_requests_total`, `kafka_consumer_lag`, `container_memory_working_set_bytes`
+
+### 4. Logs Section (Loki + Promtail)
+- Color accent: green
+- Promtail DaemonSet tails all container logs
+- Structured JSON logging (Go `slog`, Java `logstash-logback-encoder`)
+- traceID extraction for log-to-trace correlation
+- Example LogQL in a code block: `{namespace="go-ecommerce"} | json | level="error"`
+
+### 5. Traces Section (Jaeger + OpenTelemetry)
+- Color accent: purple
+- OTel SDK with `otelgin` middleware for HTTP
+- W3C traceparent propagation across HTTP boundaries
+- Kafka message header trace propagation (`InjectKafka`/`ExtractKafka`)
+- A request traces from HTTP → ecommerce → Kafka → analytics-service
+
+### 6. Alerting Section
+- Color accent: red
+- 16 rules across 4 groups, displayed as a 2x2 card grid:
+  - **Infrastructure:** GPU exporter, AI service health, GPU temp/VRAM
+  - **Kubernetes Health:** OOM kills, restart storms, memory/disk pressure, stuck deployments
+  - **Application SLOs:** Error rate + p95 latency (Go AI 5%/30s, Go ecommerce 2%/2s, Java gateway 2%/3s)
+  - **Streaming Analytics:** Kafka consumer lag > 1000
+- All route to Telegram via Grafana unified alerting
+
+### 7. Correlation Section
+- Color accent: yellow
+- Mermaid sequence diagram showing the investigation workflow:
+  1. Telegram alert fires
+  2. Open Grafana metrics dashboard, see the spike
+  3. Scroll to logs, filter by error level
+  4. Find traceID in log line, click it
+  5. Jaeger trace shows the full request path → root cause
+- Explain: structured logging injects traceID → Promtail extracts it → Grafana derived fields create clickable Jaeger links
+
+### 8. Footer CTA
+- "View Live Grafana Dashboard →" button linking to `https://grafana.kylebradshaw.dev`
+
+---
+
+## Navigation
+
+Add "Observability" to `SiteHeader.tsx` nav links, positioned between "CI/CD" and "Security".
+
+---
+
+## Files
+
+- **Create:** `frontend/src/app/observability/page.tsx` — the full page
+- **Modify:** `frontend/src/components/SiteHeader.tsx` — add nav link
+
+---
+
+## Patterns
+
+- Layout: `<div className="mx-auto max-w-3xl px-6 py-12">` (matches all other pages)
+- Diagrams: `<MermaidDiagram chart={...} />` component
+- Cards: shadcn/ui `Card` components for the alerting grid
+- Static content only — no API calls, no client components needed
+- Section borders color-coded: orange (metrics), green (logs), purple (traces), red (alerting), yellow (correlation)
+
+---
+
+## Verification
+
+- `npm run build` passes
+- Page renders at `localhost:3000/observability`
+- Nav link appears between CI/CD and Security, highlights correctly on active
+- Both Mermaid diagrams render (architecture + correlation sequence)
+- Grafana link opens correctly
+- Page follows same visual style as `/cicd` and `/security`

--- a/frontend/src/app/observability/page.tsx
+++ b/frontend/src/app/observability/page.tsx
@@ -1,0 +1,268 @@
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+import Link from "next/link";
+
+const architectureDiagram = `flowchart TD
+  subgraph Apps["Application Services"]
+    direction LR
+    GO["Go Services<br/><i>auth · ecommerce · ai · analytics</i>"]
+    JAVA["Java Services<br/><i>task · activity · notification · gateway</i>"]
+    PY["Python Services<br/><i>ingestion · chat · debug · eval</i>"]
+  end
+
+  subgraph Collect["Collection Layer"]
+    direction LR
+    PROM_SC["Prometheus Scrape<br/><i>15s interval · pod annotations</i>"]
+    PROMTAIL["Promtail DaemonSet<br/><i>JSON parsing · traceID extraction</i>"]
+    OTEL["OTel SDK<br/><i>W3C traceparent · Kafka headers</i>"]
+  end
+
+  subgraph Store["Storage"]
+    direction LR
+    PROM["Prometheus<br/><i>TSDB · 15d retention</i>"]
+    LOKI["Loki<br/><i>label-indexed · 7d retention</i>"]
+    JAEGER["Jaeger<br/><i>OTLP gRPC collector</i>"]
+  end
+
+  subgraph Out["Output"]
+    direction LR
+    GRAFANA["Grafana<br/><i>5 dashboards · 16 alert rules</i>"]
+    TELEGRAM["Telegram<br/><i>instant notifications</i>"]
+  end
+
+  Apps -->|metrics| PROM_SC
+  Apps -->|logs| PROMTAIL
+  Apps -->|traces| OTEL
+
+  PROM_SC --> PROM
+  PROMTAIL --> LOKI
+  OTEL --> JAEGER
+
+  PROM --> GRAFANA
+  LOKI --> GRAFANA
+  JAEGER --> GRAFANA
+  GRAFANA -->|alerts| TELEGRAM`;
+
+const correlationDiagram = `sequenceDiagram
+  participant T as Telegram
+  participant G as Grafana
+  participant P as Prometheus
+  participant L as Loki
+  participant J as Jaeger
+
+  T->>G: Alert: error rate > 2%
+  G->>P: Query error rate metrics
+  P-->>G: Spike at 14:32
+  G->>L: Filter logs by namespace + time
+  L-->>G: Error logs with traceID
+  G->>J: Open trace by traceID
+  J-->>G: Full request path
+  Note over G: Root cause identified`;
+
+const ALERT_GROUPS = [
+  {
+    name: "Infrastructure",
+    color: "border-red-500/50",
+    description: "GPU exporter health, AI service readiness, GPU temperature and VRAM usage",
+    count: 4,
+  },
+  {
+    name: "Kubernetes Health",
+    color: "border-red-500/50",
+    description: "OOM kills, pod restart storms, container memory pressure, node disk pressure, stuck deployments",
+    count: 6,
+  },
+  {
+    name: "Application SLOs",
+    color: "border-red-500/50",
+    description: "HTTP error rate and p95 latency targets for Go AI, Go ecommerce, and Java gateway services",
+    count: 6,
+  },
+  {
+    name: "Streaming Analytics",
+    color: "border-red-500/50",
+    description: "Kafka consumer lag monitoring across order, cart, and product view event topics",
+    count: 1,
+  },
+];
+
+export default function ObservabilityPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="mt-8 text-3xl font-bold">Observability</h1>
+
+      {/* Intro */}
+      <section className="mt-8">
+        <p className="text-muted-foreground leading-relaxed">
+          Production monitoring across three pillars &mdash; metrics, logs, and
+          traces &mdash; with automated alerting and cross-pillar correlation.
+          Every service in this portfolio is instrumented, and a single traceID
+          connects a Grafana metric spike to the relevant log lines to the full
+          distributed trace in Jaeger.
+        </p>
+      </section>
+
+      {/* Architecture diagram */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Architecture</h2>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          Three language stacks feed three collection pipelines. Everything
+          converges in Grafana for unified dashboards and alerting.
+        </p>
+        <div className="mt-6 rounded-xl border border-foreground/10 bg-card p-6">
+          <MermaidDiagram chart={architectureDiagram} />
+        </div>
+      </section>
+
+      {/* Metrics */}
+      <section className="mt-12">
+        <div className="border-l-4 border-orange-500/60 pl-4">
+          <h2 className="text-2xl font-semibold">Metrics &mdash; Prometheus</h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Prometheus scrapes every pod annotated with{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              prometheus.io/scrape: &quot;true&quot;
+            </code>{" "}
+            on a 15-second interval. Infrastructure exporters provide cluster
+            and hardware visibility: kube-state-metrics for pod status and
+            deployment health, node-exporter for CPU, memory, and disk, and a
+            GPU exporter for NVIDIA utilization and temperature.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {[
+              "http_requests_total",
+              "http_request_duration_seconds",
+              "kafka_consumer_lag",
+              "container_memory_working_set_bytes",
+              "go_goroutines",
+              "nvidia_smi_temperature_gpu",
+            ].map((m) => (
+              <code
+                key={m}
+                className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+              >
+                {m}
+              </code>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Logs */}
+      <section className="mt-12">
+        <div className="border-l-4 border-green-500/60 pl-4">
+          <h2 className="text-2xl font-semibold">
+            Logs &mdash; Loki + Promtail
+          </h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Promtail runs as a DaemonSet on every node, tailing container logs
+            from{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              /var/log/pods/
+            </code>
+            . Go services emit structured JSON via{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              slog
+            </code>{" "}
+            with a custom handler that injects the OpenTelemetry traceID into
+            every log line. Java services use logstash-logback-encoder for the
+            same JSON output. Loki indexes only labels &mdash; namespace, pod,
+            level &mdash; keeping storage efficient on a single-node cluster.
+          </p>
+          <div className="mt-4 rounded-lg border border-foreground/10 bg-muted/50 p-3">
+            <code className="text-xs text-green-400">
+              {'{namespace="go-ecommerce"} | json | level="error"'}
+            </code>
+          </div>
+        </div>
+      </section>
+
+      {/* Traces */}
+      <section className="mt-12">
+        <div className="border-l-4 border-purple-500/60 pl-4">
+          <h2 className="text-2xl font-semibold">
+            Traces &mdash; Jaeger + OpenTelemetry
+          </h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            The Go services are instrumented with the OpenTelemetry SDK.{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              otelgin
+            </code>{" "}
+            middleware auto-instruments HTTP handlers, and{" "}
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+              otelhttp
+            </code>{" "}
+            propagates W3C traceparent headers on outbound calls. Trace context
+            also flows through Kafka message headers, so a single request can be
+            traced from the HTTP gateway through ecommerce processing, across an
+            async Kafka boundary, to the analytics consumer.
+          </p>
+        </div>
+      </section>
+
+      {/* Alerting */}
+      <section className="mt-12">
+        <div className="border-l-4 border-red-500/60 pl-4">
+          <h2 className="text-2xl font-semibold">
+            Alerting &mdash; 16 Rules &rarr; Telegram
+          </h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            Four alert groups cover infrastructure through application layers.
+            Symptom-based SLO alerts catch user-facing degradation before
+            anything crashes. All alerts route to Telegram via Grafana unified
+            alerting.
+          </p>
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {ALERT_GROUPS.map((group) => (
+              <div
+                key={group.name}
+                className="rounded-lg border border-foreground/10 bg-card p-4"
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">{group.name}</h3>
+                  <span className="text-xs text-muted-foreground">
+                    {group.count} {group.count === 1 ? "rule" : "rules"}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+                  {group.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Correlation */}
+      <section className="mt-12">
+        <div className="border-l-4 border-yellow-500/60 pl-4">
+          <h2 className="text-2xl font-semibold">
+            Correlation &mdash; Connecting the Pillars
+          </h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            The real value of observability is connecting the pillars. Structured
+            logging injects the OpenTelemetry traceID into every log line.
+            Grafana&rsquo;s derived fields on the Loki datasource turn those
+            traceIDs into clickable Jaeger links. When an alert fires, the
+            investigation path is: metric spike &rarr; filtered logs &rarr;
+            distributed trace &rarr; root cause.
+          </p>
+          <div className="mt-6 rounded-xl border border-foreground/10 bg-card p-6">
+            <MermaidDiagram chart={correlationDiagram} />
+          </div>
+        </div>
+      </section>
+
+      {/* Footer CTA */}
+      <section className="mt-16 text-center">
+        <Link
+          href="https://grafana.kylebradshaw.dev/d/system-overview/system-overview?orgId=1&from=now-1h&to=now&timezone=browser"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          View Live Grafana Dashboard &rarr;
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -38,6 +38,12 @@ export function SiteHeader() {
             <Link href="/cicd" className={navLinkClass("/cicd")}>
               CI/CD
             </Link>
+            <Link
+              href="/observability"
+              className={navLinkClass("/observability")}
+            >
+              Observability
+            </Link>
             <Link href="/security" className={navLinkClass("/security")}>
               Security
             </Link>


### PR DESCRIPTION
## Summary
- Add `/observability` page showcasing the three-pillar monitoring stack
- Mermaid architecture diagram showing services → collectors → backends → Grafana
- Color-coded sections for Metrics (Prometheus), Logs (Loki), Traces (Jaeger)
- 2x2 card grid showing 16 alert rules across 4 groups
- Correlation sequence diagram showing the metrics → logs → traces investigation workflow
- Add "Observability" nav link to SiteHeader between CI/CD and Security

## Test plan
- [ ] Page renders at `/observability`
- [ ] Nav link appears between CI/CD and Security, highlights when active
- [ ] Both Mermaid diagrams render (architecture + correlation sequence)
- [ ] Grafana link opens correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)