### PR TITLE
feat: observability gaps — deploy annotations, event exporter, connection tracking

### DIFF
--- a/.claude/skills/debug-observability/SKILL.md
+++ b/.claude/skills/debug-observability/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: debug-observability
-description: Debug Go service issues using Loki, Jaeger, and Grafana. Use when encountering runtime errors, checkout failures, saga stuck states, gRPC connection issues, or any service misbehavior in QA or prod.
+description: Debug service issues and triage alerts using Loki, Jaeger, Grafana, and Prometheus. Use when encountering runtime errors, alerts firing, post-incident health verification, checkout failures, saga stuck states, gRPC connection issues, circuit breaker issues, or any service misbehavior in QA or prod. Also use after resolving an incident to verify recovery and clear stale alerts.
 ---
 
 # Debug with Observability Stack
 
-**Rule: Use Grafana/Loki/Jaeger before SSH.** Every runtime issue should be diagnosable from the observability stack. SSH + `kubectl logs` is a last resort.
+**Rule: Use Grafana/Loki/Jaeger before SSH.** Every runtime issue should be diagnosable from the observability stack. SSH + `kubectl logs` is a last resort — the only exception is pods in CrashLoopBackOff where the monitoring target is dead.
+
+## When to Use This Skill
+
+- **Alerts firing** — triage whether alerts are real or stale (see Alert Triage below)
+- **Post-incident** — verify cluster recovery and clear stale alerts (see Post-Incident Verification below)
+- **Runtime errors** — 5xx responses, failed requests, timeouts
+- **Saga issues** — stuck orders, DLQ accumulation, step errors
+- **Circuit breakers** — open or flapping breakers
+- **gRPC failures** — connection refused, TLS handshake errors
+- **Performance** — high latency, low cache hit ratio
 
 ## Key Facts
 
@@ -133,3 +143,118 @@ ssh debian 'kubectl get certificates -n go-ecommerce'
 ssh debian 'kubectl get pods -n cert-manager'
 ssh debian 'kubectl describe certificate payment-grpc-tls -n go-ecommerce'
 ```
+
+## Alert Triage
+
+When alerts fire, classify them before acting. Most alerts after an incident are stale.
+
+### Step 1: Get all active alerts with classification
+
+```bash
+ssh debian "curl -s 'http://10.100.246.150:3000/api/alertmanager/grafana/api/v2/alerts' | python3 -c \"
+import json,sys
+alerts=json.load(sys.stdin)
+if not alerts:
+    print('No active alerts!')
+    sys.exit()
+nodata = [a for a in alerts if a['labels'].get('alertname') == 'DatasourceNoData']
+restart = [a for a in alerts if 'restarted more than' in a['annotations'].get('summary','')]
+real = [a for a in alerts if a['labels'].get('alertname') != 'DatasourceNoData' and 'restarted' not in a['annotations'].get('summary','')]
+print(str(len(alerts)) + ' total: ' + str(len(nodata)) + ' NoData(stale), ' + str(len(restart)) + ' restart-storm(stale), ' + str(len(real)) + ' real')
+for a in real:
+    print('  REAL: ' + a['annotations'].get('summary','?')[:80])
+for a in nodata[:3]:
+    print('  STALE: ' + a['annotations'].get('summary','?')[:80] + ' [NoData]')
+if len(nodata) > 3:
+    print('  ... and ' + str(len(nodata)-3) + ' more NoData alerts')
+\""
+```
+
+### Understanding alert types
+
+| alertname | Meaning | Action |
+|-----------|---------|--------|
+| `DatasourceNoData` | Prometheus query returned empty — usually stale after pod restarts | No action — will auto-resolve as rate windows fill with data. Restart Grafana to clear immediately. |
+| Pod restart storm (summary contains "restarted more than") | References pods that may no longer exist | Check if the named pod still exists: `kubectl get pod <name> -n <ns>`. If gone, it's stale. |
+| Everything else | Potentially real | Investigate — check the specific metric via Prometheus. |
+
+### Step 2: For "real" alerts, verify via Prometheus
+
+```bash
+# Circuit breakers — which are actually open right now?
+ssh debian "curl -s 'http://10.98.36.175:9090/api/v1/query?query=circuit_breaker_state==2' | python3 -c \"
+import json,sys
+r=json.load(sys.stdin)['data']['result']
+if not r: print('No open circuit breakers')
+for m in r:
+    name=m['metric'].get('name','?')
+    svc=m['metric'].get('service','?')
+    pod=m['metric'].get('pod','?')
+    print('OPEN: ' + name + ' (' + svc + ', pod=' + pod + ')')
+\""
+
+# Check if the pod still exists (stale metric from terminated pod)
+ssh debian "kubectl get pod <pod-name> -n go-ecommerce 2>&1"
+```
+
+### Step 3: Clear stale alerts
+
+If all alerts are stale `DatasourceNoData` from a resolved incident, restart Grafana to reset alert state:
+
+```bash
+ssh debian "kubectl rollout restart deployment grafana -n monitoring && kubectl wait --for=condition=ready pod -l app=grafana -n monitoring --timeout=60s"
+```
+
+This works because provisioned alert rules (file-based, not database-backed) reset their state on restart. The `noDataState: OK` rules will then evaluate cleanly.
+
+**Only do this when you've confirmed the cluster is healthy.** Don't clear alerts to silence a real problem.
+
+## Post-Incident Verification
+
+After resolving any incident, run this checklist before declaring recovery.
+
+### Step 1: Pod health (all namespaces)
+
+```bash
+ssh debian "kubectl get pods --all-namespaces --no-headers | grep -v 'Running\|Completed' || echo 'All pods healthy'"
+```
+
+All pods should be Running with 0 restarts on current pods. Old pods from before the incident will show higher restart counts — that's expected as long as the *current* pods are clean.
+
+### Step 2: Endpoint smoke test
+
+```bash
+ssh debian "curl -s -o /dev/null -w 'auth:%{http_code} ' http://192.168.49.2/go-auth/health && \
+curl -s -o /dev/null -w 'products:%{http_code} ' http://192.168.49.2/go-products/products && \
+curl -s -o /dev/null -w 'ai:%{http_code} ' http://192.168.49.2/ai-api/health && \
+curl -s -o /dev/null -w 'orders:%{http_code} ' http://192.168.49.2/go-orders/health && \
+curl -s -o /dev/null -w 'gql:%{http_code} ' http://192.168.49.2/graphql -X POST -H 'Content-Type: application/json' -d '{\"query\":\"{__typename}\"}' && \
+echo ''"
+```
+
+All should return 200.
+
+### Step 3: Postgres health
+
+```bash
+ssh debian "kubectl exec deployment/postgres -n java-tasks -- pg_isready -U taskuser -d taskdb"
+```
+
+### Step 4: Circuit breaker state
+
+```bash
+ssh debian "curl -s 'http://10.98.36.175:9090/api/v1/query?query=circuit_breaker_state==2' | python3 -c \"
+import json,sys
+r=json.load(sys.stdin)['data']['result']
+if not r: print('All circuit breakers closed')
+for m in r:
+    pod=m['metric'].get('pod','?')
+    print('OPEN: ' + m['metric'].get('name','?') + ' (' + m['metric'].get('service','?') + ', pod=' + pod + ')')
+\""
+```
+
+If a breaker is open on a pod that still exists, restart that service. If the pod no longer exists, it's a stale Prometheus metric — will clear in ~5 minutes.
+
+### Step 5: Classify remaining alerts
+
+Run the Alert Triage Step 1 query above. If all alerts are `DatasourceNoData` or reference terminated pods, the cluster is healthy and alerts are stale. Clear with Grafana restart if needed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1115,6 +1115,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET_QA }}
+          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
@@ -1225,6 +1226,18 @@ jobs:
           $SSH "kubectl rollout restart deployment -n java-tasks-qa"
           $SSH "kubectl rollout restart deployment -n go-ecommerce-qa"
 
+          # Post deploy annotations to Grafana
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          if [ -n "${GRAFANA_API_KEY:-}" ]; then
+            for NS in ai-services-qa java-tasks-qa go-ecommerce-qa; do
+              $SSH "curl -sf -X POST 'http://grafana.monitoring.svc.cluster.local:3000/api/annotations' \
+                -H 'Authorization: Bearer ${GRAFANA_API_KEY}' \
+                -H 'Content-Type: application/json' \
+                -d '{\"text\":\"Deploy: ${NS} (sha:${SHORT_SHA})\",\"tags\":[\"qa-deploy\",\"${NS}\"]}'" || echo "::warning::Grafana annotation failed for ${NS} (non-fatal)"
+            done
+          fi
+
           $SSH "kubectl rollout status deployment -n ai-services-qa --timeout=180s"
           $SSH "kubectl rollout status deployment -n java-tasks-qa --timeout=180s"
           $SSH "kubectl rollout status deployment -n go-ecommerce-qa --timeout=180s"
@@ -1306,6 +1319,7 @@ jobs:
           K8S_CHANGED: ${{ needs.changes.outputs.k8s }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET_PROD }}
+          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
@@ -1423,6 +1437,18 @@ jobs:
             echo "Restarting go-ecommerce deployments..."
             $SSH "kubectl rollout restart deployment -n go-ecommerce"
             $SSH "kubectl rollout status deployment -n go-ecommerce --timeout=180s"
+          fi
+
+          # Post deploy annotations to Grafana
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          if [ -n "${GRAFANA_API_KEY:-}" ]; then
+            for NS in ai-services java-tasks go-ecommerce; do
+              $SSH "curl -sf -X POST 'http://grafana.monitoring.svc.cluster.local:3000/api/annotations' \
+                -H 'Authorization: Bearer ${GRAFANA_API_KEY}' \
+                -H 'Content-Type: application/json' \
+                -d '{\"text\":\"Deploy: ${NS} (sha:${SHORT_SHA})\",\"tags\":[\"deploy\",\"${NS}\"]}'" || echo "::warning::Grafana annotation failed for ${NS} (non-fatal)"
+            done
           fi
 
           # Verify monitoring stack health

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,14 @@ Three pillars in the `monitoring` namespace: Prometheus (metrics), Loki+Promtail
 
 **Minikube:** 16Gi memory (cannot increase without `minikube delete` which wipes all cluster state).
 
-**Debugging:** Use the `/debug-observability` skill for Loki queries, Jaeger traces, saga debugging, and circuit breaker diagnosis. Rule: query the observability stack before SSH.
+**Debugging triage hierarchy** — follow this order:
+
+1. **Pods down / CrashLoopBackOff:** `kubectl get pods` + `kubectl logs` directly. Observability can't help if the monitoring target is dead. Fix the pod first, then assess.
+2. **Alerts firing:** Use `/debug-observability` — it has a structured alert triage routine that classifies stale vs real alerts and identifies what actually needs attention.
+3. **Pods running but errors:** Use `/debug-observability` — Loki logs, Jaeger traces, circuit breaker queries. Don't SSH and grep logs manually.
+4. **Post-incident verification:** Use `/debug-observability` — it has a health verification checklist and stale alert cleanup procedure.
+
+Rule: only skip the observability skill for step 1 (pods down). For everything else, use the skill first.
 
 
 ## Kafka Streaming Analytics

--- a/docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md
+++ b/docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md
@@ -1,0 +1,114 @@
+# ADR: PostgreSQL Data Integrity & Observability (2026-04-24)
+
+## Status
+Accepted
+
+## Context
+
+The shared PostgreSQL 17 instance in `java-tasks` namespace hosts 9 databases (7 prod, 7 QA, plus `taskdb`) serving all Go and Java services. On 2026-04-23, a WAL checkpoint corruption (`PANIC: could not locate a valid checkpoint record`) took down every Go and Java service. The same corruption recurred on 2026-04-24 during a deployment that added a postgres_exporter sidecar.
+
+Investigation revealed:
+
+1. **No backups existed.** Recovery required a full PVC reset and reseed — acceptable only because all data was recreatable from migrations and seeds. A production system with user-generated data would have suffered total data loss.
+2. **No Postgres-specific monitoring.** The only indication was cascading 503s from dependent services. There were no connection pool, cache, or disk metrics.
+3. **No PodDisruptionBudget.** Postgres could be voluntarily evicted during node drains.
+4. **The default `RollingUpdate` deployment strategy caused the WAL corruption.** With a single-replica `ReadWriteOnce` PVC, `RollingUpdate` starts the new pod before terminating the old one. Since only one pod can mount an RWO PVC, Kubernetes forcibly kills the old pod — bypassing the `preStop` hook's graceful `pg_ctl stop`. This corrupted the WAL on both occasions.
+5. **Alert rules defaulted `noDataState` to `NoData`**, which fires alerts when Prometheus rate queries return empty results after pod restarts. This produced 20+ false-positive Telegram notifications after each incident, making it impossible to distinguish real problems from noise.
+
+Spec: `docs/superpowers/specs/2026-04-23-postgres-data-integrity-design.md`. Plan: `docs/superpowers/plans/2026-04-24-postgres-data-integrity.md`.
+
+## Decisions
+
+### Recreate deployment strategy for Postgres
+
+Changed `strategy.type` from `RollingUpdate` (Kubernetes default) to `Recreate`. This ensures the old pod terminates completely — including running the `preStop` hook (`pg_ctl stop -m fast`) — before the new pod starts. The trade-off is a brief window of unavailability during deploys (typically 10-15 seconds), but for a single-replica stateful workload with no redundancy, a clean shutdown is worth more than zero-downtime rollouts.
+
+The `terminationGracePeriodSeconds: 90` and `preStop` hook were already in place; the problem was that `RollingUpdate` bypassed them by force-killing the old pod when the new pod needed the PVC.
+
+### Daily pg_dump backups with 7-day retention
+
+A CronJob (`postgres-backup`) runs at 02:00 UTC, dumping each prod database individually using `pg_dump --format=custom`. Custom format was chosen over plain SQL because it supports parallel restore and selective table restore. Individual per-database dumps (not `pg_dumpall`) allow restoring a single database without touching others.
+
+Backups write to a hostPath PV at `/backups/postgres` on the Minikube node. This is separate from the Postgres data PVC — a PVC corruption or deletion doesn't affect backups. The hostPath sits on the Minikube node's persistent disk (`/dev/nvme1n1p2`), so it survives pod restarts and Minikube reboots.
+
+QA databases are not backed up — they're fully recreatable from migrations and seeds.
+
+**Trade-off vs. WAL archiving:** pg_dump provides daily snapshots (RPO ≤ 24 hours). WAL-based continuous archiving would provide point-in-time recovery (RPO ≈ 0), but requires `archive_command` configuration, a WAL archive volume, and `pg_basebackup` for base backups — significantly more complexity. pg_dump is the right first step; WAL archiving is planned for Phase 2.
+
+**Trade-off vs. cloud storage:** A production system would upload backups to S3/GCS for off-host durability. The hostPath volume lives on the same physical disk as the data — it protects against PVC corruption and accidental deletion, but not disk failure. This is the "no paid services" constraint accepted for the portfolio.
+
+### postgres_exporter sidecar
+
+Added `prometheuscommunity/postgres-exporter:v0.16.0` as a sidecar container in the Postgres pod. It connects via `localhost:5432` (same pod, no network hop) and exposes metrics on port 9187. Prometheus discovers it via the existing `kubernetes-pods` scrape config using pod annotations.
+
+Sidecar was chosen over a separate Deployment because: (a) it shares the pod lifecycle with Postgres — no stale metrics from a running exporter pointing at a dead database, (b) localhost connection eliminates network config and auth complexity, (c) it's the standard pattern for database exporters in Kubernetes.
+
+### Grafana PostgreSQL dashboard
+
+Six panels covering the operational metrics that matter for a shared database:
+
+| Panel | Why |
+|-------|-----|
+| Connection utilization (gauge) | The #1 operational risk for a shared Postgres — if connections saturate, all services fail simultaneously |
+| Cache hit ratio (stat) | Should be >99%; a drop means queries are hitting disk and shared_buffers needs tuning |
+| Last successful backup (stat) | Time since the most recent CronJob completion — turns the backup into something visible, not just a silent cron |
+| Database sizes (bar gauge) | Early warning for disk pressure on the 2Gi PVC |
+| Transaction rate (time series) | Commits + rollbacks per database — shows load distribution and detects anomalies |
+| Deadlocks (time series) | Should be zero; any spike indicates a query pattern problem |
+
+### Four alert rules with noDataState: OK
+
+| Alert | Threshold | Why |
+|-------|-----------|-----|
+| Connection utilization > 80% | 5m | Gives time to investigate before saturation |
+| Cache hit ratio < 95% | 10m | Longer window to avoid transient dips after restarts |
+| Deadlocks > 0 | immediate | Any deadlock warrants investigation |
+| Backup stale > 26h | immediate | 2h buffer past the 24h schedule to account for transient failures |
+
+All rules use `noDataState: OK`. The earlier incident proved that `NoData` (Grafana's default) generates unacceptable false-positive noise after pod restarts. For rate-based and event-based metrics, no data means no activity, which means no problem. This was also applied retroactively to all 22 existing alert rules that had the same issue.
+
+### PodDisruptionBudget (maxUnavailable: 0)
+
+Prevents voluntary eviction of the Postgres pod during `kubectl drain`, node upgrades, or cluster rebalancing. This does NOT prevent the `Recreate` deployment strategy from terminating the pod (that's a controller-initiated change, not a voluntary disruption). It protects against the scenario where a cluster maintenance operation kills Postgres without the operator intending to.
+
+`maxUnavailable: 0` was chosen over `minAvailable: 1` because the Go service PDBs use `maxUnavailable: 1` (as noted in `go/CLAUDE.md`) — using the same field style but with a stricter value makes the intent clear: this workload must never be disrupted.
+
+### Recovery runbook
+
+Three scenarios documented in `docs/runbooks/postgres-recovery.md`:
+
+1. **Corrupted WAL / fresh PVC reset** — for when Postgres won't start and either no backups exist or data is all seeded. This is the procedure we executed twice on 2026-04-23/24.
+2. **Full restore from pg_dump** — for when backups exist and data preservation matters.
+3. **Partial restore (single database)** — for when one service's database is corrupted but others are healthy, minimizing blast radius.
+
+Each scenario includes symptoms, prerequisites, step-by-step commands, and verification steps. The runbook references Grafana alert names so an on-call engineer knows which alert maps to which procedure.
+
+### Postgres init scripts updated
+
+Added `ecommercedb` and `projectordb` to `java/k8s/configmaps/postgres-initdb.yml`. These databases were previously created dynamically during CI deploy but not by the init scripts — so a PVC reset required manual `CREATE DATABASE` commands. Now all 7 prod databases are created automatically on fresh initialization.
+
+QA databases (`*_qa`) are still created dynamically during deploy because they follow a naming convention (suffix) rather than being fixed names in the init scripts.
+
+### Auth-service smoke user seed
+
+Moved the smoke test user (`smoke@kylebradshaw.dev`) from `go/order-service/seed.sql` (where it referenced a `users` table that no longer exists in `orderdb` post-decomposition) to a new `go/auth-service/seed.sql`. Updated the auth-service Dockerfile and migration job to include a seed step. This ensures the smoke user is automatically seeded into `authdb` on every deploy — including after a full PVC reset.
+
+## Consequences
+
+**Positive:**
+- Automated daily backups with a tested restore procedure — proven to work when the second WAL corruption hit 30 minutes after the first backup ran.
+- Postgres-specific observability that didn't exist before — connection saturation, cache health, and backup freshness are now visible and alerted.
+- `Recreate` strategy eliminates the root cause of both WAL corruptions.
+- `noDataState: OK` eliminates the false-positive alert storms that made incident response harder.
+- Recovery time for a full PVC reset dropped from ~30 minutes (manual investigation + ad hoc commands) to ~5 minutes (follow the runbook).
+
+**Trade-offs:**
+- `Recreate` introduces 10-15 seconds of Postgres unavailability during deploys. All dependent services have circuit breakers and retry logic, so this manifests as brief connection errors, not data loss.
+- Backups are on the same physical disk as data — protects against logical corruption and PVC deletion, but not disk failure.
+- pg_dump snapshots have up to 24h RPO. WAL archiving (Phase 2) would close this gap.
+- The postgres_exporter sidecar adds ~32-64Mi memory to the Postgres pod. Acceptable given the 768Mi limit and the value of the metrics.
+
+**Phase 2 (future):**
+- WAL-based continuous archiving with point-in-time recovery
+- Automated backup verification (periodic restore to a temp database)
+- Connection pooling via PgBouncer if connection count grows

--- a/go/k8s/configmaps/auth-service-config.yml
+++ b/go/k8s/configmaps/auth-service-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: auth-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
   PORT: "8091"
   OTEL_EXPORTER_OTLP_ENDPOINT: "jaeger.monitoring.svc.cluster.local:4317"

--- a/go/k8s/configmaps/cart-service-config.yml
+++ b/go/k8s/configmaps/cart-service-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: cart-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb?sslmode=disable
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb?sslmode=disable&application_name=cart-service
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   KAFKA_BROKERS: "kafka.go-ecommerce.svc.cluster.local:9092"
   PRODUCT_GRPC_ADDR: "go-product-service.go-ecommerce.svc.cluster.local:9095"

--- a/go/k8s/configmaps/order-projector-config.yml
+++ b/go/k8s/configmaps/order-projector-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: order-projector-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb?sslmode=disable"
+  DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb?sslmode=disable&application_name=order-projector"
   KAFKA_BROKERS: "kafka.go-ecommerce.svc.cluster.local:9092"
   PORT: "8097"
   ALLOWED_ORIGINS: "http://localhost:3000,https://kylebradshaw.dev"

--- a/go/k8s/configmaps/order-service-config.yml
+++ b/go/k8s/configmaps/order-service-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: order-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable&application_name=order-service
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   RABBITMQ_URL: amqp://guest:guest@rabbitmq.java-tasks.svc.cluster.local:5672
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev

--- a/go/k8s/configmaps/payment-service-config.yml
+++ b/go/k8s/configmaps/payment-service-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: payment-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb?sslmode=disable"
+  DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb?sslmode=disable&application_name=payment-service"
   PORT: "8098"
   GRPC_PORT: "9098"
   RABBITMQ_URL: "amqp://guest:guest@rabbitmq.java-tasks.svc.cluster.local:5672"

--- a/go/k8s/configmaps/product-service-config.yml
+++ b/go/k8s/configmaps/product-service-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: product-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb?sslmode=disable
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb?sslmode=disable&application_name=product-service
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
   PORT: "8095"

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -3466,6 +3466,37 @@ data:
             "tooltip": { "mode": "multi" },
             "legend": { "displayMode": "list", "placement": "bottom" }
           }
+        },
+        {
+          "title": "Connections by Service",
+          "type": "bargauge",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+          "id": 7,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "pg_stat_activity_count{datname!~\"template.*|postgres\"}",
+              "legendFormat": "{{application_name}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 20 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "orientation": "horizontal",
+            "displayMode": "gradient"
+          }
         }
       ],
       "schemaVersion": 39,

--- a/k8s/monitoring/configmaps/kube-event-exporter-config.yml
+++ b/k8s/monitoring/configmaps/kube-event-exporter-config.yml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-event-exporter-config
+  namespace: monitoring
+data:
+  config.yaml: |
+    logLevel: error
+    logFormat: json
+    route:
+      routes:
+        - match:
+            - receiver: "loki"
+    receivers:
+      - name: "loki"
+        webhook:
+          endpoint: "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+          headers:
+            Content-Type: "application/json"
+          layout:
+            streams:
+              - stream:
+                  job: "kube-event-exporter"
+                  namespace: "{{ .InvolvedObject.Namespace }}"
+                  reason: "{{ .Reason }}"
+                  kind: "{{ .InvolvedObject.Kind }}"
+                  name: "{{ .InvolvedObject.Name }}"
+                values:
+                  - - "{{ .GetTimestampMs }}000000"
+                    - "{{ .Reason }}: {{ .Message }} ({{ .InvolvedObject.Kind }}/{{ .InvolvedObject.Name }} in {{ .InvolvedObject.Namespace }})"

--- a/k8s/monitoring/configmaps/kube-event-exporter-config.yml
+++ b/k8s/monitoring/configmaps/kube-event-exporter-config.yml
@@ -10,7 +10,8 @@ data:
     route:
       routes:
         - match:
-            - receiver: "loki"
+            - type: Warning
+          receiver: "loki"
     receivers:
       - name: "loki"
         webhook:

--- a/k8s/monitoring/deployments/grafana.yml
+++ b/k8s/monitoring/deployments/grafana.yml
@@ -24,7 +24,7 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: Viewer
             - name: GF_AUTH_DISABLE_LOGIN_FORM
-              value: "true"
+              value: "false"
             - name: GF_USERS_ALLOW_SIGN_UP
               value: "false"
             - name: GF_SERVER_ROOT_URL
@@ -33,6 +33,12 @@ spec:
               value: /var/lib/grafana/dashboards/system-overview.json
             - name: GF_UNIFIED_ALERTING_ENABLED
               value: "true"
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-secrets
+                  key: grafana-admin-password
+                  optional: true
             - name: TELEGRAM_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/monitoring/deployments/kube-event-exporter.yml
+++ b/k8s/monitoring/deployments/kube-event-exporter.yml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-event-exporter
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-event-exporter
+  template:
+    metadata:
+      labels:
+        app: kube-event-exporter
+    spec:
+      serviceAccountName: kube-event-exporter
+      containers:
+        - name: kube-event-exporter
+          image: ghcr.io/resmoio/kubernetes-event-exporter:v1.7
+          args:
+            - -conf=/data/config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /data
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+      volumes:
+        - name: config
+          configMap:
+            name: kube-event-exporter-config

--- a/k8s/monitoring/kustomization.yaml
+++ b/k8s/monitoring/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
   - rbac/promtail-clusterrole.yml
   - rbac/promtail-clusterrolebinding.yml
   - rbac/promtail-serviceaccount.yml
+  - rbac/kube-event-exporter-serviceaccount.yml
+  - rbac/kube-event-exporter-clusterrole.yml
+  - rbac/kube-event-exporter-clusterrolebinding.yml
   - pvc/prometheus-data.yml
   - pvc/loki-data.yml
   - configmaps/grafana-dashboard-provider.yml
@@ -21,10 +24,12 @@ resources:
   - configmaps/loki-config.yml
   - configmaps/promtail-config.yml
   - configmaps/prometheus-config.yml
+  - configmaps/kube-event-exporter-config.yml
   - deployments/grafana.yml
   - deployments/jaeger.yml
   - deployments/kube-state-metrics.yml
   - deployments/prometheus.yml
+  - deployments/kube-event-exporter.yml
   - statefulsets/loki.yml
   - daemonsets/node-exporter.yml
   - daemonsets/promtail.yml

--- a/k8s/monitoring/rbac/kube-event-exporter-clusterrole.yml
+++ b/k8s/monitoring/rbac/kube-event-exporter-clusterrole.yml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-event-exporter
+rules:
+  - apiGroups: [""]
+    resources:
+      - events
+    verbs: ["get", "watch", "list"]

--- a/k8s/monitoring/rbac/kube-event-exporter-clusterrolebinding.yml
+++ b/k8s/monitoring/rbac/kube-event-exporter-clusterrolebinding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-event-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-event-exporter
+subjects:
+  - kind: ServiceAccount
+    name: kube-event-exporter
+    namespace: monitoring

--- a/k8s/monitoring/rbac/kube-event-exporter-serviceaccount.yml
+++ b/k8s/monitoring/rbac/kube-event-exporter-serviceaccount.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-event-exporter
+  namespace: monitoring

--- a/k8s/monitoring/secrets/grafana-secrets.yml.template
+++ b/k8s/monitoring/secrets/grafana-secrets.yml.template
@@ -6,3 +6,4 @@ metadata:
 type: Opaque
 stringData:
   TELEGRAM_BOT_TOKEN: "<your-rotated-telegram-bot-token>"
+  grafana-admin-password: "<your-grafana-admin-password>"

--- a/k8s/overlays/qa-go/kustomization.yaml
+++ b/k8s/overlays/qa-go/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb_qa?sslmode=disable"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb_qa?sslmode=disable&application_name=auth-service"
       - op: add
         path: /data/GRPC_PORT
         value: "9091"
@@ -33,7 +33,7 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb_qa?sslmode=disable"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb_qa?sslmode=disable&application_name=order-service"
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
@@ -115,7 +115,7 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb_qa?sslmode=disable"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb_qa?sslmode=disable&application_name=product-service"
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
@@ -128,7 +128,7 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb_qa?sslmode=disable"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb_qa?sslmode=disable&application_name=cart-service"
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
@@ -153,7 +153,7 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb_qa?sslmode=disable"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb_qa?sslmode=disable&application_name=payment-service"
       - op: replace
         path: /data/KAFKA_BROKERS
         value: "kafka.go-ecommerce-qa.svc.cluster.local:9092"
@@ -169,7 +169,7 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb_qa?sslmode=disable"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb_qa?sslmode=disable&application_name=order-projector"
       - op: replace
         path: /data/KAFKA_BROKERS
         value: "kafka.go-ecommerce-qa.svc.cluster.local:9092"


### PR DESCRIPTION
## Summary

Closes three observability gaps identified during the 2026-04-24 Postgres incident:

- **Grafana deploy annotations**: CI posts annotations after QA/prod rollouts so metric changes can be correlated with deploys. Requires `GRAFANA_API_KEY` GitHub secret (created via Grafana service account after first deploy). Grafana admin login re-enabled via `GF_SECURITY_ADMIN_PASSWORD` from K8s secret.
- **Kubernetes event exporter**: New `kube-event-exporter` Deployment in monitoring namespace forwards Warning events (OOM kills, probe failures, evictions) to Loki. Queryable via Grafana Explore.
- **Per-service Postgres connection tracking**: `&application_name=<service>` appended to all Go service DATABASE_URLs (prod + QA). New "Connections by Service" bar gauge panel in PostgreSQL dashboard.

## Changes

- `k8s/monitoring/deployments/grafana.yml` — admin password env, login form enabled
- `k8s/monitoring/secrets/grafana-secrets.yml.template` — grafana-admin-password key
- `.github/workflows/ci.yml` — annotation curls in QA + prod deploy
- `k8s/monitoring/deployments/kube-event-exporter.yml` — new Deployment
- `k8s/monitoring/configmaps/kube-event-exporter-config.yml` — Warning filter + Loki sink
- `k8s/monitoring/rbac/kube-event-exporter-*.yml` — RBAC (3 files)
- `k8s/monitoring/kustomization.yaml` — register new resources
- `go/k8s/configmaps/*-config.yml` — application_name on DATABASE_URL (6 files)
- `k8s/overlays/qa-go/kustomization.yaml` — application_name on QA patches
- `k8s/monitoring/configmaps/grafana-dashboards.yml` — Connections by Service panel

## Manual setup needed after merge

1. Deploy to create the Grafana pod with admin password
2. Create Grafana service account: `POST /api/serviceaccounts` → generate token
3. Store token as `GRAFANA_API_KEY` GitHub Actions secret

## Test plan

- [ ] `kubectl kustomize k8s/monitoring/` builds without errors
- [ ] `kubectl kustomize k8s/overlays/qa-go/` builds without errors
- [ ] After QA deploy: verify kube-event-exporter pod is running
- [ ] Query Loki for `{job="kube-event-exporter"}` — should show Warning events
- [ ] Check PostgreSQL dashboard for "Connections by Service" panel
- [ ] Verify `pg_stat_activity` shows application_name for Go services

🤖 Generated with [Claude Code](https://claude.com/claude-code)