### PR TITLE
feat: graceful shutdown orchestration and production polish

### DIFF
--- a/go/ai-service/cmd/server/main.go
+++ b/go/ai-service/cmd/server/main.go
@@ -161,9 +161,7 @@ func runServe() {
 
 	// Graceful shutdown
 	sm := shutdown.New(15 * time.Second)
-	sm.Register("http", 20, func(ctx context.Context) error {
-		return srv.Shutdown(ctx)
-	})
+	sm.Register("drain-http", 0, shutdown.DrainHTTP("ai-http", srv))
 	sm.Register("otel", 30, func(sctx context.Context) error {
 		return shutdownTracer(sctx)
 	})

--- a/go/ai-service/cmd/server/routes.go
+++ b/go/ai-service/cmd/server/routes.go
@@ -24,6 +24,10 @@ import (
 	pkgmw "github.com/kabradshaw1/portfolio/go/pkg/middleware"
 )
 
+// healthClient is reused across health check probes to avoid creating
+// a new transport per call.
+var healthClient = &http.Client{Timeout: 2 * time.Second}
+
 // setupRouter creates the Gin engine with all middleware and routes.
 func setupRouter(
 	cfg Config,
@@ -43,8 +47,7 @@ func setupRouter(
 		"llm": func() error {
 			if cfg.LLMProvider == "ollama" {
 				req, _ := http.NewRequest(http.MethodGet, cfg.OllamaURL+"/api/tags", nil)
-				client := &http.Client{Timeout: 2 * time.Second}
-				resp, err := client.Do(req)
+				resp, err := healthClient.Do(req)
 				if err != nil {
 					return err
 				}
@@ -59,8 +62,7 @@ func setupRouter(
 		},
 		"ecommerce": func() error {
 			req, _ := http.NewRequest(http.MethodGet, cfg.OrderURL+"/health", nil)
-			client := &http.Client{Timeout: 2 * time.Second}
-			resp, err := client.Do(req)
+			resp, err := healthClient.Do(req)
 			if err != nil {
 				return err
 			}

--- a/go/analytics-service/cmd/server/main.go
+++ b/go/analytics-service/cmd/server/main.go
@@ -66,11 +66,10 @@ func main() {
 		cancel()
 		return nil
 	})
-	sm.Register("kafka-close", 10, func(_ context.Context) error {
+	sm.Register("drain-http", 0, shutdown.DrainHTTP("analytics-http", srv))
+	sm.Register("wait-kafka", 10, shutdown.WaitForInflight("kafka-consumer", cons.IsIdle, 100*time.Millisecond))
+	sm.Register("kafka-close", 20, func(_ context.Context) error {
 		return cons.Close()
-	})
-	sm.Register("http", 20, func(ctx context.Context) error {
-		return srv.Shutdown(ctx)
 	})
 	sm.Register("otel", 30, func(ctx context.Context) error {
 		return shutdownTracer(ctx)

--- a/go/analytics-service/internal/consumer/consumer.go
+++ b/go/analytics-service/internal/consumer/consumer.go
@@ -27,7 +27,8 @@ type Consumer struct {
 	orders    *aggregator.OrderAggregator
 	trending  *aggregator.TrendingAggregator
 	carts     *aggregator.CartAggregator
-	connected atomic.Bool
+	connected  atomic.Bool
+	processing atomic.Bool
 }
 
 // New creates a Kafka consumer for the given brokers.
@@ -52,6 +53,11 @@ func New(brokers []string, orders *aggregator.OrderAggregator, trending *aggrega
 // Connected returns whether the consumer has successfully connected to Kafka.
 func (c *Consumer) Connected() bool {
 	return c.connected.Load()
+}
+
+// IsIdle returns true when the consumer is not processing a message.
+func (c *Consumer) IsIdle() bool {
+	return !c.processing.Load()
 }
 
 // Run reads messages until ctx is cancelled.
@@ -79,7 +85,9 @@ func (c *Consumer) Run(ctx context.Context) error {
 		msgCtx := tracing.ExtractKafka(ctx, msg.Headers)
 		_ = msgCtx // available for span creation if tracing is enabled
 
+		c.processing.Store(true)
 		c.route(msg)
+		c.processing.Store(false)
 
 		if err := c.reader.CommitMessages(ctx, msg); err != nil {
 			slog.Error("kafka commit error", "error", err)

--- a/go/auth-service/cmd/server/main.go
+++ b/go/auth-service/cmd/server/main.go
@@ -101,18 +101,13 @@ func main() {
 	}()
 
 	sm := shutdown.New(15 * time.Second)
-	sm.Register("grpc-drain", 10, func(ctx context.Context) error {
-		grpcServer.GracefulStop()
-		return nil
-	})
-	sm.Register("http", 20, func(ctx context.Context) error {
-		return srv.Shutdown(ctx)
-	})
-	sm.Register("postgres", 20, func(ctx context.Context) error {
+	sm.Register("drain-http", 0, shutdown.DrainHTTP("auth-http", srv))
+	sm.Register("drain-grpc", 0, shutdown.DrainGRPC("auth-grpc", grpcServer))
+	sm.Register("postgres", 20, func(_ context.Context) error {
 		pool.Close()
 		return nil
 	})
-	sm.Register("redis", 20, func(ctx context.Context) error {
+	sm.Register("redis", 20, func(_ context.Context) error {
 		if redisClient != nil {
 			return redisClient.Close()
 		}

--- a/go/cart-service/cmd/server/main.go
+++ b/go/cart-service/cmd/server/main.go
@@ -72,20 +72,21 @@ func main() {
 	cartSvc := service.NewCartService(cartRepo, kafkaPub, prodClient)
 
 	// RabbitMQ saga handler (optional)
+	var rmqConn *amqp.Connection
+	var rmqCh *amqp.Channel
+	var sagaHandler *worker.SagaHandler
 	if cfg.RabbitmqURL != "" {
-		conn, err := amqp.Dial(cfg.RabbitmqURL)
+		rmqConn, err = amqp.Dial(cfg.RabbitmqURL)
 		if err != nil {
 			log.Fatalf("rabbitmq connect: %v", err)
 		}
-		defer conn.Close()
 
-		ch, err := conn.Channel()
+		rmqCh, err = rmqConn.Channel()
 		if err != nil {
 			log.Fatalf("rabbitmq channel: %v", err)
 		}
-		defer ch.Close()
 
-		sagaHandler := worker.NewSagaHandler(cartSvc, ch)
+		sagaHandler = worker.NewSagaHandler(cartSvc, rmqCh)
 		go func() {
 			if err := sagaHandler.Start(ctx); err != nil {
 				slog.Error("saga handler failed", "error", err)
@@ -158,13 +159,21 @@ func main() {
 		cancel()
 		return nil
 	})
-	sm.Register("grpc-drain", 10, func(_ context.Context) error {
-		grpcServer.GracefulStop()
+	sm.Register("drain-http", 0, shutdown.DrainHTTP("cart-http", httpSrv))
+	sm.Register("drain-grpc", 0, shutdown.DrainGRPC("cart-grpc", grpcServer))
+	if sagaHandler != nil {
+		sm.Register("wait-saga", 10, shutdown.WaitForInflight("cart-saga", sagaHandler.IsIdle, 100*time.Millisecond))
+	}
+	sm.Register("postgres", 20, func(_ context.Context) error {
+		pool.Close()
 		return nil
 	})
-	sm.Register("http", 20, func(ctx context.Context) error {
-		return httpSrv.Shutdown(ctx)
-	})
+	if rmqCh != nil {
+		sm.Register("rabbitmq", 20, func(_ context.Context) error {
+			_ = rmqCh.Close()
+			return rmqConn.Close()
+		})
+	}
 	sm.Register("otel", 30, func(ctx context.Context) error {
 		return shutdownTracer(ctx)
 	})

--- a/go/cart-service/internal/worker/saga_handler.go
+++ b/go/cart-service/internal/worker/saga_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,13 +46,19 @@ type event struct {
 
 // SagaHandler consumes saga commands from RabbitMQ and publishes reply events.
 type SagaHandler struct {
-	svc CartServiceForSaga
-	ch  *amqp.Channel
+	svc        CartServiceForSaga
+	ch         *amqp.Channel
+	processing atomic.Bool
 }
 
 // NewSagaHandler creates a saga command handler.
 func NewSagaHandler(svc CartServiceForSaga, ch *amqp.Channel) *SagaHandler {
 	return &SagaHandler{svc: svc, ch: ch}
+}
+
+// IsIdle returns true when the handler is not processing a message.
+func (h *SagaHandler) IsIdle() bool {
+	return !h.processing.Load()
 }
 
 // Start begins consuming saga commands. Blocks until ctx is cancelled.
@@ -71,12 +78,14 @@ func (h *SagaHandler) Start(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
+			h.processing.Store(true)
 			if err := h.handleMessage(ctx, msg); err != nil {
 				slog.Error("saga command handling failed", "error", err)
 				_ = msg.Nack(false, true)
 			} else {
 				_ = msg.Ack(false)
 			}
+			h.processing.Store(false)
 		}
 	}
 }

--- a/go/order-service/cmd/server/main.go
+++ b/go/order-service/cmd/server/main.go
@@ -145,8 +145,15 @@ func main() {
 		cancel()
 		return nil
 	})
-	sm.Register("http", 20, func(ctx context.Context) error {
-		return srv.Shutdown(ctx)
+	sm.Register("drain-http", 0, shutdown.DrainHTTP("order-http", srv))
+	sm.Register("wait-saga", 10, shutdown.WaitForInflight("order-saga", consumer.IsIdle, 100*time.Millisecond))
+	sm.Register("postgres", 20, func(_ context.Context) error {
+		pool.Close()
+		return nil
+	})
+	sm.Register("rabbitmq", 20, func(_ context.Context) error {
+		_ = ch.Close()
+		return conn.Close()
 	})
 	sm.Register("otel", 30, func(ctx context.Context) error {
 		return shutdownTracer(ctx)

--- a/go/order-service/internal/repository/order.go
+++ b/go/order-service/internal/repository/order.go
@@ -187,7 +187,7 @@ func (r *OrderRepository) UpdateSagaStep(ctx context.Context, orderID uuid.UUID,
 func (r *OrderRepository) FindIncompleteSagas(ctx context.Context) ([]uuid.UUID, error) {
 	return resilience.Call(ctx, r.breaker, r.retryCfg, func(ctx context.Context) ([]uuid.UUID, error) {
 		rows, err := r.pool.Query(ctx,
-			`SELECT id FROM orders WHERE saga_step NOT IN ($1, $2, $3)`,
+			`SELECT id FROM orders WHERE saga_step NOT IN ($1, $2, $3) LIMIT 100`,
 			"COMPLETED", "COMPENSATION_COMPLETE", "FAILED",
 		)
 		if err != nil {

--- a/go/order-service/internal/saga/consumer.go
+++ b/go/order-service/internal/saga/consumer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
@@ -12,12 +13,18 @@ import (
 
 // Consumer listens on the saga.order.events queue and dispatches to the orchestrator.
 type Consumer struct {
-	orch *Orchestrator
+	orch       *Orchestrator
+	processing atomic.Bool
 }
 
 // NewConsumer creates a saga event consumer.
 func NewConsumer(orch *Orchestrator) *Consumer {
 	return &Consumer{orch: orch}
+}
+
+// IsIdle returns true when the consumer is not processing a message.
+func (c *Consumer) IsIdle() bool {
+	return !c.processing.Load()
 }
 
 // Start begins consuming saga events. Blocks until ctx is cancelled.
@@ -37,12 +44,14 @@ func (c *Consumer) Start(ctx context.Context, ch *amqp.Channel) error {
 			if !ok {
 				return nil
 			}
+			c.processing.Store(true)
 			if err := c.handleMessage(ctx, msg); err != nil {
 				slog.Error("saga event handling failed", "error", err)
 				_ = msg.Nack(false, true)
 			} else {
 				_ = msg.Ack(false)
 			}
+			c.processing.Store(false)
 		}
 	}
 }

--- a/go/pkg/go.mod
+++ b/go/pkg/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	google.golang.org/grpc v1.80.0
 )
 
 require (
@@ -107,7 +108,6 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go/pkg/shutdown/drain.go
+++ b/go/pkg/shutdown/drain.go
@@ -1,0 +1,63 @@
+package shutdown
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// DrainHTTP returns a shutdown hook that gracefully drains an HTTP server.
+// It stops accepting new connections and waits for in-flight requests to
+// complete, up to the context deadline.
+func DrainHTTP(name string, srv interface{ Shutdown(ctx context.Context) error }) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		slog.Info("draining HTTP server", "name", name)
+		return srv.Shutdown(ctx)
+	}
+}
+
+// DrainGRPC returns a shutdown hook that gracefully drains a gRPC server.
+// It stops accepting new RPCs and waits for active RPCs to finish. Falls
+// back to hard Stop() if the context deadline expires.
+func DrainGRPC(name string, srv *grpc.Server) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		slog.Info("draining gRPC server", "name", name)
+		done := make(chan struct{})
+		go func() {
+			srv.GracefulStop()
+			close(done)
+		}()
+		select {
+		case <-done:
+			return nil
+		case <-ctx.Done():
+			slog.Warn("gRPC drain timeout, forcing stop", "name", name)
+			srv.Stop()
+			return ctx.Err()
+		}
+	}
+}
+
+// WaitForInflight returns a shutdown hook that polls idle() until it
+// returns true (no in-flight work) or the context expires. Use this to
+// let saga handlers and Kafka consumers finish processing their current
+// message before closing connections.
+func WaitForInflight(name string, idle func() bool, pollInterval time.Duration) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		slog.Info("waiting for in-flight work to complete", "name", name)
+		for {
+			if idle() {
+				slog.Info("in-flight work complete", "name", name)
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				slog.Warn("in-flight wait timeout", "name", name)
+				return ctx.Err()
+			case <-time.After(pollInterval):
+			}
+		}
+	}
+}

--- a/go/pkg/shutdown/shutdown_test.go
+++ b/go/pkg/shutdown/shutdown_test.go
@@ -2,6 +2,9 @@ package shutdown
 
 import (
 	"context"
+	"net"
+	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -88,4 +91,112 @@ func TestErrorsAreLoggedNotFatal(t *testing.T) {
 
 	// Should not panic
 	m.runAll()
+}
+
+func TestDrainHTTPCompletesInflightRequests(t *testing.T) {
+	// Handler that takes 500ms to respond — simulates in-flight work.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	srv := &http.Server{Handler: handler}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+
+	addr := "http://" + ln.Addr().String()
+
+	// Start an in-flight request.
+	var resp *http.Response
+	var reqErr error
+	reqDone := make(chan struct{})
+	go func() {
+		resp, reqErr = http.Get(addr)
+		close(reqDone)
+	}()
+
+	// Give the request time to reach the handler.
+	time.Sleep(50 * time.Millisecond)
+
+	// Track shutdown hook execution order.
+	var order []string
+	var mu sync.Mutex
+	record := func(name string) {
+		mu.Lock()
+		order = append(order, name)
+		mu.Unlock()
+	}
+
+	m := New(5 * time.Second)
+	m.Register("drain-http", 0, func(ctx context.Context) error {
+		err := DrainHTTP("test-http", srv)(ctx)
+		record("drain-http")
+		return err
+	})
+	m.Register("close-pool", 20, func(ctx context.Context) error {
+		record("close-pool")
+		return nil
+	})
+	m.Register("flush-otel", 30, func(ctx context.Context) error {
+		record("flush-otel")
+		return nil
+	})
+
+	// Trigger shutdown (bypass signal, call runAll directly).
+	m.runAll()
+
+	// Wait for in-flight request to complete.
+	<-reqDone
+
+	if reqErr != nil {
+		t.Fatalf("in-flight request failed: %v", reqErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Verify hook execution order.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 3 {
+		t.Fatalf("expected 3 hooks, got %d: %v", len(order), order)
+	}
+	if order[0] != "drain-http" || order[1] != "close-pool" || order[2] != "flush-otel" {
+		t.Fatalf("expected [drain-http close-pool flush-otel], got %v", order)
+	}
+
+	// Verify new requests are rejected after shutdown.
+	_, err = http.Get(addr)
+	if err == nil {
+		t.Fatal("expected error for request after shutdown")
+	}
+}
+
+func TestWaitForInflight(t *testing.T) {
+	var processing atomic.Bool
+	processing.Store(true)
+
+	// Simulate work completing after 200ms.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		processing.Store(false)
+	}()
+
+	m := New(5 * time.Second)
+	m.Register("wait-inflight", 10, WaitForInflight("test-worker", func() bool {
+		return !processing.Load()
+	}, 50*time.Millisecond))
+
+	start := time.Now()
+	m.runAll()
+	elapsed := time.Since(start)
+
+	if elapsed < 150*time.Millisecond || elapsed > 1*time.Second {
+		t.Fatalf("expected ~200ms wait, got %v", elapsed)
+	}
 }

--- a/go/product-service/cmd/server/main.go
+++ b/go/product-service/cmd/server/main.go
@@ -106,12 +106,11 @@ func main() {
 		cancel()
 		return nil
 	})
-	sm.Register("grpc-drain", 10, func(_ context.Context) error {
-		grpcServer.GracefulStop()
+	sm.Register("drain-http", 0, shutdown.DrainHTTP("product-http", httpSrv))
+	sm.Register("drain-grpc", 0, shutdown.DrainGRPC("product-grpc", grpcServer))
+	sm.Register("postgres", 20, func(_ context.Context) error {
+		pool.Close()
 		return nil
-	})
-	sm.Register("http", 20, func(ctx context.Context) error {
-		return httpSrv.Shutdown(ctx)
 	})
 	sm.Register("otel", 30, func(ctx context.Context) error {
 		return shutdownTracer(ctx)

--- a/go/product-service/internal/repository/product.go
+++ b/go/product-service/internal/repository/product.go
@@ -254,7 +254,7 @@ func (r *ProductRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.
 
 func (r *ProductRepository) Categories(ctx context.Context) ([]string, error) {
 	return resilience.Call(ctx, r.breaker, r.retryCfg, func(ctx context.Context) ([]string, error) {
-		rows, err := r.pool.Query(ctx, "SELECT DISTINCT category FROM products ORDER BY category")
+		rows, err := r.pool.Query(ctx, "SELECT DISTINCT category FROM products ORDER BY category LIMIT 100")
 		if err != nil {
 			return nil, fmt.Errorf("list categories: %w", err)
 		}


### PR DESCRIPTION
## Summary
- Add shared `DrainHTTP`, `DrainGRPC`, `WaitForInflight` helpers to `go/pkg/shutdown/`
- Update all 6 Go services with consistent priority-based shutdown orchestration
- Add `pool.Close()` to product, cart, and order services (previously missing)
- Add `IsIdle()` atomic flag to saga handlers and Kafka consumer for in-flight awareness
- Integration test proving in-flight HTTP requests complete during shutdown
- Defensive `LIMIT 100` on unbounded categories and saga recovery queries
- Shared health check HTTP client in ai-service

## Shutdown priority ordering (all services)
| Priority | Stage | What happens |
|---|---|---|
| 0 | Stop accepting work | HTTP drain, gRPC drain |
| 10 | Wait for in-flight | Saga steps complete, Kafka messages finish |
| 20 | Close connections | PostgreSQL, Redis, RabbitMQ, Kafka |
| 30 | Flush telemetry | OpenTelemetry |

## Test plan
- [x] `make preflight-go` passes (lint + all tests including new shutdown test)
- [ ] CI quality checks pass
- [ ] Verify shutdown logs show hook names during `kubectl rollout restart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)