### PR TITLE
fix: ecommerce Dockerfile copy product-service for gRPC imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,7 +724,7 @@ jobs:
             context: go
             file: go/ecommerce-service/Dockerfile
             image: go-ecommerce-service
-            paths: go/ecommerce-service go/pkg go/go.work
+            paths: go/ecommerce-service go/product-service go/pkg go/go.work
           - service: go-ai-service
             context: go
             file: go/ai-service/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,7 @@ jobs:
           - go/ecommerce-service/Dockerfile
           - go/ai-service/Dockerfile
           - go/analytics-service/Dockerfile
+          - go/product-service/Dockerfile
     steps:
       - uses: actions/checkout@v4
 

--- a/go/ecommerce-service/Dockerfile
+++ b/go/ecommerce-service/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.26-alpine AS builder
 
 WORKDIR /app/ecommerce-service
 COPY pkg/ /app/pkg/
+COPY product-service/ /app/product-service/
 COPY ecommerce-service/go.mod ecommerce-service/go.sum ./
 RUN go mod download
 COPY ecommerce-service/ .


### PR DESCRIPTION
## Summary
- Fix Docker build failure: ecommerce-service Dockerfile needs to copy `product-service/` directory since `go.mod` has a `replace` directive for the gRPC proto imports
- Add `go/product-service/Dockerfile` to Hadolint security scan matrix
- Update CI paths to trigger ecommerce rebuild when product-service changes

## Context
PR #102 introduced a cross-module dependency (ecommerce → product-service proto). The Dockerfile didn't copy product-service into the build context, causing `go mod download` to fail.

## Test plan
- [ ] CI passes (ecommerce Docker build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)