### PR TITLE
fix: update smoke tests for product-service URL path

### DIFF
--- a/frontend/e2e/smoke-prod/smoke.spec.ts
+++ b/frontend/e2e/smoke-prod/smoke.spec.ts
@@ -235,7 +235,7 @@ test.describe("Go ecommerce smoke tests", () => {
   const SMOKE_PASSWORD = process.env.SMOKE_GO_PASSWORD;
 
   test("products endpoint returns a non-empty catalog", async ({ request }) => {
-    const res = await request.get(`${API_URL}/go-api/products`);
+    const res = await request.get(`${API_URL}/go-products/products`);
     expect(res.status()).toBe(200);
     const body = await res.json();
     expect(Array.isArray(body.products)).toBe(true);
@@ -243,7 +243,7 @@ test.describe("Go ecommerce smoke tests", () => {
   });
 
   test("categories endpoint returns a non-empty list", async ({ request }) => {
-    const res = await request.get(`${API_URL}/go-api/categories`);
+    const res = await request.get(`${API_URL}/go-products/categories`);
     expect(res.status()).toBe(200);
     const body = await res.json();
     expect(Array.isArray(body.categories)).toBe(true);
@@ -300,7 +300,7 @@ test.describe("Go ecommerce smoke tests", () => {
 
     // Step 2: Find the Smoke Test Widget product
     const productsRes = await authContext.get(
-      `${API_URL}/go-api/products?limit=50`
+      `${API_URL}/go-products/products?limit=50`
     );
     expect(productsRes.status()).toBe(200);
     const productsBody = await productsRes.json();


### PR DESCRIPTION
## Summary
- Update E2E smoke tests to use `/go-products/products` and `/go-products/categories` instead of `/go-api/products` and `/go-api/categories`
- Product endpoints moved from ecommerce-service to product-service with a new ingress path

## Context
QA smoke tests failed because they were still hitting the old ecommerce-service product routes which no longer exist.

Also manually seeded `productdb` on the QA cluster (tables were created but had no data).

## Test plan
- [ ] QA smoke tests pass — products, categories, and checkout lifecycle tests hit the new service

🤖 Generated with [Claude Code](https://claude.com/claude-code)