### PR TITLE
fix: handle missing Docker image in retag step for new services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,10 +819,15 @@ jobs:
           # When the build is skipped, :latest still exists from the last build.
           # The deploy rewrites manifests to qa-<sha>, so we retag :latest so
           # the deploy can find the image under the new tag.
+          # If :latest doesn't exist (new service), skip — the next push that
+          # touches the service's paths will trigger a full build.
           SHORT_SHA=$(echo "$SHA" | cut -c1-7)
-          docker pull "${IMAGE}:latest"
-          docker tag "${IMAGE}:latest" "${IMAGE}:qa-${SHORT_SHA}"
-          docker push "${IMAGE}:qa-${SHORT_SHA}"
+          if docker pull "${IMAGE}:latest" 2>/dev/null; then
+            docker tag "${IMAGE}:latest" "${IMAGE}:qa-${SHORT_SHA}"
+            docker push "${IMAGE}:qa-${SHORT_SHA}"
+          else
+            echo "No existing :latest for ${IMAGE} — skipping retag (new service, needs first build)"
+          fi
 
   # ---------- Deploy QA ----------
 

--- a/go/product-service/Dockerfile
+++ b/go/product-service/Dockerfile
@@ -1,5 +1,6 @@
 FROM migrate/migrate:v4.17.0 AS migrate
 
+# Product-service: REST :8095, gRPC :9095
 FROM golang:1.26-alpine AS builder
 
 WORKDIR /app/product-service


### PR DESCRIPTION
## Summary
- Fix retag step failing when a new service has no existing `:latest` image in GHCR
- Touch product-service Dockerfile to trigger its first Docker build via change detection

## Root cause
PR #103's push to `qa` only changed CI files, so `git diff HEAD~1` didn't detect product-service changes. The retag step tried `docker pull :latest` which doesn't exist yet for a brand-new service.

## Fix
- Wrap `docker pull` in a conditional — skip gracefully if `:latest` doesn't exist
- Include a product-service file change to trigger the first build

## Test plan
- [ ] CI passes — product-service Docker image builds and pushes for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)