### PR TITLE
feat(frontend): DLQ admin panel at /go/admin

### DIFF
--- a/frontend/e2e/mocked/go-dlq-admin.spec.ts
+++ b/frontend/e2e/mocked/go-dlq-admin.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "./fixtures";
+
+const MOCK_DLQ_MESSAGES = {
+  messages: [
+    {
+      index: 0,
+      routing_key: "saga.cart.commands",
+      exchange: "ecommerce.saga",
+      timestamp: new Date().toISOString(),
+      retry_count: 0,
+      headers: { "x-retry-count": 0 },
+      body: { command: "reserve.items", order_id: "test-order-1" },
+    },
+    {
+      index: 1,
+      routing_key: "saga.order.events",
+      exchange: "ecommerce.saga",
+      timestamp: new Date(Date.now() - 900_000).toISOString(),
+      retry_count: 1,
+      headers: { "x-retry-count": 1 },
+      body: { event: "items.reserved", order_id: "test-order-2" },
+    },
+  ],
+  count: 2,
+};
+
+test.describe("DLQ Admin Panel", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/admin/dlq/messages*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_DLQ_MESSAGES),
+      }),
+    );
+  });
+
+  test("renders the admin page with demo banner", async ({ page }) => {
+    await page.goto("/go/admin");
+    await expect(page.locator("h1", { hasText: "DLQ Admin" })).toBeVisible();
+    await expect(page.getByText("Portfolio Demo")).toBeVisible();
+  });
+
+  test("displays DLQ messages in a table", async ({ page }) => {
+    await page.goto("/go/admin");
+    await expect(page.getByText("saga.cart.commands")).toBeVisible();
+    await expect(page.getByText("saga.order.events")).toBeVisible();
+  });
+
+  test("shows message count", async ({ page }) => {
+    await page.goto("/go/admin");
+    await expect(page.getByText("2", { exact: true })).toBeVisible();
+  });
+
+  test("expands row to show message body", async ({ page }) => {
+    await page.goto("/go/admin");
+    await page.getByText("saga.cart.commands").click();
+    await expect(page.getByText("reserve.items")).toBeVisible();
+    await expect(page.getByText("test-order-1")).toBeVisible();
+  });
+
+  test("replay button sends POST request", async ({ page }) => {
+    let replayRequested = false;
+
+    await page.route("**/admin/dlq/replay", (route) => {
+      replayRequested = true;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          replayed: { ...MOCK_DLQ_MESSAGES.messages[0], retry_count: 1 },
+        }),
+      });
+    });
+
+    await page.goto("/go/admin");
+    const replayButtons = page.getByRole("button", { name: "Replay" });
+    await replayButtons.first().click();
+
+    await expect(page.getByText("Replayed")).toBeVisible();
+    expect(replayRequested).toBe(true);
+  });
+
+  test("shows unreachable state when backend is down", async ({ page }) => {
+    await page.route("**/admin/dlq/messages*", (route) => route.abort());
+
+    await page.goto("/go/admin");
+    await expect(
+      page.getByText("Admin endpoints are not publicly exposed"),
+    ).toBeVisible();
+  });
+});

--- a/frontend/src/app/go/admin/page.tsx
+++ b/frontend/src/app/go/admin/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { DemoBanner } from "@/components/go/DemoBanner";
+import { DLQMessageRow } from "@/components/go/DLQMessageRow";
+import { fetchDLQMessages } from "@/lib/go-admin-api";
+import type { DLQMessage } from "@/lib/go-admin-api";
+
+export default function AdminPage() {
+  const [messages, setMessages] = useState<DLQMessage[]>([]);
+  const [count, setCount] = useState(0);
+  const [connected, setConnected] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const result = await fetchDLQMessages();
+    setLoading(false);
+    setConnected(result.connected);
+
+    if (result.data) {
+      setMessages(result.data.messages);
+      setCount(result.data.count);
+    } else if (result.error) {
+      setError(result.error);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      const result = await fetchDLQMessages();
+      if (cancelled) return;
+      setLoading(false);
+      setConnected(result.connected);
+
+      if (result.data) {
+        setMessages(result.data.messages);
+        setCount(result.data.count);
+      } else if (result.error) {
+        setError(result.error);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-8">
+      <h1 className="mb-2 text-2xl font-bold">DLQ Admin</h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Inspect and replay dead-lettered messages from the checkout saga.
+      </p>
+
+      <DemoBanner />
+
+      {!connected && (
+        <div className="mb-6 rounded-lg border border-muted-foreground/20 bg-muted px-4 py-4">
+          <p className="font-medium">Admin endpoints are not publicly exposed</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            These endpoints are only reachable from within the Kubernetes
+            cluster. To use this panel locally:
+          </p>
+          <pre className="mt-2 overflow-x-auto rounded bg-background px-3 py-2 text-xs">
+            ssh -f -N -L 8092:localhost:8092 debian
+          </pre>
+        </div>
+      )}
+
+      {connected && (
+        <>
+          <div className="mb-6 flex items-center gap-4">
+            <div className="rounded border bg-card px-4 py-3">
+              <p className="text-xs text-muted-foreground">DLQ Messages</p>
+              <p className="mt-1 text-2xl font-bold">{count}</p>
+            </div>
+            <button
+              onClick={refresh}
+              disabled={loading}
+              className="rounded bg-muted px-4 py-2 text-sm font-medium transition-colors hover:bg-muted/80 disabled:opacity-50"
+            >
+              {loading ? "Loading..." : "↻ Refresh"}
+            </button>
+          </div>
+
+          {error && (
+            <div className="mb-4 rounded border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm text-red-600 dark:text-red-400">
+              {error}
+            </div>
+          )}
+
+          <div className="rounded border bg-card">
+            {messages.length > 0 ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="px-4 py-2">Index</th>
+                    <th className="px-4 py-2">Routing Key</th>
+                    <th className="px-4 py-2">Timestamp</th>
+                    <th className="px-4 py-2 text-center">Retries</th>
+                    <th className="px-4 py-2 text-right">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {messages.map((msg) => (
+                    <DLQMessageRow
+                      key={msg.index}
+                      message={msg}
+                      onReplayed={refresh}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p className="px-4 py-8 text-center text-muted-foreground">
+                {loading ? "Loading..." : "No messages in the dead-letter queue"}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/go/DLQMessageRow.tsx
+++ b/frontend/src/components/go/DLQMessageRow.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import type { DLQMessage } from "@/lib/go-admin-api";
+import { replayDLQMessage } from "@/lib/go-admin-api";
+
+function timeAgo(timestamp: string): string {
+  const seconds = Math.floor(
+    (Date.now() - new Date(timestamp).getTime()) / 1000,
+  );
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+interface DLQMessageRowProps {
+  message: DLQMessage;
+  onReplayed: () => void;
+}
+
+export function DLQMessageRow({ message, onReplayed }: DLQMessageRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [replaying, setReplaying] = useState(false);
+  const [replayResult, setReplayResult] = useState<
+    "success" | "error" | null
+  >(null);
+  const [replayError, setReplayError] = useState<string | null>(null);
+
+  async function handleReplay(e: React.MouseEvent) {
+    e.stopPropagation();
+    setReplaying(true);
+    setReplayResult(null);
+    setReplayError(null);
+
+    const result = await replayDLQMessage(message.index);
+
+    setReplaying(false);
+    if (result.data) {
+      setReplayResult("success");
+      setTimeout(() => onReplayed(), 1000);
+    } else {
+      setReplayResult("error");
+      setReplayError(result.error || "Replay failed");
+    }
+  }
+
+  return (
+    <>
+      <tr
+        className="cursor-pointer border-b transition-colors hover:bg-muted/50"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <td className="px-4 py-2 text-muted-foreground">#{message.index}</td>
+        <td className="px-4 py-2 font-mono text-sm">{message.routing_key}</td>
+        <td className="px-4 py-2 text-muted-foreground">
+          {message.timestamp ? timeAgo(message.timestamp) : "—"}
+        </td>
+        <td className="px-4 py-2 text-center">{message.retry_count}</td>
+        <td className="px-4 py-2 text-right">
+          {replayResult === "success" ? (
+            <span className="text-sm text-green-600 dark:text-green-400">
+              Replayed
+            </span>
+          ) : (
+            <button
+              onClick={handleReplay}
+              disabled={replaying}
+              className="rounded bg-primary px-3 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/80 disabled:opacity-50"
+            >
+              {replaying ? "..." : "Replay"}
+            </button>
+          )}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b bg-muted/30">
+          <td colSpan={5} className="px-4 py-3">
+            <div className="space-y-3 text-sm">
+              <div>
+                <span className="text-xs font-medium uppercase text-muted-foreground">
+                  Exchange
+                </span>
+                <p className="font-mono">{message.exchange}</p>
+              </div>
+              <div>
+                <span className="text-xs font-medium uppercase text-muted-foreground">
+                  Headers
+                </span>
+                <pre className="mt-1 overflow-x-auto rounded bg-background p-2 text-xs">
+                  {JSON.stringify(message.headers, null, 2)}
+                </pre>
+              </div>
+              <div>
+                <span className="text-xs font-medium uppercase text-muted-foreground">
+                  Body
+                </span>
+                <pre className="mt-1 overflow-x-auto rounded bg-background p-2 text-xs">
+                  {JSON.stringify(message.body, null, 2)}
+                </pre>
+              </div>
+              {replayResult === "error" && replayError && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {replayError}
+                </p>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/go/DemoBanner.tsx
+++ b/frontend/src/components/go/DemoBanner.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+export function DemoBanner() {
+  return (
+    <div className="mb-6 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3">
+      <p className="text-sm font-medium text-yellow-700 dark:text-yellow-400">
+        Portfolio Demo
+      </p>
+      <p className="mt-1 text-sm text-yellow-600/80 dark:text-yellow-400/70">
+        This panel demonstrates DLQ operational tooling for the checkout saga. In
+        a production environment, this would be implemented as a CLI tool with
+        role-based access control.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/go/GoSubHeader.tsx
+++ b/frontend/src/components/go/GoSubHeader.tsx
@@ -10,8 +10,9 @@ export function GoSubHeader() {
   const pathname = usePathname();
   const inStore = pathname.startsWith("/go/ecommerce");
   const inAnalytics = pathname.startsWith("/go/analytics");
+  const inAdmin = pathname.startsWith("/go/admin");
   const onStoreRoot = pathname === "/go/ecommerce";
-  const showNav = inStore || inAnalytics;
+  const showNav = inStore || inAnalytics || inAdmin;
   const { categories, activeCategory, setActiveCategory } = useGoStore();
 
   if (!showNav) return null;
@@ -35,6 +36,14 @@ export function GoSubHeader() {
             }`}
           >
             Analytics
+          </Link>
+          <Link
+            href="/go/admin"
+            className={`text-sm font-medium transition-colors ${
+              inAdmin ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Admin
           </Link>
         </div>
         <div className="flex flex-wrap items-center justify-center gap-2">

--- a/frontend/src/lib/go-admin-api.ts
+++ b/frontend/src/lib/go-admin-api.ts
@@ -1,0 +1,64 @@
+const GO_ORDER_URL =
+  process.env.NEXT_PUBLIC_GO_ORDER_URL || "http://localhost:8092";
+
+export interface DLQMessage {
+  index: number;
+  routing_key: string;
+  exchange: string;
+  timestamp: string;
+  retry_count: number;
+  headers: Record<string, unknown>;
+  body: unknown;
+}
+
+export interface DLQListResponse {
+  messages: DLQMessage[];
+  count: number;
+}
+
+export interface DLQReplayResponse {
+  replayed: DLQMessage;
+}
+
+export interface DLQResult<T> {
+  data: T | null;
+  error: string | null;
+  connected: boolean;
+}
+
+export async function fetchDLQMessages(
+  limit = 50,
+): Promise<DLQResult<DLQListResponse>> {
+  try {
+    const res = await fetch(
+      `${GO_ORDER_URL}/admin/dlq/messages?limit=${limit}`,
+    );
+    if (!res.ok) {
+      return { data: null, error: `HTTP ${res.status}`, connected: true };
+    }
+    const data: DLQListResponse = await res.json();
+    return { data, error: null, connected: true };
+  } catch {
+    return { data: null, error: null, connected: false };
+  }
+}
+
+export async function replayDLQMessage(
+  index: number,
+): Promise<DLQResult<DLQReplayResponse>> {
+  try {
+    const res = await fetch(`${GO_ORDER_URL}/admin/dlq/replay`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ index }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      return { data: null, error: text || `HTTP ${res.status}`, connected: true };
+    }
+    const data: DLQReplayResponse = await res.json();
+    return { data, error: null, connected: true };
+  } catch {
+    return { data: null, error: null, connected: false };
+  }
+}


### PR DESCRIPTION
## Summary
- New `/go/admin` route with DLQ message inspection and replay UI
- Demo banner explaining this is portfolio tooling (production would use CLI + RBAC)
- Table with expandable rows showing message body, headers, and exchange
- Inline replay button with loading state and success/error feedback
- Graceful unreachable state when backend admin endpoints aren't accessible
- "Admin" link added to GoSubHeader navigation

## Test plan
- [ ] `make preflight-frontend` passes (tsc + lint + build)
- [ ] `make preflight-e2e` passes (21/21 mocked tests including 6 new DLQ admin tests)
- [ ] Navigate to `/go/admin` — demo banner renders, unreachable state shows with SSH instructions
- [ ] With SSH tunnel — messages load, rows expand, replay works

Follow-up to #97 (DLQ replay tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)