### PR TITLE
feat: update /go AI assistant section with RAG tools

### DIFF
--- a/docs/superpowers/specs/2026-04-21-go-page-microservices-redesign.md
+++ b/docs/superpowers/specs/2026-04-21-go-page-microservices-redesign.md
@@ -1,0 +1,168 @@
+# /go Page Redesign — Microservices Architecture Showcase
+
+## Context
+
+The `/go` page (`frontend/src/app/go/page.tsx`) was written when the ecommerce platform was a monolith (auth + ecommerce, 2 services). Phase 1-3 of the decomposition is now complete: product-service, cart-service, and order-service are extracted with gRPC inter-service communication and a RabbitMQ saga orchestrator. The page needs to reflect the new architecture as the featured view, preserve the original content for comparison, and pull the AI assistant into its own standalone section.
+
+## Design
+
+### Page Structure
+
+```
+/go page
+├── Bio section (updated: "six Go services")
+├── "Ecommerce Platform" heading
+├── Tab bar: [ Microservices (default) | Original ]
+│   ├── Microservices tab
+│   │   ├── "Why Decompose?" — portfolio-aware justification
+│   │   ├── Tech Stack — badge/pill list
+│   │   ├── Architecture — Mermaid diagram (6 services, gRPC, RabbitMQ, Kafka)
+│   │   ├── Checkout Saga Flow — sequence diagram (happy path + compensation)
+│   │   └── "What Changed" — 2x2 highlight cards
+│   └── Original tab
+│       ├── Old architecture description + Mermaid diagram
+│       ├── Old checkout sequence diagram
+│       └── Stress Testing & Scalability section
+├── CTA buttons (View Store, Streaming Analytics)
+└── AI Shopping Assistant (standalone section, below tabs)
+    ├── Existing content (tool catalog, agent loop, product search flow)
+    └── [Future spec will enhance this section]
+```
+
+### Tab Implementation
+
+Use client-side React state (`useState`) for the tab toggle — no routing changes. The tab bar sits below the "Ecommerce Platform" heading. "Microservices" is the default active tab. The page must be converted to `"use client"` since the current page is a server component.
+
+### Microservices Tab Content
+
+**"Why Decompose?" section:**
+Portfolio-aware tone: "I decomposed the monolithic ecommerce-service into three independent services to demonstrate service extraction patterns, gRPC inter-service communication, and saga-based distributed transactions — skills relevant to teams managing growing microservice architectures. Each service owns its own database, scales independently, and communicates through well-defined contracts."
+
+**Tech Stack:**
+Inline badge/pill format: 6 Go microservices, gRPC + Protobuf, RabbitMQ Saga, PostgreSQL (per-service), Redis, Kafka Analytics, Kubernetes + HPA, Prometheus + Jaeger.
+
+**Architecture diagram (Mermaid):**
+```mermaid
+flowchart LR
+  FE[Next.js Frontend]
+  AUTH[auth-service<br/>REST :8091]
+  PROD[product-service<br/>REST :8095 / gRPC :9095]
+  CART[cart-service<br/>REST :8096 / gRPC :9096]
+  ORD[order-service<br/>REST :8092]
+  AI[ai-service<br/>REST :8093]
+  ANA[analytics-service<br/>REST :8094]
+  PG_A[(authdb)]
+  PG_P[(productdb)]
+  PG_C[(cartdb)]
+  PG_O[(ecommercedb)]
+  RD[(Redis)]
+  MQ{{RabbitMQ<br/>Saga Exchange}}
+  KF{{Kafka}}
+
+  FE -->|REST /go-auth| AUTH
+  FE -->|REST /go-products| PROD
+  FE -->|REST /go-cart| CART
+  FE -->|REST /go-orders| ORD
+  FE -->|REST /ai-api| AI
+
+  AUTH --> PG_A
+  PROD --> PG_P
+  CART --> PG_C
+  ORD --> PG_O
+
+  CART -->|gRPC| PROD
+  ORD -->|gRPC| CART
+  ORD -->|gRPC| PROD
+
+  ORD -->|saga commands| MQ
+  MQ -->|saga events| ORD
+  MQ -->|saga commands| CART
+
+  ORD -->|order events| KF
+  CART -->|cart events| KF
+  KF --> ANA
+
+  PROD --> RD
+  CART --> RD
+```
+
+Short paragraph: "Six services communicate via REST (frontend-facing) and gRPC (inter-service). The checkout saga coordinates cart reservation, stock validation, and order completion through RabbitMQ command/event queues. Kafka streams analytics events to the analytics-service for real-time aggregation."
+
+**Checkout Saga Flow (sequence diagram):**
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant FE as Frontend
+  participant ORD as order-service
+  participant CART as cart-service
+  participant PROD as product-service
+  participant MQ as RabbitMQ
+  participant KF as Kafka
+
+  U->>FE: Click "Checkout"
+  FE->>ORD: POST /orders (Bearer JWT)
+  ORD->>CART: gRPC GetCart(userId)
+  CART->>PROD: gRPC GetProduct (price enrichment)
+  CART-->>ORD: cart items + prices
+  ORD->>ORD: INSERT order (status=pending, saga_step=CREATED)
+  ORD-->>FE: 201 order (status=pending)
+
+  Note over ORD,MQ: Saga begins asynchronously
+  ORD->>MQ: publish reserve.items
+  MQ->>CART: reserve.items command
+  CART->>CART: SET reserved=true
+  CART->>MQ: items.reserved event
+  MQ->>ORD: items.reserved
+  ORD->>PROD: gRPC CheckAvailability
+  PROD-->>ORD: available=true
+  ORD->>MQ: publish clear.cart
+  MQ->>CART: clear.cart command
+  CART->>CART: DELETE cart items
+  CART->>MQ: cart.cleared event
+  MQ->>ORD: cart.cleared
+  ORD->>ORD: status=completed, saga_step=COMPLETED
+  ORD->>KF: order.completed event
+  KF->>ANA: analytics aggregation
+```
+
+Short paragraph below explaining the compensation path: if stock check fails at the CheckAvailability step, order-service publishes `release.items` to unreserve cart items, marks order as FAILED. Crash recovery on startup queries incomplete sagas and resumes from last known step.
+
+**"What Changed" highlight cards (2x2 grid):**
+1. **Database-per-Service** — Each service owns its database (productdb, cartdb, ecommercedb). No shared tables.
+2. **gRPC Contracts** — Protobuf-defined service contracts with buf toolchain. Type-safe cross-service calls.
+3. **Saga Orchestration** — RabbitMQ-based saga with compensation flows, DLQ, and crash recovery.
+4. **Independent Scaling** — Each service has its own HPA, PDB, and resource limits. Scale what needs scaling.
+
+### Original Tab Content
+
+All current page content moves here unchanged:
+- Old "Two Go services — auth and ecommerce" architecture description + Mermaid diagram
+- Old synchronous checkout sequence diagram
+- Stress Testing & Scalability section (table, fixes applied, k6 details)
+
+Note: The AI Shopping Assistant does NOT go in this tab — it's now a standalone section.
+
+### AI Shopping Assistant Section
+
+Pulled out of the tabbed area into its own top-level section below the tabs and CTA buttons. Existing content preserved as-is:
+- Overview paragraph
+- Tool Catalog diagram
+- Agent Loop flowchart
+- Product search sequence diagram
+
+No content changes — just relocated. A future spec will enhance this section with MCP, RAG bridge, and other additions.
+
+### File Changes
+
+| File | Change |
+|------|--------|
+| `frontend/src/app/go/page.tsx` | Rewrite: add `"use client"`, tab state, new Microservices tab content, move old content to Original tab, pull AI section out |
+
+Single file change. No new components needed — the tab toggle is simple enough to inline with `useState`.
+
+## Verification
+
+- `npx tsc --noEmit` — no type errors
+- `npm run lint` — no lint errors
+- Visual check: both tabs render correctly, Mermaid diagrams load, AI section appears below tabs
+- Tab switching works (client-side state, no page reload)

--- a/docs/superpowers/specs/2026-04-21-go-page-rag-tools-update-design.md
+++ b/docs/superpowers/specs/2026-04-21-go-page-rag-tools-update-design.md
@@ -1,0 +1,78 @@
+# Go Page AI Assistant Section — RAG Tools Update
+
+## Context
+
+The Go ai-service recently gained 3 RAG tools (`search_documents`, `ask_document`, `list_collections`) that bridge to the Python chat/ingestion services and Qdrant vector DB. The frontend `AiAssistantDrawer` already renders RAG results (green-bordered cards with source citations), but the `/go` portfolio page's AI Shopping Assistant section still only documents the original 9 ecommerce tools. This update brings the page content in sync with the actual 12-tool agent.
+
+## Approach
+
+Expand existing content in-place (Approach A) — add a 4th tool domain to the catalog diagram, tweak the agent loop, and add a second request flow. No new components, no structural changes to the page layout.
+
+## Changes
+
+All edits are in `frontend/src/app/go/page.tsx`, within the `{/* AI Shopping Assistant — standalone section */}` block (lines 502–611).
+
+### 1. Update intro paragraph (lines 505–511)
+
+Current text describes the agent as wrapping "the ecommerce backend" with no mention of RAG.
+
+Replace with text that mentions both the ecommerce backend and RAG knowledge base, the cross-stack bridge (Go → Python chat service → Qdrant), circuit breakers, and OTel trace propagation across the stack boundary.
+
+### 2. Update Tool Catalog description + diagram (lines 513–546)
+
+**Description text:**
+- "nine tools" → "twelve tools"
+- "three domains" → "four domains"
+- Add sentence: Knowledge Base tools are public and hit the Python RAG pipeline via a circuit-breaker HTTP bridge with 30-second timeout.
+
+**Mermaid flowchart:** Add a 4th subgraph `Knowledge ["Knowledge Base (public, RAG)"]` containing:
+- `search_documents` — semantic search, ranked chunks
+- `ask_document` — natural-language Q&A with sources
+- `list_collections` — list vector store collections
+
+Add `AGENT --> Knowledge` edge. Keep the existing `place_order` excluded node.
+
+### 3. Update Agent Loop diagram (lines 548–579)
+
+Two label changes in the existing flowchart:
+- `DISPATCH` box: "Dispatch tool to ecommerce API" → "Dispatch tool to ecommerce API or RAG pipeline"
+- `GUARD` box: "Max 8 steps or 30s?" → "Max 8 steps or 90s?" (matches actual `agent.go` config)
+
+No structural changes to the flowchart.
+
+### 4. Add second request flow — RAG query (after line 610)
+
+New `<h3>` + `<p>` + `<MermaidDiagram>` block titled "Request flow: Product knowledge query".
+
+Example scenario: user asks "What's the warranty on the Storm Jacket?"
+
+Sequence diagram participants:
+- User, Frontend, AI Service, Ollama, Python Chat Svc, Qdrant
+
+Flow:
+1. User → FE: natural language question
+2. FE → AI Service: POST /chat (SSE stream, Bearer JWT)
+3. AI Service → Ollama: Chat(messages, tool_schemas)
+4. Ollama → AI Service: tool_call: ask_document
+5. AI Service → FE: SSE: tool_call event
+6. AI Service → Python Chat Svc: POST /chat {question, collection}
+7. Python Chat Svc → Qdrant: vector search
+8. Qdrant → Python Chat Svc: ranked chunks
+9. Python Chat Svc → Ollama: RAG prompt + context
+10. Ollama → Python Chat Svc: generated answer
+11. Python Chat Svc → AI Service: {answer, sources}
+12. AI Service → Ollama: Chat(messages + tool_result)
+13. Ollama → AI Service: final text
+14. AI Service → FE: SSE: final event
+15. FE → User: rendered answer with source citations
+
+## Files Modified
+
+- `frontend/src/app/go/page.tsx` — all 4 changes above
+
+## Verification
+
+1. `npx tsc --noEmit` — type check passes
+2. `npm run lint` — no lint errors
+3. Visual check — both tabs still render, all 4 Mermaid diagrams load, Knowledge Base subgraph visible in tool catalog, RAG sequence diagram renders below ecommerce one
+4. `make preflight-frontend` — full frontend preflight passes

--- a/frontend/src/app/go/page.tsx
+++ b/frontend/src/app/go/page.tsx
@@ -1,7 +1,14 @@
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
 import { MermaidDiagram } from "@/components/MermaidDiagram";
 
+type Tab = "microservices" | "original";
+
 export default function GoPage() {
+  const [activeTab, setActiveTab] = useState<Tab>("microservices");
+
   return (
     <div className="mx-auto max-w-3xl px-6 py-12">
       <h1 className="mt-8 text-3xl font-bold">Go Backend Developer</h1>
@@ -10,12 +17,12 @@ export default function GoPage() {
       <section className="mt-8">
         <p className="text-muted-foreground leading-relaxed">
           Go is my preferred language due to its readability, simplicity, and
-          strong performance. It’s my first choice for many backend tasks, and
-          I’ve used it to build microservices, automation scripts, and
+          strong performance. It&apos;s my first choice for many backend tasks,
+          and I&apos;ve used it to build microservices, automation scripts, and
           command-line tools with a focus on clean, efficient design.
         </p>
         <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
-          All three Go services expose Prometheus metrics to a live{" "}
+          All six Go services expose Prometheus metrics to a live{" "}
           <a
             href="https://grafana.kylebradshaw.dev/d/system-overview/system-overview?orgId=1&from=now-1h&to=now&timezone=browser"
             target="_blank"
@@ -28,42 +35,269 @@ export default function GoPage() {
         </p>
       </section>
 
-      {/* Project Section */}
+      {/* Project Section with Tabs */}
       <section className="mt-12">
         <h2 className="text-2xl font-semibold">Ecommerce Platform</h2>
 
-        <p className="mt-4 text-muted-foreground leading-relaxed">
-          Microservices ecommerce platform built with Go, demonstrating
-          RESTful API design, JWT authentication, PostgreSQL, Redis caching,
-          asynchronous order processing with RabbitMQ, and an LLM-powered
-          shopping assistant with tool-calling agent loop. Deployed using
-          Docker and Kubernetes.
-        </p>
+        {/* Tab Bar */}
+        <div className="mt-4 flex gap-0 border-b border-foreground/10">
+          <button
+            onClick={() => setActiveTab("microservices")}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              activeTab === "microservices"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Microservices
+          </button>
+          <button
+            onClick={() => setActiveTab("original")}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              activeTab === "original"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Original
+          </button>
+        </div>
 
-        <h3 className="mt-6 text-lg font-medium">Tech Stack</h3>
-        <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
-          <li>4 Go microservices (auth, ecommerce, ai-service, analytics)</li>
-          <li>Gin HTTP framework with JWT authentication</li>
-          <li>Ollama (Qwen 2.5 14B) tool-calling agent with 9 tools</li>
-          <li>PostgreSQL (users, products, carts, orders)</li>
-          <li>Redis caching + rate limiting</li>
-          <li>RabbitMQ asynchronous order processing</li>
-          <li>Apache Kafka streaming analytics pipeline</li>
-          <li>Prometheus metrics instrumentation</li>
-          <li>Next.js + TypeScript frontend</li>
-          <li>Docker Compose (local dev), Kubernetes (production)</li>
-        </ul>
+        {/* Microservices Tab */}
+        {activeTab === "microservices" && (
+          <div className="mt-8">
+            {/* Why Decompose */}
+            <section>
+              <h3 className="text-lg font-medium">Why Decompose?</h3>
+              <p className="mt-4 text-muted-foreground leading-relaxed">
+                I decomposed the monolithic ecommerce-service into three
+                independent services to demonstrate{" "}
+                <span className="text-foreground font-medium">
+                  service extraction patterns
+                </span>
+                ,{" "}
+                <span className="text-foreground font-medium">
+                  gRPC inter-service communication
+                </span>
+                , and{" "}
+                <span className="text-foreground font-medium">
+                  saga-based distributed transactions
+                </span>{" "}
+                &mdash; skills relevant to teams managing growing microservice
+                architectures. Each service owns its own database, scales
+                independently, and communicates through well-defined contracts.
+              </p>
+            </section>
 
-        <section className="mt-12">
-          <h2 className="text-2xl font-semibold">Architecture</h2>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            Two Go services — auth and ecommerce — sharing Postgres. The
-            ecommerce service caches product reads in Redis and offloads order
-            finalization to a RabbitMQ-driven goroutine worker pool.
-          </p>
-          <div className="mt-6">
-            <MermaidDiagram
-              chart={`flowchart LR
+            {/* Tech Stack */}
+            <section className="mt-8">
+              <h3 className="text-lg font-medium">Tech Stack</h3>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {[
+                  "6 Go microservices",
+                  "gRPC + Protobuf",
+                  "RabbitMQ Saga",
+                  "PostgreSQL (per-service)",
+                  "Redis",
+                  "Kafka Analytics",
+                  "Kubernetes + HPA",
+                  "Prometheus + Jaeger",
+                ].map((tech) => (
+                  <span
+                    key={tech}
+                    className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </section>
+
+            {/* Architecture Diagram */}
+            <section className="mt-12">
+              <h3 className="text-xl font-semibold">Architecture</h3>
+              <p className="mt-4 text-muted-foreground leading-relaxed">
+                Six services communicate via REST (frontend-facing) and gRPC
+                (inter-service). The checkout saga coordinates cart reservation,
+                stock validation, and order completion through RabbitMQ
+                command/event queues. Kafka streams analytics events to the
+                analytics-service for real-time aggregation.
+              </p>
+              <div className="mt-6">
+                <MermaidDiagram
+                  chart={`flowchart LR
+  FE[Next.js Frontend]
+  AUTH[auth-service<br/>REST :8091]
+  PROD[product-service<br/>REST :8095 / gRPC :9095]
+  CART[cart-service<br/>REST :8096 / gRPC :9096]
+  ORD[order-service<br/>REST :8092]
+  AI[ai-service<br/>REST :8093]
+  ANA[analytics-service<br/>REST :8094]
+  PG_A[(authdb)]
+  PG_P[(productdb)]
+  PG_C[(cartdb)]
+  PG_O[(ecommercedb)]
+  RD[(Redis)]
+  MQ{{RabbitMQ<br/>Saga Exchange}}
+  KF{{Kafka}}
+  FE -->|REST /go-auth| AUTH
+  FE -->|REST /go-products| PROD
+  FE -->|REST /go-cart| CART
+  FE -->|REST /go-orders| ORD
+  FE -->|REST /ai-api| AI
+  AUTH --> PG_A
+  PROD --> PG_P
+  CART --> PG_C
+  ORD --> PG_O
+  CART -->|gRPC| PROD
+  ORD -->|gRPC| CART
+  ORD -->|gRPC| PROD
+  ORD -->|saga commands| MQ
+  MQ -->|saga events| ORD
+  MQ -->|saga commands| CART
+  ORD -->|order events| KF
+  CART -->|cart events| KF
+  KF --> ANA
+  PROD --> RD
+  CART --> RD`}
+                />
+              </div>
+            </section>
+
+            {/* Checkout Saga Flow */}
+            <section className="mt-12">
+              <h3 className="text-xl font-semibold">
+                Request flow: Checkout saga
+              </h3>
+              <p className="mt-4 text-muted-foreground leading-relaxed">
+                Checkout uses a saga orchestrator pattern: the order-service
+                creates a pending order, then asynchronously publishes commands
+                to cart-service via RabbitMQ, validates stock via gRPC to
+                product-service, and clears the cart on success. The client gets
+                an immediate 201 response while the saga runs in the background.
+              </p>
+              <div className="mt-6">
+                <MermaidDiagram
+                  chart={`sequenceDiagram
+  participant U as User
+  participant FE as Frontend
+  participant ORD as order-service
+  participant CART as cart-service
+  participant PROD as product-service
+  participant MQ as RabbitMQ
+  participant KF as Kafka
+  U->>FE: Click "Checkout"
+  FE->>ORD: POST /orders (Bearer JWT)
+  ORD->>CART: gRPC GetCart(userId)
+  CART->>PROD: gRPC GetProduct (price enrichment)
+  CART-->>ORD: cart items + prices
+  ORD->>ORD: INSERT order (status=pending, saga_step=CREATED)
+  ORD-->>FE: 201 order (status=pending)
+  Note over ORD,MQ: Saga begins asynchronously
+  ORD->>MQ: publish reserve.items
+  MQ->>CART: reserve.items command
+  CART->>CART: SET reserved=true
+  CART->>MQ: items.reserved event
+  MQ->>ORD: items.reserved
+  ORD->>PROD: gRPC CheckAvailability
+  PROD-->>ORD: available=true
+  ORD->>MQ: publish clear.cart
+  MQ->>CART: clear.cart command
+  CART->>CART: DELETE cart items
+  CART->>MQ: cart.cleared event
+  MQ->>ORD: cart.cleared
+  ORD->>ORD: status=completed, saga_step=COMPLETED
+  ORD->>KF: order.completed event
+  KF->>ANA: analytics aggregation`}
+                />
+              </div>
+              <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
+                If stock is insufficient at the CheckAvailability step, the saga
+                compensates: order-service publishes{" "}
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                  release.items
+                </code>{" "}
+                to unreserve cart items and marks the order as FAILED. On
+                startup, crash recovery queries incomplete sagas and resumes each
+                from its last known step.
+              </p>
+            </section>
+
+            {/* What Changed */}
+            <section className="mt-12">
+              <h3 className="text-xl font-semibold">What Changed</h3>
+              <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {[
+                  {
+                    title: "Database-per-Service",
+                    desc: "Each service owns its database (productdb, cartdb, ecommercedb). No shared tables.",
+                  },
+                  {
+                    title: "gRPC Contracts",
+                    desc: "Protobuf-defined service contracts with buf toolchain. Type-safe cross-service calls.",
+                  },
+                  {
+                    title: "Saga Orchestration",
+                    desc: "RabbitMQ-based saga with compensation flows, DLQ, and crash recovery.",
+                  },
+                  {
+                    title: "Independent Scaling",
+                    desc: "Each service has its own HPA, PDB, and resource limits. Scale what needs scaling.",
+                  },
+                ].map((card) => (
+                  <div
+                    key={card.title}
+                    className="rounded-lg border border-foreground/10 p-4"
+                  >
+                    <h4 className="text-sm font-semibold">{card.title}</h4>
+                    <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+                      {card.desc}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+        )}
+
+        {/* Original Tab */}
+        {activeTab === "original" && (
+          <div className="mt-8">
+            <p className="mt-4 text-muted-foreground leading-relaxed">
+              Microservices ecommerce platform built with Go, demonstrating
+              RESTful API design, JWT authentication, PostgreSQL, Redis caching,
+              asynchronous order processing with RabbitMQ, and an LLM-powered
+              shopping assistant with tool-calling agent loop. Deployed using
+              Docker and Kubernetes.
+            </p>
+
+            <h3 className="mt-6 text-lg font-medium">Tech Stack</h3>
+            <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
+              <li>
+                4 Go microservices (auth, ecommerce, ai-service, analytics)
+              </li>
+              <li>Gin HTTP framework with JWT authentication</li>
+              <li>Ollama (Qwen 2.5 14B) tool-calling agent with 9 tools</li>
+              <li>PostgreSQL (users, products, carts, orders)</li>
+              <li>Redis caching + rate limiting</li>
+              <li>RabbitMQ asynchronous order processing</li>
+              <li>Apache Kafka streaming analytics pipeline</li>
+              <li>Prometheus metrics instrumentation</li>
+              <li>Next.js + TypeScript frontend</li>
+              <li>Docker Compose (local dev), Kubernetes (production)</li>
+            </ul>
+
+            <section className="mt-12">
+              <h3 className="text-xl font-semibold">Architecture</h3>
+              <p className="mt-4 text-muted-foreground leading-relaxed">
+                Two Go services &mdash; auth and ecommerce &mdash; sharing
+                Postgres. The ecommerce service caches product reads in Redis
+                and offloads order finalization to a RabbitMQ-driven goroutine
+                worker pool.
+              </p>
+              <div className="mt-6">
+                <MermaidDiagram
+                  chart={`flowchart LR
   FE[Next.js Frontend]
   AUTH[auth-service<br/>Go + JWT]
   EC[ecommerce-service<br/>Go]
@@ -80,23 +314,23 @@ export default function GoPage() {
   MQ --> WP
   WP --> PG
   WP -->|invalidate products| RD`}
-            />
-          </div>
+                />
+              </div>
 
-          <h3 className="mt-10 text-xl font-semibold">
-            Request flow: Checkout order
-          </h3>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            The HTTP handler reads the cart from Postgres, inserts a pending
-            order, clears the cart, and publishes to RabbitMQ — all
-            synchronously — then returns 201. A 3-goroutine worker pool
-            consumes the event and drives the order through processing to
-            completed, decrementing product stock and invalidating the Redis
-            product cache along the way.
-          </p>
-          <div className="mt-6">
-            <MermaidDiagram
-              chart={`sequenceDiagram
+              <h3 className="mt-10 text-xl font-semibold">
+                Request flow: Checkout order
+              </h3>
+              <p className="mt-4 text-muted-foreground leading-relaxed">
+                The HTTP handler reads the cart from Postgres, inserts a pending
+                order, clears the cart, and publishes to RabbitMQ &mdash; all
+                synchronously &mdash; then returns 201. A 3-goroutine worker
+                pool consumes the event and drives the order through processing
+                to completed, decrementing product stock and invalidating the
+                Redis product cache along the way.
+              </p>
+              <div className="mt-6">
+                <MermaidDiagram
+                  chart={`sequenceDiagram
   participant U as User
   participant FE as Frontend
   participant AUTH as auth-service
@@ -124,30 +358,168 @@ export default function GoPage() {
   WP->>RD: DEL ecom:products:* cache
   FE->>EC: GET /orders/{id}
   EC-->>FE: status=completed`}
-            />
+                />
+              </div>
+            </section>
+
+            <section className="mt-12">
+              <h3 className="text-xl font-semibold">
+                Stress Testing &amp; Scalability
+              </h3>
+              <p className="mt-4 text-muted-foreground leading-relaxed">
+                The ecommerce platform was stress-tested using{" "}
+                <a
+                  href="https://k6.io"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground transition-colors"
+                >
+                  k6
+                </a>{" "}
+                across all three services to find bottlenecks, fix them, and
+                measure the improvement. The full analysis is documented in a{" "}
+                <a
+                  href="https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/go-stress-testing.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground transition-colors"
+                >
+                  stress testing ADR
+                </a>
+                .
+              </p>
+
+              <h4 className="mt-8 text-lg font-medium">
+                What we found and fixed
+              </h4>
+              <div className="mt-4 overflow-x-auto">
+                <table className="w-full text-sm text-muted-foreground">
+                  <thead>
+                    <tr className="border-b text-left">
+                      <th className="pb-2 pr-4 font-medium text-foreground">
+                        Issue
+                      </th>
+                      <th className="pb-2 pr-4 font-medium text-foreground">
+                        Before
+                      </th>
+                      <th className="pb-2 pr-4 font-medium text-foreground">
+                        After
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    <tr>
+                      <td className="py-2 pr-4">
+                        Stock overselling (race condition)
+                      </td>
+                      <td className="py-2 pr-4">296 orders on stock=50</td>
+                      <td className="py-2 pr-4">
+                        0 oversells (SELECT FOR UPDATE)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">Auth service under load</td>
+                      <td className="py-2 pr-4">57% error rate at 20 req/s</td>
+                      <td className="py-2 pr-4">
+                        0% errors (HPA scales to 3 replicas)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">Checkout throughput</td>
+                      <td className="py-2 pr-4">34 req/s</td>
+                      <td className="py-2 pr-4">
+                        113 req/s (3.3x improvement)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td className="py-2 pr-4">Product browse (50 VUs)</td>
+                      <td className="py-2 pr-4" colSpan={2}>
+                        195 req/s at p95=27ms, 0% errors &mdash; no fix needed
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <h4 className="mt-8 text-lg font-medium">Fixes applied</h4>
+              <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
+                <li>
+                  <span className="text-foreground font-medium">
+                    Stock race condition
+                  </span>{" "}
+                  &mdash; replaced bare UPDATE with SELECT FOR UPDATE in a
+                  transaction
+                </li>
+                <li>
+                  <span className="text-foreground font-medium">
+                    HPA autoscaling
+                  </span>{" "}
+                  &mdash; CPU-based autoscaling (70% target, 1-3 replicas) for
+                  auth and ecommerce services
+                </li>
+                <li>
+                  <span className="text-foreground font-medium">
+                    Connection pool tuning
+                  </span>{" "}
+                  &mdash; explicit pgxpool config (25 max, 5 min conns, health
+                  checks)
+                </li>
+                <li>
+                  <span className="text-foreground font-medium">
+                    Server timeouts
+                  </span>{" "}
+                  &mdash; read/write/idle timeouts on the HTTP server
+                </li>
+              </ul>
+
+              <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
+                k6 metrics are pushed to Prometheus via remote-write and
+                correlated with service-side metrics in a dedicated Grafana
+                dashboard, showing both the load generator and service
+                perspective side-by-side.
+              </p>
+            </section>
           </div>
-        </section>
+        )}
 
-        <section className="mt-12">
-          <h2 className="text-2xl font-semibold">AI Shopping Assistant</h2>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            An LLM-powered shopping assistant that wraps a tool-calling agent
-            loop around the ecommerce backend. Users ask natural language
-            questions — the agent decides which tools to invoke, calls the
-            ecommerce API, and synthesizes a streamed response. Built in Go
-            with Ollama (Qwen 2.5 14B).
-          </p>
+        {/* CTA Buttons */}
+        <div className="mt-8 flex gap-3">
+          <Link
+            href="/go/ecommerce"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            View Store &rarr;
+          </Link>
+          <Link
+            href="/go/analytics"
+            className="inline-flex items-center gap-2 rounded-lg border px-6 py-3 text-sm font-medium hover:bg-accent transition-colors"
+          >
+            Streaming Analytics &rarr;
+          </Link>
+        </div>
+      </section>
 
-          <h3 className="mt-10 text-xl font-semibold">Tool Catalog</h3>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            The agent has access to nine tools organized into three domains.
-            Catalog tools are public; order, cart, and return tools require JWT
-            authentication. Checkout is deliberately excluded — the agent can
-            advise but not transact.
-          </p>
-          <div className="mt-6">
-            <MermaidDiagram
-              chart={`flowchart LR
+      {/* AI Shopping Assistant — standalone section */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">AI Shopping Assistant</h2>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          An LLM-powered shopping assistant that wraps a tool-calling agent
+          loop around the ecommerce backend. Users ask natural language
+          questions &mdash; the agent decides which tools to invoke, calls the
+          ecommerce API, and synthesizes a streamed response. Built in Go with
+          Ollama (Qwen 2.5 14B).
+        </p>
+
+        <h3 className="mt-10 text-xl font-semibold">Tool Catalog</h3>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          The agent has access to nine tools organized into three domains.
+          Catalog tools are public; order, cart, and return tools require JWT
+          authentication. Checkout is deliberately excluded &mdash; the agent
+          can advise but not transact.
+        </p>
+        <div className="mt-6">
+          <MermaidDiagram
+            chart={`flowchart LR
   AGENT((Agent<br/>Qwen 2.5 14B))
   subgraph Catalog ["Catalog (public)"]
     T1[search_products<br/>query + max_price]
@@ -170,21 +542,20 @@ export default function GoPage() {
   X[place_order<br/>deliberately excluded]:::disabled
   AGENT -.-x X
   classDef disabled stroke-dasharray: 5 5,opacity:0.5`}
-            />
-          </div>
+          />
+        </div>
 
-          <h3 className="mt-10 text-xl font-semibold">Agent Loop</h3>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            The agent runs a synchronous ReAct-style loop — call the LLM,
-            dispatch any requested tools, feed results back into the
-            conversation, and repeat until the LLM produces a final answer.
-            Bounded by 8 steps and a 30-second wall-clock timeout. Tool errors
-            become conversation context for the LLM to handle, not hard
-            failures.
-          </p>
-          <div className="mt-6">
-            <MermaidDiagram
-              chart={`flowchart TD
+        <h3 className="mt-10 text-xl font-semibold">Agent Loop</h3>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          The agent runs a synchronous ReAct-style loop &mdash; call the LLM,
+          dispatch any requested tools, feed results back into the
+          conversation, and repeat until the LLM produces a final answer.
+          Bounded by 8 steps and a 30-second wall-clock timeout. Tool errors
+          become conversation context for the LLM to handle, not hard failures.
+        </p>
+        <div className="mt-6">
+          <MermaidDiagram
+            chart={`flowchart TD
   START([Receive user message])
   LLM[Call Ollama<br/>history + tool schemas]
   DECIDE{Tool calls<br/>in response?}
@@ -205,21 +576,20 @@ export default function GoPage() {
   REFUSAL -->|Yes| TAG
   TAG --> STREAM
   REFUSAL -->|No| STREAM`}
-            />
-          </div>
+          />
+        </div>
 
-          <h3 className="mt-10 text-xl font-semibold">
-            Request flow: Product search
-          </h3>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            A concrete example: the user asks &ldquo;find me a waterproof
-            jacket under $150.&rdquo; The frontend streams Server-Sent Events
-            from the AI service, which orchestrates between Ollama and the
-            ecommerce API.
-          </p>
-          <div className="mt-6">
-            <MermaidDiagram
-              chart={`sequenceDiagram
+        <h3 className="mt-10 text-xl font-semibold">
+          Request flow: Product search
+        </h3>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          A concrete example: the user asks &ldquo;find me a waterproof jacket
+          under $150.&rdquo; The frontend streams Server-Sent Events from the
+          AI service, which orchestrates between Ollama and the ecommerce API.
+        </p>
+        <div className="mt-6">
+          <MermaidDiagram
+            chart={`sequenceDiagram
   participant U as User
   participant FE as Frontend
   participant AI as AI Service
@@ -236,132 +606,7 @@ export default function GoPage() {
   OL-->>AI: final text
   AI-->>FE: SSE: final {text}
   FE-->>U: "I found 3 waterproof jackets under $150..."`}
-            />
-          </div>
-        </section>
-
-        <section className="mt-12">
-          <h2 className="text-2xl font-semibold">
-            Stress Testing &amp; Scalability
-          </h2>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            The ecommerce platform was stress-tested using{" "}
-            <a
-              href="https://k6.io"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-foreground transition-colors"
-            >
-              k6
-            </a>{" "}
-            across all three services to find bottlenecks, fix them, and measure
-            the improvement. The full analysis is documented in a{" "}
-            <a
-              href="https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/go-stress-testing.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-foreground transition-colors"
-            >
-              stress testing ADR
-            </a>
-            .
-          </p>
-
-          <h3 className="mt-8 text-lg font-medium">What we found and fixed</h3>
-          <div className="mt-4 overflow-x-auto">
-            <table className="w-full text-sm text-muted-foreground">
-              <thead>
-                <tr className="border-b text-left">
-                  <th className="pb-2 pr-4 font-medium text-foreground">
-                    Issue
-                  </th>
-                  <th className="pb-2 pr-4 font-medium text-foreground">
-                    Before
-                  </th>
-                  <th className="pb-2 pr-4 font-medium text-foreground">
-                    After
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                <tr>
-                  <td className="py-2 pr-4">Stock overselling (race condition)</td>
-                  <td className="py-2 pr-4">296 orders on stock=50</td>
-                  <td className="py-2 pr-4">
-                    0 oversells (SELECT FOR UPDATE)
-                  </td>
-                </tr>
-                <tr>
-                  <td className="py-2 pr-4">Auth service under load</td>
-                  <td className="py-2 pr-4">57% error rate at 20 req/s</td>
-                  <td className="py-2 pr-4">
-                    0% errors (HPA scales to 3 replicas)
-                  </td>
-                </tr>
-                <tr>
-                  <td className="py-2 pr-4">Checkout throughput</td>
-                  <td className="py-2 pr-4">34 req/s</td>
-                  <td className="py-2 pr-4">113 req/s (3.3x improvement)</td>
-                </tr>
-                <tr>
-                  <td className="py-2 pr-4">Product browse (50 VUs)</td>
-                  <td className="py-2 pr-4" colSpan={2}>
-                    195 req/s at p95=27ms, 0% errors — no fix needed
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <h3 className="mt-8 text-lg font-medium">Fixes applied</h3>
-          <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
-            <li>
-              <span className="text-foreground font-medium">
-                Stock race condition
-              </span>{" "}
-              — replaced bare UPDATE with SELECT FOR UPDATE in a transaction
-            </li>
-            <li>
-              <span className="text-foreground font-medium">
-                HPA autoscaling
-              </span>{" "}
-              — CPU-based autoscaling (70% target, 1-3 replicas) for auth and
-              ecommerce services
-            </li>
-            <li>
-              <span className="text-foreground font-medium">
-                Connection pool tuning
-              </span>{" "}
-              — explicit pgxpool config (25 max, 5 min conns, health checks)
-            </li>
-            <li>
-              <span className="text-foreground font-medium">
-                Server timeouts
-              </span>{" "}
-              — read/write/idle timeouts on the HTTP server
-            </li>
-          </ul>
-
-          <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
-            k6 metrics are pushed to Prometheus via remote-write and correlated
-            with service-side metrics in a dedicated Grafana dashboard, showing
-            both the load generator and service perspective side-by-side.
-          </p>
-        </section>
-
-        <div className="mt-8 flex gap-3">
-          <Link
-            href="/go/ecommerce"
-            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-          >
-            View Project &rarr;
-          </Link>
-          <Link
-            href="/go/analytics"
-            className="inline-flex items-center gap-2 rounded-lg border px-6 py-3 text-sm font-medium hover:bg-accent transition-colors"
-          >
-            Streaming Analytics &rarr;
-          </Link>
+          />
         </div>
       </section>
     </div>

--- a/frontend/src/app/go/page.tsx
+++ b/frontend/src/app/go/page.tsx
@@ -504,18 +504,23 @@ export default function GoPage() {
         <h2 className="text-2xl font-semibold">AI Shopping Assistant</h2>
         <p className="mt-4 text-muted-foreground leading-relaxed">
           An LLM-powered shopping assistant that wraps a tool-calling agent
-          loop around the ecommerce backend. Users ask natural language
-          questions &mdash; the agent decides which tools to invoke, calls the
-          ecommerce API, and synthesizes a streamed response. Built in Go with
-          Ollama (Qwen 2.5 14B).
+          loop around the ecommerce backend and a RAG knowledge base. Users
+          ask natural language questions &mdash; the agent decides which tools
+          to invoke, calls Go microservices or the Python RAG pipeline, and
+          synthesizes a streamed response. Built in Go with Ollama (Qwen 2.5
+          14B). The RAG bridge connects Go &rarr; Python chat service &rarr;
+          Qdrant vector DB, with circuit breakers and OTel trace propagation
+          across the stack boundary.
         </p>
 
         <h3 className="mt-10 text-xl font-semibold">Tool Catalog</h3>
         <p className="mt-4 text-muted-foreground leading-relaxed">
-          The agent has access to nine tools organized into three domains.
+          The agent has access to twelve tools organized into four domains.
           Catalog tools are public; order, cart, and return tools require JWT
-          authentication. Checkout is deliberately excluded &mdash; the agent
-          can advise but not transact.
+          authentication; knowledge base tools are public and hit the Python
+          RAG pipeline via a circuit-breaker HTTP bridge with 30-second
+          timeout. Checkout is deliberately excluded &mdash; the agent can
+          advise but not transact.
         </p>
         <div className="mt-6">
           <MermaidDiagram
@@ -536,9 +541,15 @@ export default function GoPage() {
     T8[add_to_cart<br/>product + quantity]
     T9[initiate_return<br/>order item + reason]
   end
+  subgraph Knowledge ["Knowledge Base (public, RAG)"]
+    T10[search_documents<br/>semantic search + sources]
+    T11[ask_document<br/>natural-language Q&A]
+    T12[list_collections<br/>vector store inventory]
+  end
   AGENT --> Catalog
   AGENT --> Orders
   AGENT --> CartReturns
+  AGENT --> Knowledge
   X[place_order<br/>deliberately excluded]:::disabled
   AGENT -.-x X
   classDef disabled stroke-dasharray: 5 5,opacity:0.5`}
@@ -559,9 +570,9 @@ export default function GoPage() {
   START([Receive user message])
   LLM[Call Ollama<br/>history + tool schemas]
   DECIDE{Tool calls<br/>in response?}
-  DISPATCH[Dispatch tool to<br/>ecommerce API]
+  DISPATCH[Dispatch tool to<br/>ecommerce API or RAG pipeline]
   APPEND[Append result to<br/>conversation history]
-  GUARD{Max 8 steps<br/>or 30s?}
+  GUARD{Max 8 steps<br/>or 90s?}
   REFUSAL{Refusal<br/>detected?}
   TAG[Tag outcome as refused]
   STREAM([Stream final answer<br/>via SSE])
@@ -606,6 +617,42 @@ export default function GoPage() {
   OL-->>AI: final text
   AI-->>FE: SSE: final {text}
   FE-->>U: "I found 3 waterproof jackets under $150..."`}
+          />
+        </div>
+
+        <h3 className="mt-10 text-xl font-semibold">
+          Request flow: Product knowledge query
+        </h3>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          A cross-stack example: the user asks &ldquo;what&rsquo;s the warranty
+          on the Storm Jacket?&rdquo; The Go AI service calls the Python RAG
+          pipeline, which searches Qdrant for relevant document chunks and
+          generates an answer with source citations.
+        </p>
+        <div className="mt-6">
+          <MermaidDiagram
+            chart={`sequenceDiagram
+  participant U as User
+  participant FE as Frontend
+  participant AI as AI Service (Go)
+  participant OL as Ollama
+  participant PY as Python Chat Svc
+  participant QD as Qdrant
+  U->>FE: "what's the warranty on the Storm Jacket?"
+  FE->>AI: POST /chat (SSE stream, Bearer JWT)
+  AI->>OL: Chat(messages, tool_schemas)
+  OL-->>AI: tool_call: ask_document
+  AI-->>FE: SSE: tool_call {name, args}
+  AI->>PY: POST /chat {question, collection}
+  PY->>QD: vector search (embedded question)
+  QD-->>PY: ranked chunks + scores
+  PY->>OL: RAG prompt + retrieved context
+  OL-->>PY: generated answer
+  PY-->>AI: {answer, sources: [{file, page}]}
+  AI->>OL: Chat(messages + tool_result)
+  OL-->>AI: final text
+  AI-->>FE: SSE: final {text}
+  FE-->>U: answer with source citations`}
           />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add Knowledge Base domain (3 RAG tools) to the Tool Catalog Mermaid diagram, bringing total from 9 to 12 tools
- Update Agent Loop diagram: dispatch label mentions RAG pipeline, timeout corrected to 90s
- Add new "Request flow: Product knowledge query" sequence diagram showing cross-stack RAG path (Go → Python → Qdrant → Ollama)
- Update intro paragraph to describe RAG bridge architecture

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run lint` passes with 0 errors (verified locally)
- [ ] All 4 Mermaid diagrams render correctly on the /go page
- [ ] Knowledge Base subgraph visible in tool catalog
- [ ] RAG sequence diagram shows full Go→Python→Qdrant→Ollama flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)