### PR TITLE
fix(payment): resolve webhook payment lookup failure

### DIFF
--- a/go/payment-service/internal/handler/webhook.go
+++ b/go/payment-service/internal/handler/webhook.go
@@ -13,14 +13,14 @@ import (
 
 // WebhookService processes validated Stripe webhook events.
 type WebhookService interface {
-	HandlePaymentSucceeded(ctx context.Context, eventID, intentID string) error
-	HandlePaymentFailed(ctx context.Context, eventID, intentID string) error
+	HandlePaymentSucceeded(ctx context.Context, eventID, intentID string, metadata map[string]string) error
+	HandlePaymentFailed(ctx context.Context, eventID, intentID string, metadata map[string]string) error
 	HandleRefund(ctx context.Context, eventID, intentID string) error
 }
 
 // EventVerifier validates the Stripe-Signature header and extracts event fields.
 type EventVerifier interface {
-	VerifyAndParse(payload []byte, sigHeader string) (eventType, eventID, intentID string, err error)
+	VerifyAndParse(payload []byte, sigHeader string) (eventType, eventID, intentID string, metadata map[string]string, err error)
 }
 
 // WebhookHandler handles incoming Stripe webhook events.
@@ -44,7 +44,7 @@ func (h *WebhookHandler) HandleWebhook(c *gin.Context) {
 	}
 
 	sigHeader := c.GetHeader("Stripe-Signature")
-	eventType, eventID, intentID, err := h.verifier.VerifyAndParse(payload, sigHeader)
+	eventType, eventID, intentID, metadata, err := h.verifier.VerifyAndParse(payload, sigHeader)
 	if err != nil {
 		_ = c.Error(apperror.BadRequest("WEBHOOK_INVALID_SIGNATURE", "webhook signature verification failed"))
 		return
@@ -55,14 +55,14 @@ func (h *WebhookHandler) HandleWebhook(c *gin.Context) {
 
 	switch eventType {
 	case "payment_intent.succeeded":
-		if err := h.svc.HandlePaymentSucceeded(ctx, eventID, intentID); err != nil {
+		if err := h.svc.HandlePaymentSucceeded(ctx, eventID, intentID, metadata); err != nil {
 			metrics.WebhookEvents.WithLabelValues(eventType, "error").Inc()
 			_ = c.Error(err)
 			return
 		}
 		metrics.WebhookEvents.WithLabelValues(eventType, "processed").Inc()
 	case "payment_intent.payment_failed":
-		if err := h.svc.HandlePaymentFailed(ctx, eventID, intentID); err != nil {
+		if err := h.svc.HandlePaymentFailed(ctx, eventID, intentID, metadata); err != nil {
 			metrics.WebhookEvents.WithLabelValues(eventType, "error").Inc()
 			_ = c.Error(err)
 			return

--- a/go/payment-service/internal/handler/webhook_test.go
+++ b/go/payment-service/internal/handler/webhook_test.go
@@ -21,12 +21,12 @@ type mockWebhookService struct {
 	calls        []string
 }
 
-func (m *mockWebhookService) HandlePaymentSucceeded(_ context.Context, _, _ string) error {
+func (m *mockWebhookService) HandlePaymentSucceeded(_ context.Context, _, _ string, _ map[string]string) error {
 	m.calls = append(m.calls, "succeeded")
 	return m.succeededErr
 }
 
-func (m *mockWebhookService) HandlePaymentFailed(_ context.Context, _, _ string) error {
+func (m *mockWebhookService) HandlePaymentFailed(_ context.Context, _, _ string, _ map[string]string) error {
 	m.calls = append(m.calls, "failed")
 	return m.failedErr
 }
@@ -40,11 +40,12 @@ type mockEventVerifier struct {
 	eventType string
 	eventID   string
 	intentID  string
+	metadata  map[string]string
 	err       error
 }
 
-func (m *mockEventVerifier) VerifyAndParse(_ []byte, _ string) (string, string, string, error) {
-	return m.eventType, m.eventID, m.intentID, m.err
+func (m *mockEventVerifier) VerifyAndParse(_ []byte, _ string) (string, string, string, map[string]string, error) {
+	return m.eventType, m.eventID, m.intentID, m.metadata, m.err
 }
 
 // --- helpers ---
@@ -82,6 +83,7 @@ func TestWebhookHandler_PaymentSucceeded(t *testing.T) {
 		eventType: "payment_intent.succeeded",
 		eventID:   "evt_123",
 		intentID:  "pi_123",
+		metadata:  map[string]string{"order_id": "f5cd888c-c661-41ad-a2fd-e14fdeac800d"},
 	}
 	router := setupWebhookRouter(svc, verifier)
 

--- a/go/payment-service/internal/outbox/poller.go
+++ b/go/payment-service/internal/outbox/poller.go
@@ -3,6 +3,7 @@ package outbox
 import (
 	"context"
 	"log/slog"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 type OutboxFetcher interface {
 	FetchUnpublished(ctx context.Context, limit int) ([]model.OutboxMessage, error)
 	MarkPublished(ctx context.Context, id uuid.UUID) error
+	Ping(ctx context.Context) error
 }
 
 // Poller periodically fetches unpublished outbox messages and publishes them to RabbitMQ.
@@ -46,9 +48,38 @@ func (p *Poller) IsIdle() bool {
 	return p.idle.Load()
 }
 
+const (
+	waitForDBInitialBackoff = 1 * time.Second
+	waitForDBMaxBackoff     = 30 * time.Second
+)
+
+// waitForDB blocks until the database is reachable or the context is cancelled.
+// Uses exponential backoff starting at 1s, capped at 30s.
+func (p *Poller) waitForDB(ctx context.Context) {
+	backoff := waitForDBInitialBackoff
+	for {
+		if err := p.fetcher.Ping(ctx); err == nil {
+			slog.InfoContext(ctx, "outbox poller: database ready")
+			return
+		}
+
+		slog.WarnContext(ctx, "outbox poller: database not ready, retrying", "backoff", backoff)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		backoff = time.Duration(math.Min(float64(backoff*2), float64(waitForDBMaxBackoff)))
+	}
+}
+
 // Run starts the polling loop. It ticks at the configured interval and calls poll on each tick.
 // It stops when the context is cancelled.
 func (p *Poller) Run(ctx context.Context) {
+	p.waitForDB(ctx)
+
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
 

--- a/go/payment-service/internal/outbox/poller_test.go
+++ b/go/payment-service/internal/outbox/poller_test.go
@@ -1,15 +1,66 @@
 package outbox
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/kabradshaw1/portfolio/go/payment-service/internal/model"
 )
+
+type mockFetcher struct {
+	pingErr   error
+	pingCalls int
+}
+
+func (m *mockFetcher) FetchUnpublished(_ context.Context, _ int) ([]model.OutboxMessage, error) {
+	return nil, nil
+}
+
+func (m *mockFetcher) MarkPublished(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func (m *mockFetcher) Ping(ctx context.Context) error {
+	m.pingCalls++
+	return m.pingErr
+}
 
 func TestNewPoller(t *testing.T) {
 	p := NewPoller(nil, (*amqp.Channel)(nil), time.Second, 10)
 	if p == nil {
 		t.Fatal("expected non-nil Poller")
+	}
+}
+
+func TestWaitForDB_SuccessFirstAttempt(t *testing.T) {
+	f := &mockFetcher{}
+	p := NewPoller(f, (*amqp.Channel)(nil), time.Second, 10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	p.waitForDB(ctx)
+
+	if f.pingCalls != 1 {
+		t.Errorf("expected 1 ping call, got %d", f.pingCalls)
+	}
+}
+
+func TestWaitForDB_ContextCancelled(t *testing.T) {
+	f := &mockFetcher{pingErr: errors.New("connection refused")}
+	p := NewPoller(f, (*amqp.Channel)(nil), time.Second, 10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	p.waitForDB(ctx)
+
+	if f.pingCalls < 1 {
+		t.Errorf("expected at least 1 ping call, got %d", f.pingCalls)
 	}
 }

--- a/go/payment-service/internal/repository/outbox.go
+++ b/go/payment-service/internal/repository/outbox.go
@@ -85,6 +85,11 @@ func (r *OutboxRepository) FetchUnpublished(ctx context.Context, limit int) ([]m
 	})
 }
 
+// Ping checks whether the database connection is alive.
+func (r *OutboxRepository) Ping(ctx context.Context) error {
+	return r.pool.Ping(ctx)
+}
+
 // MarkPublished sets the published flag to true for the given outbox message ID.
 func (r *OutboxRepository) MarkPublished(ctx context.Context, id uuid.UUID) error {
 	if r.pool == nil {

--- a/go/payment-service/internal/service/webhook.go
+++ b/go/payment-service/internal/service/webhook.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/kabradshaw1/portfolio/go/payment-service/internal/metrics"
 	"github.com/kabradshaw1/portfolio/go/payment-service/internal/model"
@@ -51,7 +52,7 @@ func NewWebhookService(
 
 // HandlePaymentSucceeded deduplicates the event, updates payment status to succeeded,
 // and writes a saga confirmation event to the outbox.
-func (s *WebhookService) HandlePaymentSucceeded(ctx context.Context, eventID, intentID string) error {
+func (s *WebhookService) HandlePaymentSucceeded(ctx context.Context, eventID, intentID string, metadata map[string]string) error {
 	inserted, err := s.eventRepo.TryInsert(ctx, nil, eventID, "payment_intent.succeeded")
 	if err != nil {
 		return fmt.Errorf("dedup payment succeeded: %w", err)
@@ -62,9 +63,21 @@ func (s *WebhookService) HandlePaymentSucceeded(ctx context.Context, eventID, in
 		return nil
 	}
 
-	payment, err := s.paymentRepo.FindByStripeIntentID(ctx, intentID)
+	orderID, err := orderIDFromMetadata(metadata)
+	if err != nil {
+		return fmt.Errorf("payment succeeded metadata: %w", err)
+	}
+
+	payment, err := s.paymentRepo.FindByOrderID(ctx, orderID)
 	if err != nil {
 		return fmt.Errorf("find payment for succeeded event: %w", err)
+	}
+
+	// Backfill Stripe intent ID for future refund lookups.
+	if intentID != "" {
+		if backfillErr := s.paymentRepo.UpdateStripeIDs(ctx, orderID, intentID, payment.StripeCheckoutSessionID); backfillErr != nil {
+			slog.ErrorContext(ctx, "failed to backfill stripe intent ID", "orderID", orderID, "intentID", intentID, "error", backfillErr)
+		}
 	}
 
 	if err := s.paymentRepo.UpdateStatus(ctx, payment.OrderID, model.PaymentStatusSucceeded); err != nil {
@@ -90,7 +103,7 @@ func (s *WebhookService) HandlePaymentSucceeded(ctx context.Context, eventID, in
 
 // HandlePaymentFailed deduplicates the event, updates payment status to failed,
 // and writes a saga failure event to the outbox.
-func (s *WebhookService) HandlePaymentFailed(ctx context.Context, eventID, intentID string) error {
+func (s *WebhookService) HandlePaymentFailed(ctx context.Context, eventID, intentID string, metadata map[string]string) error {
 	inserted, err := s.eventRepo.TryInsert(ctx, nil, eventID, "payment_intent.payment_failed")
 	if err != nil {
 		return fmt.Errorf("dedup payment failed: %w", err)
@@ -101,9 +114,21 @@ func (s *WebhookService) HandlePaymentFailed(ctx context.Context, eventID, inten
 		return nil
 	}
 
-	payment, err := s.paymentRepo.FindByStripeIntentID(ctx, intentID)
+	orderID, err := orderIDFromMetadata(metadata)
+	if err != nil {
+		return fmt.Errorf("payment failed metadata: %w", err)
+	}
+
+	payment, err := s.paymentRepo.FindByOrderID(ctx, orderID)
 	if err != nil {
 		return fmt.Errorf("find payment for failed event: %w", err)
+	}
+
+	// Backfill Stripe intent ID for future refund lookups.
+	if intentID != "" {
+		if backfillErr := s.paymentRepo.UpdateStripeIDs(ctx, orderID, intentID, payment.StripeCheckoutSessionID); backfillErr != nil {
+			slog.ErrorContext(ctx, "failed to backfill stripe intent ID", "orderID", orderID, "intentID", intentID, "error", backfillErr)
+		}
 	}
 
 	if err := s.paymentRepo.UpdateStatus(ctx, payment.OrderID, model.PaymentStatusFailed); err != nil {
@@ -152,4 +177,17 @@ func (s *WebhookService) HandleRefund(ctx context.Context, eventID, intentID str
 
 	slog.InfoContext(ctx, "payment refunded", "orderID", payment.OrderID, "intentID", intentID)
 	return nil
+}
+
+// orderIDFromMetadata extracts and parses the order_id UUID from PaymentIntent metadata.
+func orderIDFromMetadata(metadata map[string]string) (uuid.UUID, error) {
+	raw, ok := metadata["order_id"]
+	if !ok || raw == "" {
+		return uuid.Nil, fmt.Errorf("order_id not found in payment intent metadata")
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid order_id in metadata: %w", err)
+	}
+	return id, nil
 }

--- a/go/payment-service/internal/service/webhook_test.go
+++ b/go/payment-service/internal/service/webhook_test.go
@@ -31,9 +31,14 @@ func (m *mockOutboxRepo) Insert(_ context.Context, _ pgx.Tx, _, _ string, _ []by
 }
 
 type mockPaymentRepoForWebhook struct {
-	findErr    error
-	updateErr  error
-	findCalled int
+	findByOrderPayment *model.Payment
+	findByOrderErr     error
+	findByIntentErr    error
+	updateStatusErr    error
+	updateStripeIDsErr error
+	findByOrderCalled  int
+	findByIntentCalled int
+	updateStripeCalled int
 }
 
 func (m *mockPaymentRepoForWebhook) Create(_ context.Context, _ uuid.UUID, _ int, _ string) (*model.Payment, error) {
@@ -41,23 +46,56 @@ func (m *mockPaymentRepoForWebhook) Create(_ context.Context, _ uuid.UUID, _ int
 }
 
 func (m *mockPaymentRepoForWebhook) FindByOrderID(_ context.Context, _ uuid.UUID) (*model.Payment, error) {
-	return nil, nil
+	m.findByOrderCalled++
+	return m.findByOrderPayment, m.findByOrderErr
 }
 
 func (m *mockPaymentRepoForWebhook) FindByStripeIntentID(_ context.Context, _ string) (*model.Payment, error) {
-	m.findCalled++
-	return nil, m.findErr
+	m.findByIntentCalled++
+	return nil, m.findByIntentErr
 }
 
 func (m *mockPaymentRepoForWebhook) UpdateStatus(_ context.Context, _ uuid.UUID, _ model.PaymentStatus) error {
-	return m.updateErr
+	return m.updateStatusErr
 }
 
 func (m *mockPaymentRepoForWebhook) UpdateStripeIDs(_ context.Context, _ uuid.UUID, _, _ string) error {
-	return nil
+	m.updateStripeCalled++
+	return m.updateStripeIDsErr
 }
 
 // --- tests ---
+
+func TestWebhookService_HandlePaymentSucceeded_MetadataLookup(t *testing.T) {
+	orderID := uuid.MustParse("f5cd888c-c661-41ad-a2fd-e14fdeac800d")
+	eventRepo := &mockProcessedEventRepo{inserted: true, err: nil}
+	outboxRepo := &mockOutboxRepo{}
+	paymentRepo := &mockPaymentRepoForWebhook{
+		findByOrderPayment: &model.Payment{
+			OrderID:                 orderID,
+			StripeCheckoutSessionID: "cs_test_abc",
+		},
+	}
+	svc := NewWebhookService(paymentRepo, eventRepo, outboxRepo, nil)
+
+	metadata := map[string]string{"order_id": orderID.String()}
+	err := svc.HandlePaymentSucceeded(context.Background(), "evt_123", "pi_new_123", metadata)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if paymentRepo.findByOrderCalled != 1 {
+		t.Errorf("expected FindByOrderID called once, got %d", paymentRepo.findByOrderCalled)
+	}
+	if paymentRepo.findByIntentCalled != 0 {
+		t.Errorf("expected FindByStripeIntentID not called, got %d", paymentRepo.findByIntentCalled)
+	}
+	if paymentRepo.updateStripeCalled != 1 {
+		t.Errorf("expected UpdateStripeIDs called once to backfill, got %d", paymentRepo.updateStripeCalled)
+	}
+	if outboxRepo.calls != 1 {
+		t.Errorf("expected 1 outbox insert, got %d", outboxRepo.calls)
+	}
+}
 
 func TestWebhookService_HandlePaymentSucceeded_DuplicateEvent(t *testing.T) {
 	eventRepo := &mockProcessedEventRepo{inserted: false, err: nil}
@@ -66,14 +104,27 @@ func TestWebhookService_HandlePaymentSucceeded_DuplicateEvent(t *testing.T) {
 
 	svc := NewWebhookService(paymentRepo, eventRepo, outboxRepo, nil)
 
-	err := svc.HandlePaymentSucceeded(context.Background(), "evt_dup", "pi_123")
+	err := svc.HandlePaymentSucceeded(context.Background(), "evt_dup", "pi_123", map[string]string{"order_id": "f5cd888c-c661-41ad-a2fd-e14fdeac800d"})
 	if err != nil {
 		t.Errorf("expected nil error for duplicate event, got %v", err)
 	}
-	if paymentRepo.findCalled != 0 {
-		t.Errorf("expected no FindByStripeIntentID call for duplicate, got %d", paymentRepo.findCalled)
+	if paymentRepo.findByOrderCalled != 0 {
+		t.Errorf("expected no FindByOrderID call for duplicate, got %d", paymentRepo.findByOrderCalled)
 	}
 	if outboxRepo.calls != 0 {
 		t.Errorf("expected no outbox insert for duplicate event, got %d", outboxRepo.calls)
+	}
+}
+
+func TestWebhookService_HandlePaymentSucceeded_MissingOrderID(t *testing.T) {
+	eventRepo := &mockProcessedEventRepo{inserted: true, err: nil}
+	outboxRepo := &mockOutboxRepo{}
+	paymentRepo := &mockPaymentRepoForWebhook{}
+
+	svc := NewWebhookService(paymentRepo, eventRepo, outboxRepo, nil)
+
+	err := svc.HandlePaymentSucceeded(context.Background(), "evt_123", "pi_123", map[string]string{})
+	if err == nil {
+		t.Fatal("expected error for missing order_id in metadata")
 	}
 }

--- a/go/payment-service/internal/stripe/verifier.go
+++ b/go/payment-service/internal/stripe/verifier.go
@@ -20,51 +20,52 @@ func NewVerifier(webhookSecret string) *Verifier {
 }
 
 // VerifyAndParse validates the Stripe-Signature header and returns the event type,
-// event ID, and payment intent ID extracted from the event payload.
-// For "payment_intent.*" events, intentID is the PaymentIntent ID.
+// event ID, payment intent ID, and metadata extracted from the event payload.
+// For "payment_intent.*" events, intentID is the PaymentIntent ID and metadata
+// contains the PaymentIntent's metadata map (e.g., order_id).
 // For "charge.refunded" events, intentID is the PaymentIntent ID from the Charge.
-func (v *Verifier) VerifyAndParse(payload []byte, sigHeader string) (eventType, eventID, intentID string, err error) {
+func (v *Verifier) VerifyAndParse(payload []byte, sigHeader string) (eventType, eventID, intentID string, metadata map[string]string, err error) {
 	event, err := webhook.ConstructEventWithOptions(payload, sigHeader, v.webhookSecret, webhook.ConstructEventOptions{
 		IgnoreAPIVersionMismatch: true,
 	})
 	if err != nil {
-		return "", "", "", fmt.Errorf("stripe signature verification: %w", err)
+		return "", "", "", nil, fmt.Errorf("stripe signature verification: %w", err)
 	}
 
 	eventType = string(event.Type)
 	eventID = event.ID
 
-	intentID, err = extractIntentID(event)
+	intentID, metadata, err = extractIntentAndMetadata(event)
 	if err != nil {
-		return "", "", "", fmt.Errorf("extract intent id from event %s: %w", eventID, err)
+		return "", "", "", nil, fmt.Errorf("extract intent id from event %s: %w", eventID, err)
 	}
 
-	return eventType, eventID, intentID, nil
+	return eventType, eventID, intentID, metadata, nil
 }
 
-// extractIntentID reads the PaymentIntent ID from the event's data object.
+// extractIntentAndMetadata reads the PaymentIntent ID and metadata from the event's data object.
 // For payment_intent.* events the object is a PaymentIntent; for charge.refunded
 // the object is a Charge whose PaymentIntent field holds the intent ID.
-func extractIntentID(event gostripe.Event) (string, error) {
+func extractIntentAndMetadata(event gostripe.Event) (string, map[string]string, error) {
 	switch {
 	case strings.HasPrefix(string(event.Type), "payment_intent."):
 		var pi gostripe.PaymentIntent
 		if err := json.Unmarshal(event.Data.Raw, &pi); err != nil {
-			return "", fmt.Errorf("unmarshal payment intent: %w", err)
+			return "", nil, fmt.Errorf("unmarshal payment intent: %w", err)
 		}
-		return pi.ID, nil
+		return pi.ID, pi.Metadata, nil
 
 	case event.Type == "charge.refunded":
 		var charge gostripe.Charge
 		if err := json.Unmarshal(event.Data.Raw, &charge); err != nil {
-			return "", fmt.Errorf("unmarshal charge: %w", err)
+			return "", nil, fmt.Errorf("unmarshal charge: %w", err)
 		}
 		if charge.PaymentIntent != nil {
-			return charge.PaymentIntent.ID, nil
+			return charge.PaymentIntent.ID, nil, nil
 		}
-		return "", fmt.Errorf("charge.refunded event has no payment intent")
+		return "", nil, fmt.Errorf("charge.refunded event has no payment intent")
 
 	default:
-		return "", nil
+		return "", nil, nil
 	}
 }

--- a/go/payment-service/internal/stripe/verifier_test.go
+++ b/go/payment-service/internal/stripe/verifier_test.go
@@ -2,6 +2,8 @@ package stripe
 
 import (
 	"testing"
+
+	gostripe "github.com/stripe/stripe-go/v82"
 )
 
 func TestVerifier_InvalidSignature(t *testing.T) {
@@ -10,8 +12,64 @@ func TestVerifier_InvalidSignature(t *testing.T) {
 	payload := []byte(`{"id":"evt_123","type":"payment_intent.succeeded","api_version":"2024-06-20.basil"}`)
 	sigHeader := "t=1234567890,v1=invalidsignature"
 
-	_, _, _, err := v.VerifyAndParse(payload, sigHeader)
+	_, _, _, _, err := v.VerifyAndParse(payload, sigHeader)
 	if err == nil {
 		t.Fatal("expected error for invalid signature, got nil")
+	}
+}
+
+func TestExtractIntentAndMetadata_PaymentIntentEvent(t *testing.T) {
+	raw := []byte(`{"id":"pi_123","object":"payment_intent","metadata":{"order_id":"f5cd888c-c661-41ad-a2fd-e14fdeac800d"}}`)
+	event := gostripe.Event{
+		Type: "payment_intent.succeeded",
+		Data: &gostripe.EventData{Raw: raw},
+	}
+
+	intentID, metadata, err := extractIntentAndMetadata(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if intentID != "pi_123" {
+		t.Errorf("expected intentID pi_123, got %s", intentID)
+	}
+	if metadata["order_id"] != "f5cd888c-c661-41ad-a2fd-e14fdeac800d" {
+		t.Errorf("expected order_id in metadata, got %v", metadata)
+	}
+}
+
+func TestExtractIntentAndMetadata_ChargeRefundedEvent(t *testing.T) {
+	raw := []byte(`{"id":"ch_123","object":"charge","payment_intent":"pi_456"}`)
+	event := gostripe.Event{
+		Type: "charge.refunded",
+		Data: &gostripe.EventData{Raw: raw},
+	}
+
+	intentID, metadata, err := extractIntentAndMetadata(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if intentID != "pi_456" {
+		t.Errorf("expected intentID pi_456, got %s", intentID)
+	}
+	if metadata != nil {
+		t.Errorf("expected nil metadata for charge event, got %v", metadata)
+	}
+}
+
+func TestExtractIntentAndMetadata_UnknownEvent(t *testing.T) {
+	event := gostripe.Event{
+		Type: "unknown.event",
+		Data: &gostripe.EventData{Raw: []byte(`{}`)},
+	}
+
+	intentID, metadata, err := extractIntentAndMetadata(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if intentID != "" {
+		t.Errorf("expected empty intentID, got %s", intentID)
+	}
+	if metadata != nil {
+		t.Errorf("expected nil metadata, got %v", metadata)
 	}
 }


### PR DESCRIPTION
## Summary

- **Fix Stripe webhook payment lookup**: The `payment_intent.succeeded` webhook handler couldn't find payment records because `stripe_payment_intent_id` was never stored (Stripe doesn't include PaymentIntent on Checkout Session creation). Now extracts `order_id` from PaymentIntent metadata, looks up via `FindByOrderID`, and backfills the intent ID for future refund lookups.
- **Add outbox poller startup resilience**: The outbox poller now waits for postgres to be reachable (exponential backoff, 1s-30s) before entering its polling loop, preventing circuit breaker trips during startup.

## Root Cause

When creating a Stripe Checkout Session, `sess.PaymentIntent` is nil — the PaymentIntent isn't created until the customer pays. The `UpdateStripeIDs` call saved an empty intent ID. When the webhook fired with the real intent ID, `FindByStripeIntentID` found nothing, the handler errored, no outbox message was written, and the saga stalled at `PAYMENT_CREATED`.

## Changes

| File | Change |
|------|--------|
| `stripe/verifier.go` | `VerifyAndParse` now returns `metadata map[string]string` from PaymentIntent events |
| `handler/webhook.go` | Updated `WebhookService` + `EventVerifier` interfaces, passes metadata through |
| `service/webhook.go` | `HandlePaymentSucceeded`/`Failed` use `order_id` from metadata, backfill intent ID |
| `outbox/poller.go` | Added `waitForDB` with exponential backoff before polling loop |
| `repository/outbox.go` | Added `Ping` method for startup readiness check |

## Test plan

- [ ] `make preflight-go` passes (lint + tests for all 7 Go services)
- [ ] Deploy to QA, place a test order, complete Stripe checkout
- [ ] Verify in Loki: `"payment succeeded"` log appears with orderID
- [ ] Verify in DB: order status = `completed`, saga_step = `COMPLETED`, cart cleared
- [ ] Verify outbox poller starts cleanly on pod restart (no circuit breaker errors)
- [ ] Post-deploy: run manual DB cleanup for stuck orders (Task 6 in plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)