### PR TITLE
feat: mTLS between services via cert-manager (#101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -904,6 +904,13 @@ jobs:
             --from-literal=jwt-secret='dev-secret-key-at-least-32-characters-long' \
             --dry-run=client -o yaml | kubectl apply -f -"
 
+          # Install cert-manager and apply certificate resources for QA.
+          $SSH "kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml 2>/dev/null || true"
+          $SSH "kubectl wait --for=condition=available --timeout=120s deployment/cert-manager -n cert-manager 2>/dev/null || true"
+          $SSH "kubectl wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager 2>/dev/null || true"
+          cat k8s/cert-manager/cluster-issuer.yml | $SSH "kubectl apply -f -"
+          cat k8s/cert-manager/qa-certificates.yml | $SSH "kubectl apply -f -"
+
           # Apply Go overlay, excluding Jobs (they must run sequentially below).
           # Split multi-doc YAML on '---', drop any document containing 'kind: Job'.
           kubectl kustomize k8s/overlays/qa-go/ \
@@ -1020,6 +1027,15 @@ jobs:
           for f in $(find k8s/ai-services -name '*.yml' -not -name 'namespace.yml'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
           for f in $(find java/k8s -name '*.yml' -not -name 'namespace.yml' -not -path '*/secrets/*'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
           for f in $(find k8s/monitoring -name '*.yml' -not -name 'namespace.yml'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
+          # Install cert-manager and apply certificate resources for prod.
+          $SSH "kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml 2>/dev/null || true"
+          $SSH "kubectl wait --for=condition=available --timeout=120s deployment/cert-manager -n cert-manager 2>/dev/null || true"
+          $SSH "kubectl wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager 2>/dev/null || true"
+          cat k8s/cert-manager/cluster-issuer.yml | $SSH "kubectl apply -f -"
+          cat k8s/cert-manager/ca-certificate.yml | $SSH "kubectl apply -f -"
+          cat k8s/cert-manager/issuer.yml | $SSH "kubectl apply -f -"
+          cat k8s/cert-manager/certificates.yml | $SSH "kubectl apply -f -"
+
           for f in $(find go/k8s -name '*.yml' -not -name 'namespace.yml' -not -path '*/secrets/*' -not -path '*/jobs/*'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
 
           # Only restart deployments that have new images

--- a/go/auth-service/cmd/server/main.go
+++ b/go/auth-service/cmd/server/main.go
@@ -17,9 +17,11 @@ import (
 	pb "github.com/kabradshaw1/portfolio/go/auth-service/pb/auth/v1"
 	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/shutdown"
+	"github.com/kabradshaw1/portfolio/go/pkg/tlsconfig"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -76,10 +78,32 @@ func main() {
 		}
 	}()
 
-	// gRPC server
-	grpcServer := grpc.NewServer(
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-	)
+	// gRPC server — mTLS if TLS_CERT_DIR is set, plaintext otherwise
+	var grpcServer *grpc.Server
+	var tlsWatchStop func()
+	if certDir := os.Getenv("TLS_CERT_DIR"); certDir != "" {
+		serverTLS, err := tlsconfig.ServerTLS(certDir)
+		if err != nil {
+			log.Fatalf("tls config: %v", err)
+		}
+		grpcServer = grpc.NewServer(
+			grpc.Creds(credentials.NewTLS(serverTLS)),
+			grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		)
+		certPtr, _, err := tlsconfig.Load(certDir)
+		if err != nil {
+			log.Fatalf("tls cert pointer: %v", err)
+		}
+		tlsWatchStop, err = tlsconfig.Watch(certDir, certPtr)
+		if err != nil {
+			log.Fatalf("tls watcher: %v", err)
+		}
+		slog.Info("mTLS enabled for gRPC server", "certDir", certDir)
+	} else {
+		grpcServer = grpc.NewServer(
+			grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		)
+	}
 	pb.RegisterAuthServiceServer(grpcServer, authgrpc.NewAuthGRPCServer(cfg.JWTSecret, denylist))
 
 	healthSrv := health.NewServer()
@@ -101,6 +125,12 @@ func main() {
 	}()
 
 	sm := shutdown.New(15 * time.Second)
+	if tlsWatchStop != nil {
+		sm.Register("tls-watcher", 0, func(_ context.Context) error {
+			tlsWatchStop()
+			return nil
+		})
+	}
 	sm.Register("grpc-drain", 10, func(ctx context.Context) error {
 		grpcServer.GracefulStop()
 		return nil

--- a/go/auth-service/go.mod
+++ b/go/auth-service/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go/auth-service/go.sum
+++ b/go/auth-service/go.sum
@@ -21,6 +21,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=

--- a/go/cart-service/cmd/server/main.go
+++ b/go/cart-service/cmd/server/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	var prodClient *productclient.GRPCClient
 	if cfg.ProductGRPCAddr != "" {
-		prodClient, err = productclient.New(cfg.ProductGRPCAddr)
+		prodClient, err = productclient.New(cfg.ProductGRPCAddr, insecure.NewCredentials())
 		if err != nil {
 			log.Fatalf("product gRPC client: %v", err)
 		}

--- a/go/cart-service/cmd/server/main.go
+++ b/go/cart-service/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -30,6 +31,7 @@ import (
 	pb "github.com/kabradshaw1/portfolio/go/cart-service/pb/cart/v1"
 	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/shutdown"
+	"github.com/kabradshaw1/portfolio/go/pkg/tlsconfig"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
@@ -58,9 +60,21 @@ func main() {
 		OnStateChange: resilience.ObserveStateChange,
 	})
 
+	// Resolve gRPC client credentials — mTLS if TLS_CERT_DIR is set
+	var grpcClientCreds credentials.TransportCredentials
+	if certDir := os.Getenv("TLS_CERT_DIR"); certDir != "" {
+		var clientTLSErr error
+		grpcClientCreds, clientTLSErr = tlsconfig.ClientTLS(certDir)
+		if clientTLSErr != nil {
+			log.Fatalf("client tls config: %v", clientTLSErr)
+		}
+	} else {
+		grpcClientCreds = insecure.NewCredentials()
+	}
+
 	var prodClient *productclient.GRPCClient
 	if cfg.ProductGRPCAddr != "" {
-		prodClient, err = productclient.New(cfg.ProductGRPCAddr, insecure.NewCredentials())
+		prodClient, err = productclient.New(cfg.ProductGRPCAddr, grpcClientCreds)
 		if err != nil {
 			log.Fatalf("product gRPC client: %v", err)
 		}
@@ -96,7 +110,7 @@ func main() {
 
 	// Auth-service gRPC connection for denylist checks.
 	authConn, err := grpc.NewClient(cfg.AuthGRPCURL,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(grpcClientCreds),
 	)
 	if err != nil {
 		log.Fatalf("auth gRPC dial: %v", err)
@@ -128,10 +142,32 @@ func main() {
 		}
 	}()
 
-	// gRPC server
-	grpcServer := grpc.NewServer(
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-	)
+	// gRPC server — mTLS if TLS_CERT_DIR is set, plaintext otherwise
+	var grpcServer *grpc.Server
+	var tlsWatchStop func()
+	if certDir := os.Getenv("TLS_CERT_DIR"); certDir != "" {
+		serverTLS, tlsErr := tlsconfig.ServerTLS(certDir)
+		if tlsErr != nil {
+			log.Fatalf("tls config: %v", tlsErr)
+		}
+		grpcServer = grpc.NewServer(
+			grpc.Creds(credentials.NewTLS(serverTLS)),
+			grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		)
+		certPtr, _, tlsErr := tlsconfig.Load(certDir)
+		if tlsErr != nil {
+			log.Fatalf("tls cert pointer: %v", tlsErr)
+		}
+		tlsWatchStop, tlsErr = tlsconfig.Watch(certDir, certPtr)
+		if tlsErr != nil {
+			log.Fatalf("tls watcher: %v", tlsErr)
+		}
+		slog.Info("mTLS enabled for gRPC server", "certDir", certDir)
+	} else {
+		grpcServer = grpc.NewServer(
+			grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		)
+	}
 	pb.RegisterCartServiceServer(grpcServer, grpcsrv.NewCartGRPCServer(cartSvc))
 
 	healthSrv := health.NewServer()
@@ -154,6 +190,12 @@ func main() {
 
 	// Graceful shutdown
 	sm := shutdown.New(15 * time.Second)
+	if tlsWatchStop != nil {
+		sm.Register("tls-watcher", 0, func(_ context.Context) error {
+			tlsWatchStop()
+			return nil
+		})
+	}
 	sm.Register("cancel-ctx", 0, func(_ context.Context) error {
 		cancel()
 		return nil

--- a/go/cart-service/go.mod
+++ b/go/cart-service/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go/cart-service/go.sum
+++ b/go/cart-service/go.sum
@@ -53,6 +53,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=

--- a/go/cart-service/internal/productclient/client.go
+++ b/go/cart-service/internal/productclient/client.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/kabradshaw1/portfolio/go/cart-service/internal/metrics"
 	"github.com/kabradshaw1/portfolio/go/cart-service/internal/model"
@@ -19,9 +19,9 @@ type GRPCClient struct {
 	conn   *grpc.ClientConn
 }
 
-func New(addr string) (*GRPCClient, error) {
+func New(addr string, creds credentials.TransportCredentials) (*GRPCClient, error) {
 	conn, err := grpc.NewClient(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("connect to product-service: %w", err)

--- a/go/k8s/configmaps/auth-service-config.yml
+++ b/go/k8s/configmaps/auth-service-config.yml
@@ -13,3 +13,4 @@ data:
   COOKIE_SAMESITE: "none"
   GRPC_PORT: "9091"
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
+  TLS_CERT_DIR: /etc/tls

--- a/go/k8s/configmaps/cart-service-config.yml
+++ b/go/k8s/configmaps/cart-service-config.yml
@@ -14,3 +14,4 @@ data:
   GRPC_PORT: "9096"
   OTEL_EXPORTER_OTLP_ENDPOINT: "jaeger.monitoring.svc.cluster.local:4317"
   AUTH_GRPC_URL: go-auth-service.go-ecommerce.svc.cluster.local:9091
+  TLS_CERT_DIR: /etc/tls

--- a/go/k8s/configmaps/order-service-config.yml
+++ b/go/k8s/configmaps/order-service-config.yml
@@ -14,3 +14,4 @@ data:
   PRODUCT_GRPC_ADDR: "go-product-service.go-ecommerce.svc.cluster.local:9095"
   CART_GRPC_ADDR: "go-cart-service.go-ecommerce.svc.cluster.local:9096"
   AUTH_GRPC_URL: go-auth-service.go-ecommerce.svc.cluster.local:9091
+  TLS_CERT_DIR: /etc/tls

--- a/go/k8s/configmaps/product-service-config.yml
+++ b/go/k8s/configmaps/product-service-config.yml
@@ -10,3 +10,4 @@ data:
   PORT: "8095"
   GRPC_PORT: "9095"
   OTEL_EXPORTER_OTLP_ENDPOINT: "jaeger.monitoring.svc.cluster.local:4317"
+  TLS_CERT_DIR: /etc/tls

--- a/go/k8s/deployments/auth-service.yml
+++ b/go/k8s/deployments/auth-service.yml
@@ -20,6 +20,10 @@ spec:
       terminationGracePeriodSeconds: 20
       imagePullSecrets:
         - name: ghcr-secret
+      volumes:
+        - name: grpc-tls
+          secret:
+            secretName: auth-grpc-tls
       containers:
         - name: go-auth-service
           image: ghcr.io/kabradshaw1/portfolio/go-auth-service:latest
@@ -75,3 +79,7 @@ spec:
               port: 8091
             initialDelaySeconds: 15
             periodSeconds: 30
+          volumeMounts:
+            - name: grpc-tls
+              mountPath: /etc/tls
+              readOnly: true

--- a/go/k8s/deployments/cart-service.yml
+++ b/go/k8s/deployments/cart-service.yml
@@ -20,6 +20,10 @@ spec:
       terminationGracePeriodSeconds: 20
       imagePullSecrets:
         - name: ghcr-secret
+      volumes:
+        - name: grpc-tls
+          secret:
+            secretName: cart-grpc-tls
       containers:
         - name: go-cart-service
           image: ghcr.io/kabradshaw1/portfolio/go-cart-service:latest
@@ -65,3 +69,7 @@ spec:
               port: 8096
             initialDelaySeconds: 15
             periodSeconds: 30
+          volumeMounts:
+            - name: grpc-tls
+              mountPath: /etc/tls
+              readOnly: true

--- a/go/k8s/deployments/order-service.yml
+++ b/go/k8s/deployments/order-service.yml
@@ -20,6 +20,10 @@ spec:
       terminationGracePeriodSeconds: 20
       imagePullSecrets:
         - name: ghcr-secret
+      volumes:
+        - name: grpc-tls
+          secret:
+            secretName: order-grpc-tls
       containers:
         - name: go-order-service
           image: ghcr.io/kabradshaw1/portfolio/go-order-service:latest
@@ -62,3 +66,7 @@ spec:
               port: 8092
             initialDelaySeconds: 15
             periodSeconds: 30
+          volumeMounts:
+            - name: grpc-tls
+              mountPath: /etc/tls
+              readOnly: true

--- a/go/k8s/deployments/product-service.yml
+++ b/go/k8s/deployments/product-service.yml
@@ -20,6 +20,10 @@ spec:
       terminationGracePeriodSeconds: 20
       imagePullSecrets:
         - name: ghcr-secret
+      volumes:
+        - name: grpc-tls
+          secret:
+            secretName: product-grpc-tls
       containers:
         - name: go-product-service
           image: ghcr.io/kabradshaw1/portfolio/go-product-service:latest
@@ -59,3 +63,7 @@ spec:
               port: 8095
             initialDelaySeconds: 15
             periodSeconds: 30
+          volumeMounts:
+            - name: grpc-tls
+              mountPath: /etc/tls
+              readOnly: true

--- a/go/order-service/cmd/server/main.go
+++ b/go/order-service/cmd/server/main.go
@@ -59,7 +59,7 @@ func main() {
 	var prodClient *productclient.GRPCClient
 	if cfg.ProductGRPCAddr != "" {
 		var err error
-		prodClient, err = productclient.New(cfg.ProductGRPCAddr)
+		prodClient, err = productclient.New(cfg.ProductGRPCAddr, insecure.NewCredentials())
 		if err != nil {
 			log.Fatalf("product gRPC client: %v", err)
 		}
@@ -70,7 +70,7 @@ func main() {
 	var cartClient *cartclient.GRPCClient
 	if cfg.CartGRPCAddr != "" {
 		var err error
-		cartClient, err = cartclient.New(cfg.CartGRPCAddr, cfg.ProductGRPCAddr)
+		cartClient, err = cartclient.New(cfg.CartGRPCAddr, cfg.ProductGRPCAddr, insecure.NewCredentials())
 		if err != nil {
 			log.Fatalf("cart gRPC client: %v", err)
 		}

--- a/go/order-service/cmd/server/main.go
+++ b/go/order-service/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/kabradshaw1/portfolio/go/auth-service/authmiddleware"
@@ -21,6 +22,7 @@ import (
 	"github.com/kabradshaw1/portfolio/go/order-service/internal/service"
 	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/shutdown"
+	"github.com/kabradshaw1/portfolio/go/pkg/tlsconfig"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
@@ -56,10 +58,32 @@ func main() {
 	orderRepo := repository.NewOrderRepository(pool, pgBreaker)
 	returnRepo := repository.NewReturnRepository(pool, pgBreaker)
 
+	// Resolve gRPC transport credentials — mTLS if TLS_CERT_DIR is set
+	var grpcCreds credentials.TransportCredentials
+	var tlsWatchStop func()
+	if certDir := os.Getenv("TLS_CERT_DIR"); certDir != "" {
+		var tlsErr error
+		grpcCreds, tlsErr = tlsconfig.ClientTLS(certDir)
+		if tlsErr != nil {
+			log.Fatalf("tls config: %v", tlsErr)
+		}
+		certPtr, _, tlsErr := tlsconfig.Load(certDir)
+		if tlsErr != nil {
+			log.Fatalf("tls cert pointer: %v", tlsErr)
+		}
+		tlsWatchStop, tlsErr = tlsconfig.Watch(certDir, certPtr)
+		if tlsErr != nil {
+			log.Fatalf("tls watcher: %v", tlsErr)
+		}
+		slog.Info("mTLS enabled for gRPC clients", "certDir", certDir)
+	} else {
+		grpcCreds = insecure.NewCredentials()
+	}
+
 	var prodClient *productclient.GRPCClient
 	if cfg.ProductGRPCAddr != "" {
 		var err error
-		prodClient, err = productclient.New(cfg.ProductGRPCAddr, insecure.NewCredentials())
+		prodClient, err = productclient.New(cfg.ProductGRPCAddr, grpcCreds)
 		if err != nil {
 			log.Fatalf("product gRPC client: %v", err)
 		}
@@ -70,7 +94,7 @@ func main() {
 	var cartClient *cartclient.GRPCClient
 	if cfg.CartGRPCAddr != "" {
 		var err error
-		cartClient, err = cartclient.New(cfg.CartGRPCAddr, cfg.ProductGRPCAddr, insecure.NewCredentials())
+		cartClient, err = cartclient.New(cfg.CartGRPCAddr, cfg.ProductGRPCAddr, grpcCreds)
 		if err != nil {
 			log.Fatalf("cart gRPC client: %v", err)
 		}
@@ -106,7 +130,7 @@ func main() {
 
 	// Auth-service gRPC connection for denylist checks.
 	authConn, err := grpc.NewClient(cfg.AuthGRPCURL,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(grpcCreds),
 	)
 	if err != nil {
 		log.Fatalf("auth gRPC dial: %v", err)
@@ -141,6 +165,12 @@ func main() {
 
 	// Graceful shutdown
 	sm := shutdown.New(15 * time.Second)
+	if tlsWatchStop != nil {
+		sm.Register("tls-watcher", 0, func(_ context.Context) error {
+			tlsWatchStop()
+			return nil
+		})
+	}
 	sm.Register("cancel-ctx", 0, func(_ context.Context) error {
 		cancel()
 		return nil

--- a/go/order-service/go.mod
+++ b/go/order-service/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go/order-service/go.sum
+++ b/go/order-service/go.sum
@@ -53,6 +53,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=

--- a/go/order-service/internal/cartclient/client.go
+++ b/go/order-service/internal/cartclient/client.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
 	cart "github.com/kabradshaw1/portfolio/go/cart-service/pb/cart/v1"
 	"github.com/kabradshaw1/portfolio/go/order-service/internal/model"
@@ -23,16 +23,16 @@ type GRPCClient struct {
 }
 
 // New dials both cart-service and product-service gRPC endpoints.
-func New(cartAddr, productAddr string) (*GRPCClient, error) {
+func New(cartAddr, productAddr string, creds credentials.TransportCredentials) (*GRPCClient, error) {
 	cartConn, err := grpc.NewClient(cartAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("connect to cart-service: %w", err)
 	}
 
 	productConn, err := grpc.NewClient(productAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
 		cartConn.Close()

--- a/go/order-service/internal/productclient/client.go
+++ b/go/order-service/internal/productclient/client.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
 	pb "github.com/kabradshaw1/portfolio/go/product-service/pb/product/v1"
 )
@@ -20,9 +20,9 @@ type GRPCClient struct {
 }
 
 // New dials the product-service gRPC endpoint and returns a ready client.
-func New(addr string) (*GRPCClient, error) {
+func New(addr string, creds credentials.TransportCredentials) (*GRPCClient, error) {
 	conn, err := grpc.NewClient(addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("connect to product-service: %w", err)

--- a/go/pkg/go.mod
+++ b/go/pkg/go.mod
@@ -3,6 +3,7 @@ module github.com/kabradshaw1/portfolio/go/pkg
 go 1.26.1
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/prometheus/client_golang v1.23.2
@@ -14,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	google.golang.org/grpc v1.80.0
 )
 
 require (
@@ -107,7 +109,6 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go/pkg/go.sum
+++ b/go/pkg/go.sum
@@ -47,6 +47,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=

--- a/go/pkg/tlsconfig/testutil_test.go
+++ b/go/pkg/tlsconfig/testutil_test.go
@@ -1,0 +1,90 @@
+package tlsconfig_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func generateTestCerts(t *testing.T, dir string) {
+	t.Helper()
+
+	// Generate CA key + self-signed CA cert
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caCert, err := x509.ParseCertificate(caCertDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate leaf key + cert signed by CA
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-service"},
+		DNSNames:     []string{"localhost", "test-service.default.svc.cluster.local"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+
+	leafCertDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writePEM(t, filepath.Join(dir, "ca.crt"), "CERTIFICATE", caCertDER)
+	writePEM(t, filepath.Join(dir, "tls.crt"), "CERTIFICATE", leafCertDER)
+
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writePEM(t, filepath.Join(dir, "tls.key"), "EC PRIVATE KEY", leafKeyDER)
+}
+
+func writePEM(t *testing.T, path, blockType string, data []byte) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := pem.Encode(f, &pem.Block{Type: blockType, Bytes: data}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/pkg/tlsconfig/tlsconfig.go
+++ b/go/pkg/tlsconfig/tlsconfig.go
@@ -1,0 +1,155 @@
+// Package tlsconfig provides mTLS configuration helpers for Go services.
+// It loads TLS certificates from a directory (ca.crt, tls.crt, tls.key),
+// supports hot-reload via fsnotify file watching, and produces tls.Config
+// for servers and gRPC TransportCredentials for clients.
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"google.golang.org/grpc/credentials"
+)
+
+const watchDebounce = 500 * time.Millisecond // coalesce rapid file events from cert rotation
+
+// ServerTLS loads certs from certDir and returns a *tls.Config for mTLS servers.
+// Uses GetCertificate with an atomic pointer for hot reload via Watch.
+func ServerTLS(certDir string) (*tls.Config, error) {
+	certPtr, caPool, err := Load(certDir)
+	if err != nil {
+		return nil, fmt.Errorf("server tls: %w", err)
+	}
+
+	return &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return certPtr.Load(), nil
+		},
+		ClientCAs:  caPool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		MinVersion: tls.VersionTLS13,
+	}, nil
+}
+
+// ClientTLS loads certs from certDir and returns gRPC TransportCredentials for mTLS clients.
+func ClientTLS(certDir string) (credentials.TransportCredentials, error) {
+	certPtr, caPool, err := Load(certDir)
+	if err != nil {
+		return nil, fmt.Errorf("client tls: %w", err)
+	}
+
+	cfg := &tls.Config{
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return certPtr.Load(), nil
+		},
+		RootCAs:    caPool,
+		MinVersion: tls.VersionTLS13,
+	}
+
+	return credentials.NewTLS(cfg), nil
+}
+
+// Load reads tls.crt, tls.key, ca.crt from certDir and returns an atomic
+// pointer to the certificate and a CA pool. The atomic pointer enables
+// lock-free hot reload when paired with Watch.
+func Load(certDir string) (*atomic.Pointer[tls.Certificate], *x509.CertPool, error) {
+	certFile := filepath.Join(certDir, "tls.crt")
+	keyFile := filepath.Join(certDir, "tls.key")
+	caFile := filepath.Join(certDir, "ca.crt")
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load cert/key: %w", err)
+	}
+
+	caData, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read ca cert: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(caData) {
+		return nil, nil, fmt.Errorf("failed to parse CA cert")
+	}
+
+	var ptr atomic.Pointer[tls.Certificate]
+	ptr.Store(&cert)
+
+	return &ptr, caPool, nil
+}
+
+// Watch monitors certDir for file changes and reloads the cert into certPtr.
+// It debounces with a 500ms timer to coalesce rapid writes from cert-manager
+// rotation. Returns a stop function that shuts down the watcher goroutine.
+func Watch(certDir string, certPtr *atomic.Pointer[tls.Certificate]) (stop func(), err error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create watcher: %w", err)
+	}
+
+	if err := watcher.Add(certDir); err != nil {
+		watcher.Close()
+		return nil, fmt.Errorf("watch %s: %w", certDir, err)
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer watcher.Close()
+
+		var debounce *time.Timer
+
+		for {
+			select {
+			case <-done:
+				if debounce != nil {
+					debounce.Stop()
+				}
+				return
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+					if debounce != nil {
+						debounce.Stop()
+					}
+
+					debounce = time.AfterFunc(watchDebounce, func() {
+						reload(certDir, certPtr)
+					})
+				}
+			case watchErr, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+
+				slog.Error("tls watcher error", "error", watchErr)
+			}
+		}
+	}()
+
+	return func() { close(done) }, nil
+}
+
+func reload(certDir string, certPtr *atomic.Pointer[tls.Certificate]) {
+	certFile := filepath.Join(certDir, "tls.crt")
+	keyFile := filepath.Join(certDir, "tls.key")
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		slog.Error("tls reload failed", "error", err)
+		return
+	}
+
+	certPtr.Store(&cert)
+	slog.Info("tls certificate reloaded", "certDir", certDir)
+}

--- a/go/pkg/tlsconfig/tlsconfig_test.go
+++ b/go/pkg/tlsconfig/tlsconfig_test.go
@@ -1,0 +1,93 @@
+package tlsconfig_test
+
+import (
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/pkg/tlsconfig"
+)
+
+func TestServerTLS_LoadsCerts(t *testing.T) {
+	dir := t.TempDir()
+	generateTestCerts(t, dir)
+
+	cfg, err := tlsconfig.ServerTLS(dir)
+	if err != nil {
+		t.Fatalf("ServerTLS: %v", err)
+	}
+
+	if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("expected RequireAndVerifyClientCert, got %v", cfg.ClientAuth)
+	}
+
+	cert, err := cfg.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+
+	if cert == nil {
+		t.Fatal("GetCertificate returned nil")
+	}
+}
+
+func TestClientTLS_LoadsCerts(t *testing.T) {
+	dir := t.TempDir()
+	generateTestCerts(t, dir)
+
+	creds, err := tlsconfig.ClientTLS(dir)
+	if err != nil {
+		t.Fatalf("ClientTLS: %v", err)
+	}
+
+	if creds == nil {
+		t.Fatal("ClientTLS returned nil credentials")
+	}
+
+	if info := creds.Info(); info.SecurityProtocol != "tls" {
+		t.Fatalf("expected 'tls', got %q", info.SecurityProtocol)
+	}
+}
+
+func TestServerTLS_MissingDir_ReturnsError(t *testing.T) {
+	_, err := tlsconfig.ServerTLS("/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error for missing cert dir")
+	}
+}
+
+func TestClientTLS_MissingDir_ReturnsError(t *testing.T) {
+	_, err := tlsconfig.ClientTLS("/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error for missing cert dir")
+	}
+}
+
+func TestWatch_ReloadsOnChange(t *testing.T) {
+	dir := t.TempDir()
+	generateTestCerts(t, dir)
+
+	certPtr, _, err := tlsconfig.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalCert := certPtr.Load()
+
+	stop, err := tlsconfig.Watch(dir, certPtr)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer stop()
+
+	// Overwrite certs with new ones
+	generateTestCerts(t, dir)
+
+	// Wait for watcher debounce (500ms) + margin
+	time.Sleep(1 * time.Second)
+
+	newCert := certPtr.Load()
+	if newCert == originalCert {
+		t.Fatal("expected cert pointer to change after file write")
+	}
+}

--- a/go/product-service/cmd/server/main.go
+++ b/go/product-service/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -23,6 +24,7 @@ import (
 	"github.com/kabradshaw1/portfolio/go/product-service/internal/service"
 	"github.com/kabradshaw1/portfolio/go/pkg/resilience"
 	"github.com/kabradshaw1/portfolio/go/pkg/shutdown"
+	"github.com/kabradshaw1/portfolio/go/pkg/tlsconfig"
 	"github.com/kabradshaw1/portfolio/go/pkg/tracing"
 )
 
@@ -73,10 +75,32 @@ func main() {
 		}
 	}()
 
-	// gRPC server
-	grpcServer := grpc.NewServer(
-		grpc.StatsHandler(otelgrpc.NewServerHandler()),
-	)
+	// gRPC server — mTLS if TLS_CERT_DIR is set, plaintext otherwise
+	var grpcServer *grpc.Server
+	var tlsWatchStop func()
+	if certDir := os.Getenv("TLS_CERT_DIR"); certDir != "" {
+		serverTLS, err := tlsconfig.ServerTLS(certDir)
+		if err != nil {
+			log.Fatalf("tls config: %v", err)
+		}
+		grpcServer = grpc.NewServer(
+			grpc.Creds(credentials.NewTLS(serverTLS)),
+			grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		)
+		certPtr, _, err := tlsconfig.Load(certDir)
+		if err != nil {
+			log.Fatalf("tls cert pointer: %v", err)
+		}
+		tlsWatchStop, err = tlsconfig.Watch(certDir, certPtr)
+		if err != nil {
+			log.Fatalf("tls watcher: %v", err)
+		}
+		slog.Info("mTLS enabled for gRPC server", "certDir", certDir)
+	} else {
+		grpcServer = grpc.NewServer(
+			grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		)
+	}
 	pb.RegisterProductServiceServer(grpcServer, grpcsrv.NewProductGRPCServer(
 		productSvc,
 		grpcsrv.WithStockDecrementer(productRepo),
@@ -102,6 +126,12 @@ func main() {
 
 	// Graceful shutdown
 	sm := shutdown.New(15 * time.Second)
+	if tlsWatchStop != nil {
+		sm.Register("tls-watcher", 0, func(_ context.Context) error {
+			tlsWatchStop()
+			return nil
+		})
+	}
 	sm.Register("cancel-ctx", 0, func(_ context.Context) error {
 		cancel()
 		return nil

--- a/go/product-service/go.mod
+++ b/go/product-service/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go/product-service/go.sum
+++ b/go/product-service/go.sum
@@ -53,6 +53,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=

--- a/k8s/cert-manager/ca-certificate.yml
+++ b/k8s/cert-manager/ca-certificate.yml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grpc-ca
+  namespace: go-ecommerce
+spec:
+  isCA: true
+  commonName: grpc-internal-ca
+  secretName: grpc-ca-keypair
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer

--- a/k8s/cert-manager/certificates.yml
+++ b/k8s/cert-manager/certificates.yml
@@ -1,0 +1,94 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: auth-grpc-tls
+  namespace: go-ecommerce
+spec:
+  commonName: go-auth-service.go-ecommerce.svc.cluster.local
+  secretName: auth-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-auth-service
+    - go-auth-service.go-ecommerce
+    - go-auth-service.go-ecommerce.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: product-grpc-tls
+  namespace: go-ecommerce
+spec:
+  commonName: go-product-service.go-ecommerce.svc.cluster.local
+  secretName: product-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-product-service
+    - go-product-service.go-ecommerce
+    - go-product-service.go-ecommerce.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cart-grpc-tls
+  namespace: go-ecommerce
+spec:
+  commonName: go-cart-service.go-ecommerce.svc.cluster.local
+  secretName: cart-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-cart-service
+    - go-cart-service.go-ecommerce
+    - go-cart-service.go-ecommerce.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: order-grpc-tls
+  namespace: go-ecommerce
+spec:
+  commonName: go-order-service.go-ecommerce.svc.cluster.local
+  secretName: order-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-order-service
+    - go-order-service.go-ecommerce
+    - go-order-service.go-ecommerce.svc.cluster.local
+  usages:
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer

--- a/k8s/cert-manager/cluster-issuer.yml
+++ b/k8s/cert-manager/cluster-issuer.yml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/k8s/cert-manager/issuer.yml
+++ b/k8s/cert-manager/issuer.yml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: grpc-ca-issuer
+  namespace: go-ecommerce
+spec:
+  ca:
+    secretName: grpc-ca-keypair

--- a/k8s/cert-manager/qa-certificates.yml
+++ b/k8s/cert-manager/qa-certificates.yml
@@ -1,0 +1,124 @@
+---
+# QA CA Certificate — bootstraps the CA for go-ecommerce-qa namespace
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grpc-ca
+  namespace: go-ecommerce-qa
+spec:
+  isCA: true
+  commonName: grpc-internal-ca
+  secretName: grpc-ca-keypair
+  duration: 8760h
+  renewBefore: 720h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+---
+# QA Issuer — namespace-scoped, uses the CA secret above
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: grpc-ca-issuer
+  namespace: go-ecommerce-qa
+spec:
+  ca:
+    secretName: grpc-ca-keypair
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: auth-grpc-tls
+  namespace: go-ecommerce-qa
+spec:
+  commonName: go-auth-service.go-ecommerce-qa.svc.cluster.local
+  secretName: auth-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-auth-service
+    - go-auth-service.go-ecommerce-qa
+    - go-auth-service.go-ecommerce-qa.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: product-grpc-tls
+  namespace: go-ecommerce-qa
+spec:
+  commonName: go-product-service.go-ecommerce-qa.svc.cluster.local
+  secretName: product-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-product-service
+    - go-product-service.go-ecommerce-qa
+    - go-product-service.go-ecommerce-qa.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cart-grpc-tls
+  namespace: go-ecommerce-qa
+spec:
+  commonName: go-cart-service.go-ecommerce-qa.svc.cluster.local
+  secretName: cart-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-cart-service
+    - go-cart-service.go-ecommerce-qa
+    - go-cart-service.go-ecommerce-qa.svc.cluster.local
+  usages:
+    - server auth
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: order-grpc-tls
+  namespace: go-ecommerce-qa
+spec:
+  commonName: go-order-service.go-ecommerce-qa.svc.cluster.local
+  secretName: order-grpc-tls
+  duration: 720h
+  renewBefore: 480h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  dnsNames:
+    - go-order-service
+    - go-order-service.go-ecommerce-qa
+    - go-order-service.go-ecommerce-qa.svc.cluster.local
+  usages:
+    - client auth
+  issuerRef:
+    name: grpc-ca-issuer
+    kind: Issuer

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -38,6 +38,16 @@ if [ "$ENV" = "qa" ]; then
   echo "==> Deploying java-tasks-qa..."
   kubectl apply -k "$SCRIPT_DIR/overlays/qa-java"
 
+  echo "==> Installing cert-manager (if not already present)..."
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml 2>/dev/null || true
+  echo "==> Waiting for cert-manager..."
+  kubectl wait --for=condition=available --timeout=120s deployment/cert-manager -n cert-manager 2>/dev/null || true
+  kubectl wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager 2>/dev/null || true
+
+  echo "==> Applying cert-manager resources..."
+  kubectl apply -f "$SCRIPT_DIR/cert-manager/cluster-issuer.yml"
+  kubectl apply -f "$SCRIPT_DIR/cert-manager/qa-certificates.yml"
+
   echo "==> Deploying go-ecommerce-qa..."
   kubectl apply -k "$SCRIPT_DIR/overlays/qa-go"
 
@@ -109,6 +119,18 @@ fi
 
 # --- Deploy go-ecommerce ---
 echo "==> Deploying go-ecommerce..."
+echo "==> Installing cert-manager (if not already present)..."
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml 2>/dev/null || true
+echo "==> Waiting for cert-manager..."
+kubectl wait --for=condition=available --timeout=120s deployment/cert-manager -n cert-manager 2>/dev/null || true
+kubectl wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager 2>/dev/null || true
+
+echo "==> Applying cert-manager resources..."
+kubectl apply -f "$SCRIPT_DIR/cert-manager/cluster-issuer.yml"
+kubectl apply -f "$SCRIPT_DIR/cert-manager/ca-certificate.yml"
+kubectl apply -f "$SCRIPT_DIR/cert-manager/issuer.yml"
+kubectl apply -f "$SCRIPT_DIR/cert-manager/certificates.yml"
+
 kubectl apply -k "$REPO_DIR/go/k8s/overlays/$ENV"
 
 echo "==> Waiting for all application services..."

--- a/k8s/overlays/qa-go/kustomization.yaml
+++ b/k8s/overlays/qa-go/kustomization.yaml
@@ -24,6 +24,9 @@ patches:
       - op: add
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
+      - op: add
+        path: /data/TLS_CERT_DIR
+        value: /etc/tls
   - target:
       kind: ConfigMap
       name: order-service-config
@@ -52,6 +55,9 @@ patches:
       - op: add
         path: /data/AUTH_GRPC_URL
         value: "go-auth-service.go-ecommerce-qa.svc.cluster.local:9091"
+      - op: add
+        path: /data/TLS_CERT_DIR
+        value: /etc/tls
   - target:
       kind: ConfigMap
       name: ai-service-config
@@ -110,6 +116,9 @@ patches:
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
+      - op: add
+        path: /data/TLS_CERT_DIR
+        value: /etc/tls
   - target:
       kind: ConfigMap
       name: cart-service-config
@@ -135,6 +144,9 @@ patches:
       - op: add
         path: /data/AUTH_GRPC_URL
         value: "go-auth-service.go-ecommerce-qa.svc.cluster.local:9091"
+      - op: add
+        path: /data/TLS_CERT_DIR
+        value: /etc/tls
   # --- Migration jobs ---
   # No Job patches needed: migration jobs read DATABASE_URL via configMapKeyRef
   # from their respective ConfigMaps above. The patches already repoint


### PR DESCRIPTION
## Summary

- **Shared `go/pkg/tlsconfig` package** with `ServerTLS`, `ClientTLS`, and `Watch` — hot-reloadable mTLS via `fsnotify` + `atomic.Pointer`, zero-downtime cert rotation
- **cert-manager infrastructure** — self-signed CA chain (ClusterIssuer → CA Certificate → Issuer), per-service Certificate resources for prod and QA
- **TLS opt-in via `TLS_CERT_DIR` env var** — all 4 gRPC-participating services (auth, product, cart, order) conditionally enable mTLS; unset = plaintext for local dev/CI
- **K8s wiring** — Secret volume mounts, ConfigMap `TLS_CERT_DIR`, QA overlay patches, deploy.sh + CI pipeline cert-manager install

## Test plan
- [ ] `go/pkg/tlsconfig` — 5 unit tests pass (ServerTLS, ClientTLS, missing dir errors, Watch hot reload)
- [ ] All 6 Go services lint clean and tests pass with `-race`
- [ ] Without `TLS_CERT_DIR`: services start in plaintext mode (local dev, CI)
- [ ] QA deploy: cert-manager installs, Certificates provision Secrets, services mount certs
- [ ] QA smoke: order → product/cart/auth gRPC calls succeed over mTLS
- [ ] Plaintext gRPC call from debug pod is rejected (manual verification)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)