### PR TITLE
ci: extend change detection to 11 more matrix and single jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,34 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [ingestion, chat, debug, eval]
+        include:
+          - service: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
 
       - name: Set up Python
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache virtualenv
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/cache@v4
         id: venv-cache
         with:
@@ -71,6 +89,7 @@ jobs:
           key: venv-${{ matrix.service }}-${{ hashFiles(format('services/{0}/requirements.txt', matrix.service), 'services/shared/pyproject.toml') }}
 
       - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true'
         if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
           python -m venv .venv
@@ -79,6 +98,7 @@ jobs:
           pip install -r services/${{ matrix.service }}/requirements.txt
 
       - name: Run tests with coverage
+        if: steps.changes.outputs.changed == 'true'
         env:
           PYTHONPATH: services
         run: |
@@ -89,7 +109,7 @@ jobs:
             --cov-report=xml:coverage-${{ matrix.service }}.xml
 
       - name: Upload coverage report
-        if: always()
+        if: steps.changes.outputs.changed == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.service }}
@@ -117,15 +137,28 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service:
-          - task-service
-          - activity-service
-          - notification-service
-          - gateway-service
+        include:
+          - service: task-service
+            paths: java/task-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: activity-service
+            paths: java/activity-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: notification-service
+            paths: java/notification-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: gateway-service
+            paths: java/gateway-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
 
       - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -133,11 +166,12 @@ jobs:
           cache: gradle
 
       - name: Run unit tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: java
         run: ./gradlew :${{ matrix.service }}:test --no-daemon --stacktrace
 
       - name: Upload test report
-        if: always()
+        if: steps.changes.outputs.changed == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
           name: java-test-report-${{ matrix.service }}
@@ -148,8 +182,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: java .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -157,11 +200,12 @@ jobs:
           cache: gradle
 
       - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: java
         run: ./gradlew integrationTest --no-daemon --stacktrace
 
       - name: Upload test report
-        if: always()
+        if: steps.changes.outputs.changed == 'true' && always()
         uses: actions/upload-artifact@v4
         with:
           name: java-test-report-integration
@@ -303,8 +347,17 @@ jobs:
       DATABASE_URL: postgres://taskuser:taskpass@localhost:5432/ecommercedb?sslmode=disable
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: go/auth-service/migrations go/auth-service/seed.sql go/order-service/migrations go/order-service/seed.sql go/product-service/migrations go/product-service/seed.sql go/order-projector/migrations .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Install postgresql-client and golang-migrate
+        if: steps.changes.outputs.changed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql-client
@@ -313,18 +366,21 @@ jobs:
           migrate -version
 
       - name: Create ecommercedb
+        if: steps.changes.outputs.changed == 'true'
         env:
           PGPASSWORD: taskpass
         run: |
           psql -h localhost -U taskuser -d taskdb -c "CREATE DATABASE ecommercedb;"
 
       - name: Create productdb
+        if: steps.changes.outputs.changed == 'true'
         env:
           PGPASSWORD: taskpass
         run: |
           psql -h localhost -U taskuser -d taskdb -c "CREATE DATABASE productdb;"
 
       - name: Create projectordb
+        if: steps.changes.outputs.changed == 'true'
         env:
           PGPASSWORD: taskpass
         run: |
@@ -335,30 +391,37 @@ jobs:
       # and whichever runs first claims the version counter, causing the other
       # to skip migrations and fail on table references. See commit 25054f5.
       - name: Run auth-service migrations
+        if: steps.changes.outputs.changed == 'true'
         run: |
           migrate -path go/auth-service/migrations -database "${DATABASE_URL}&x-migrations-table=auth_schema_migrations" up
 
       - name: Apply auth-service seed data
+        if: steps.changes.outputs.changed == 'true'
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f go/auth-service/seed.sql
 
       - name: Run order-service migrations
+        if: steps.changes.outputs.changed == 'true'
         run: |
           migrate -path go/order-service/migrations -database "${DATABASE_URL}&x-migrations-table=ecommerce_schema_migrations" up
 
       - name: Apply order-service seed data
+        if: steps.changes.outputs.changed == 'true'
         run: |
           psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f go/order-service/seed.sql
 
       - name: Run product-service migrations
+        if: steps.changes.outputs.changed == 'true'
         run: |
           migrate -path go/product-service/migrations -database "postgres://taskuser:taskpass@localhost:5432/productdb?sslmode=disable&x-migrations-table=product_schema_migrations" up
 
       - name: Apply product seed data
+        if: steps.changes.outputs.changed == 'true'
         run: |
           psql "postgres://taskuser:taskpass@localhost:5432/productdb?sslmode=disable" -v ON_ERROR_STOP=1 -f go/product-service/seed.sql
 
       - name: Verify tables exist
+        if: steps.changes.outputs.changed == 'true'
         run: |
           psql "$DATABASE_URL" -c "\dt" | tee /tmp/tables.txt
           grep -q ' users ' /tmp/tables.txt || (echo "users table missing" && exit 1)
@@ -366,15 +429,18 @@ jobs:
           grep -q ' orders ' /tmp/tables.txt || (echo "orders table missing" && exit 1)
 
       - name: Run order-projector migrations
+        if: steps.changes.outputs.changed == 'true'
         run: |
           migrate -path go/order-projector/migrations -database "postgres://taskuser:taskpass@localhost:5432/projectordb?sslmode=disable&x-migrations-table=projector_schema_migrations" up
 
       - name: Verify product tables exist
+        if: steps.changes.outputs.changed == 'true'
         run: |
           psql "postgres://taskuser:taskpass@localhost:5432/productdb?sslmode=disable" -c "\dt" | tee /tmp/product-tables.txt
           grep -q ' products ' /tmp/product-tables.txt || (echo "products table missing in productdb" && exit 1)
 
       - name: Verify projector tables exist
+        if: steps.changes.outputs.changed == 'true'
         run: |
           psql "postgres://taskuser:taskpass@localhost:5432/projectordb?sslmode=disable" -c "\dt" | tee /tmp/projector-tables.txt
           grep -q ' order_timeline ' /tmp/projector-tables.txt || (echo "order_timeline table missing in projectordb" && exit 1)
@@ -388,8 +454,17 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: frontend .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -397,15 +472,19 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true'
         run: npm ci
 
       - name: Lint
+        if: steps.changes.outputs.changed == 'true'
         run: npm run lint
 
       - name: Type check
+        if: steps.changes.outputs.changed == 'true'
         run: npx tsc --noEmit
 
       - name: Build
+        if: steps.changes.outputs.changed == 'true'
         run: npm run build
 
   e2e-mocked:
@@ -447,8 +526,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: k8s java/k8s go/k8s scripts/k8s-policy-check.sh .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Install kubeconform
+        if: steps.changes.outputs.changed == 'true'
         run: |
           curl -L -o kubeconform.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
           tar xf kubeconform.tar.gz
@@ -456,6 +544,7 @@ jobs:
           kubeconform -v
 
       - name: Install yq
+        if: steps.changes.outputs.changed == 'true'
         run: |
           sudo curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
@@ -465,6 +554,7 @@ jobs:
       # Exclude overlays/ dirs — they contain Kustomize patch fragments,
       # not standalone manifests (e.g. $patch: delete directives).
       - name: Stage A — kubeconform
+        if: steps.changes.outputs.changed == 'true'
         run: |
           find k8s/ java/k8s/ go/k8s/ \
             -type f \( -name '*.yml' -o -name '*.yaml' \) \
@@ -475,18 +565,21 @@ jobs:
 
       # Stage B: spin up a throwaway kind cluster and run server-side dry-run.
       - name: Stage B — kind cluster (create)
+        if: steps.changes.outputs.changed == 'true'
         uses: helm/kind-action@v1
         with:
           cluster_name: manifest-validation
           wait: 60s
 
       - name: Stage B — create namespaces
+        if: steps.changes.outputs.changed == 'true'
         run: |
           for ns in ai-services java-tasks go-ecommerce monitoring ai-services-qa java-tasks-qa go-ecommerce-qa; do
             kubectl create namespace "$ns"
           done
 
       - name: Stage B — server-side dry-run
+        if: steps.changes.outputs.changed == 'true'
         run: |
           # Apply every manifest directory recursively. --dry-run=server
           # exercises the real API server's validation and admission.
@@ -501,6 +594,7 @@ jobs:
 
       # Stage C: portfolio-specific policy rules.
       - name: Stage C — policy check
+        if: steps.changes.outputs.changed == 'true'
         run: scripts/k8s-policy-check.sh
 
   compose-smoke:
@@ -508,8 +602,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: services docker-compose.yml docker-compose.ci.yml nginx .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Log in to GHCR (for pulling cached images)
+        if: steps.changes.outputs.changed == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -517,9 +620,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create empty .env (required by docker-compose.yml env_file refs)
+        if: steps.changes.outputs.changed == 'true'
         run: touch .env
 
       - name: Pull pre-built images and start compose stack
+        if: steps.changes.outputs.changed == 'true'
         run: |
           # Pull pre-built GHCR images instead of building from source.
           # This skips the ~10 min pip install during docker build.
@@ -537,6 +642,7 @@ jobs:
             qdrant gateway ingestion chat debug mock-ollama
 
       - name: Wait for gateway to be reachable
+        if: steps.changes.outputs.changed == 'true'
         run: |
           for i in $(seq 1 30); do
             if curl -fsS http://localhost:8000/chat/health >/dev/null 2>&1; then
@@ -555,24 +661,27 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
       - name: Run smoke-ci Playwright tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npx playwright test --config=playwright.smoke-ci.config.ts
 
       - name: Dump compose logs on failure
-        if: failure()
+        if: steps.changes.outputs.changed == 'true' && failure()
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --no-color --tail=200
 
       - name: Tear down compose stack
-        if: always()
+        if: steps.changes.outputs.changed == 'true' && always()
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
 
@@ -583,20 +692,31 @@ jobs:
       JWT_SECRET: ci-test-secret
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: go .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Build Go service images
+        if: steps.changes.outputs.changed == 'true'
         working-directory: go
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml build \
             auth-service order-service product-service cart-service analytics-service
 
       - name: Start infra services
+        if: steps.changes.outputs.changed == 'true'
         working-directory: go
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d \
             postgres redis rabbitmq kafka
 
       - name: Wait for infra to be healthy
+        if: steps.changes.outputs.changed == 'true'
         working-directory: go
         run: |
           for i in $(seq 1 30); do
@@ -609,6 +729,7 @@ jobs:
           done
 
       - name: Run migrations and seed data before starting services
+        if: steps.changes.outputs.changed == 'true'
         working-directory: go
         run: |
           DC="docker compose -f docker-compose.yml -f docker-compose.ci.yml"
@@ -642,12 +763,14 @@ jobs:
             -c 'PGPASSWORD=taskpass psql -h postgres -U taskuser -d ecommercedb -f /seed.sql'
 
       - name: Start application services
+        if: steps.changes.outputs.changed == 'true'
         working-directory: go
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d \
             auth-service order-service product-service cart-service analytics-service
 
       - name: Wait for services to be healthy
+        if: steps.changes.outputs.changed == 'true'
         run: |
           for i in $(seq 1 60); do
             if curl -fsS http://localhost:8091/health >/dev/null 2>&1 && \
@@ -669,25 +792,28 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
       - name: Run Go smoke Playwright tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npx playwright test --config=playwright.smoke-go.config.ts
 
       - name: Dump compose logs on failure
-        if: failure()
+        if: steps.changes.outputs.changed == 'true' && failure()
         working-directory: go
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --no-color --tail=200
 
       - name: Tear down compose stack
-        if: always()
+        if: steps.changes.outputs.changed == 'true' && always()
         working-directory: go
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
@@ -697,8 +823,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: java .github/workflows/ci.yml .github/actions/check-changes/action.yml
 
       - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -706,20 +841,24 @@ jobs:
           cache: gradle
 
       - name: Build JARs (Dockerfiles expect pre-built JARs)
+        if: steps.changes.outputs.changed == 'true'
         working-directory: java
         run: ./gradlew bootJar --no-daemon
 
       - name: Build Java service images
+        if: steps.changes.outputs.changed == 'true'
         working-directory: java
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml build
 
       - name: Start Java compose stack
+        if: steps.changes.outputs.changed == 'true'
         working-directory: java
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d
 
       - name: Wait for gateway to be healthy
+        if: steps.changes.outputs.changed == 'true'
         run: |
           for i in $(seq 1 60); do
             if curl -fsS http://localhost:8080/graphql \
@@ -741,25 +880,28 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
       - name: Run Java smoke Playwright tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: frontend
         run: npx playwright test --config=playwright.smoke-java.config.ts
 
       - name: Dump compose logs on failure
-        if: failure()
+        if: steps.changes.outputs.changed == 'true' && failure()
         working-directory: java
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --no-color --tail=200
 
       - name: Tear down compose stack
-        if: always()
+        if: steps.changes.outputs.changed == 'true' && always()
         working-directory: java
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
@@ -797,16 +939,34 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [ingestion, chat, debug, eval]
+        include:
+          - service: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
 
       - name: Set up Python
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache virtualenv
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/cache@v4
         id: venv-cache
         with:
@@ -814,6 +974,7 @@ jobs:
           key: venv-audit-${{ matrix.service }}-${{ hashFiles(format('services/{0}/requirements.txt', matrix.service), 'services/shared/pyproject.toml') }}
 
       - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true'
         if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
           python -m venv .venv
@@ -838,6 +999,7 @@ jobs:
       # GHSA-rr7j-v2q5-chgv (langsmith) — streaming bypass of output redaction, not used
       # CVE-2026-3219 (pip) — pip itself, no fix version available yet
       - name: Run pip-audit
+        if: steps.changes.outputs.changed == 'true'
         run: |
           source .venv/bin/activate
           pip-audit \
@@ -899,27 +1061,52 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dockerfile:
-          - services/ingestion/Dockerfile
-          - services/chat/Dockerfile
-          - services/debug/Dockerfile
-          - services/eval/Dockerfile
-          - java/task-service/Dockerfile
-          - java/activity-service/Dockerfile
-          - java/notification-service/Dockerfile
-          - java/gateway-service/Dockerfile
-          - go/auth-service/Dockerfile
-          - go/order-service/Dockerfile
-          - go/ai-service/Dockerfile
-          - go/analytics-service/Dockerfile
-          - go/product-service/Dockerfile
-          - go/cart-service/Dockerfile
-          - go/payment-service/Dockerfile
-          - go/order-projector/Dockerfile
+        include:
+          - dockerfile: services/ingestion/Dockerfile
+            paths: services/ingestion/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: services/chat/Dockerfile
+            paths: services/chat/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: services/debug/Dockerfile
+            paths: services/debug/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: services/eval/Dockerfile
+            paths: services/eval/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: java/task-service/Dockerfile
+            paths: java/task-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: java/activity-service/Dockerfile
+            paths: java/activity-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: java/notification-service/Dockerfile
+            paths: java/notification-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: java/gateway-service/Dockerfile
+            paths: java/gateway-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/auth-service/Dockerfile
+            paths: go/auth-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/order-service/Dockerfile
+            paths: go/order-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/ai-service/Dockerfile
+            paths: go/ai-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/analytics-service/Dockerfile
+            paths: go/analytics-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/product-service/Dockerfile
+            paths: go/product-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/cart-service/Dockerfile
+            paths: go/cart-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/payment-service/Dockerfile
+            paths: go/payment-service/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - dockerfile: go/order-projector/Dockerfile
+            paths: go/order-projector/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
 
       - name: Run Hadolint
+        if: steps.changes.outputs.changed == 'true'
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ${{ matrix.dockerfile }}

--- a/docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md
+++ b/docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md
@@ -1,0 +1,604 @@
+# CI Hardening — Initiative A: Change-Detection Expansion (Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the existing `./.github/actions/check-changes` composite action to eleven more matrix and always-on jobs in `.github/workflows/ci.yml` so that unrelated subsystems skip work on pushes that don't touch them.
+
+**Architecture:** Pure CI workflow edit. Each gated job converts its matrix to `include:` with explicit `paths:` per entry, adds a `Check for changes` step using the composite action, and conditions all subsequent steps on `if: steps.changes.outputs.changed == 'true'`. The composite action itself (shipped in PR #164) is unchanged.
+
+**Tech Stack:** GitHub Actions YAML, the existing `aquasecurity`-style `actions/checkout@v4` + composite action invocation pattern.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` — Initiative A.
+
+**File structure:**
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | Modify | Eleven jobs converted to use composite action + path-gated matrices |
+
+No other files change in this PR.
+
+**Verification per task:** YAML syntax check (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`). Final verification: push to a feature branch and observe matrix instances skipping correctly on a docs-only follow-up commit (covered in Task 13).
+
+**Workflow safeguard rule:** Every gated entry's `paths` value must include `.github/workflows/ci.yml .github/actions/check-changes/action.yml` so that pipeline edits re-run all matrices.
+
+---
+
+### Task 1: python-tests — gate by per-service paths
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `python-tests:` job)
+
+- [ ] **Step 1: Replace the python-tests job**
+
+Find the existing `python-tests:` job (currently around line 52-96). Replace its body with:
+
+```yaml
+  python-tests:
+    name: Python Tests (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
+
+      - name: Set up Python
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache virtualenv
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/cache@v4
+        id: venv-cache
+        with:
+          path: .venv
+          key: venv-${{ matrix.service }}-${{ hashFiles(format('services/{0}/requirements.txt', matrix.service), 'services/shared/pyproject.toml') }}
+
+      - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true' && steps.venv-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install services/shared/
+          pip install -r services/${{ matrix.service }}/requirements.txt
+
+      - name: Run tests with coverage
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PYTHONPATH: services
+        run: |
+          source .venv/bin/activate
+          pytest services/${{ matrix.service }}/tests/ -v \
+            --cov=services/${{ matrix.service }}/app \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage-${{ matrix.service }}.xml
+
+      - name: Upload coverage report
+        if: steps.changes.outputs.changed == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.service }}
+          path: coverage-${{ matrix.service }}.xml
+```
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate python-tests matrix on per-service path changes"
+```
+
+---
+
+### Task 2: java-unit-tests — gate by per-service paths
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `java-unit-tests:` job)
+
+- [ ] **Step 1: Replace the java-unit-tests job**
+
+Find the existing `java-unit-tests:` job (currently around line 115-144). Replace its body with:
+
+```yaml
+  java-unit-tests:
+    name: Java Unit Tests (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: task-service
+            paths: java/task-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: activity-service
+            paths: java/activity-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: notification-service
+            paths: java/notification-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: gateway-service
+            paths: java/gateway-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
+
+      - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Run unit tests
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: java
+        run: ./gradlew :${{ matrix.service }}:test --no-daemon --stacktrace
+
+      - name: Upload test report
+        if: steps.changes.outputs.changed == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-test-report-${{ matrix.service }}
+          path: java/${{ matrix.service }}/build/reports/tests/
+```
+
+Note: if `java/checkstyle.xml` doesn't exist at the listed path, omit it from the `paths` value. The path is included defensively because checkstyle config affects test compilation.
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate java-unit-tests matrix on per-service path changes"
+```
+
+---
+
+### Task 3: java-integration-tests — gate on java/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `java-integration-tests:` job)
+
+- [ ] **Step 1: Add change detection to java-integration-tests**
+
+Find the existing `java-integration-tests:` job (currently around line 146-168). It is a single job (no matrix). Add the change-detection step and condition the subsequent steps. The new body:
+
+```yaml
+  java-integration-tests:
+    name: Java Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: java .github/workflows/ci.yml .github/actions/check-changes/action.yml
+
+      - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: java
+        run: ./gradlew :task-service:integrationTest --no-daemon --stacktrace
+
+      - name: Upload test report
+        if: steps.changes.outputs.changed == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-test-report-integration
+          path: java/task-service/build/reports/tests/
+```
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate java-integration-tests on java/** changes"
+```
+
+---
+
+### Task 4: frontend-checks — gate on frontend/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `frontend-checks:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find the `frontend-checks:` job (currently around line 336). Read its full body, then add a `Check for changes` step **after** the checkout but **before** the setup-node step. Add `if: steps.changes.outputs.changed == 'true'` to every subsequent step that uses Node, runs lint, runs tsc, or runs the build.
+
+The pattern to apply (modify in place — preserve all existing flags and commands):
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: frontend .github/workflows/ci.yml .github/actions/check-changes/action.yml
+
+      # ALL existing subsequent steps below get: if: steps.changes.outputs.changed == 'true'
+      # (combined with any existing if: condition using &&)
+      - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        ... (preserve rest verbatim)
+```
+
+Apply the `if: steps.changes.outputs.changed == 'true'` gate to **every** step in the job after the change-detection step. If a step already has an `if:` (e.g., `if: always()`), combine: `if: steps.changes.outputs.changed == 'true' && always()`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate frontend-checks on frontend/** changes"
+```
+
+---
+
+### Task 5: compose-smoke (Python stack) — gate on services/** + compose
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `compose-smoke:` job — Python smoke)
+
+- [ ] **Step 1: Add change detection**
+
+Find `compose-smoke:` (currently around line 459). Add a `Check for changes` step right after the checkout, with `paths: services docker-compose.yml nginx .github/workflows/ci.yml .github/actions/check-changes/action.yml`. Gate every subsequent step on `if: steps.changes.outputs.changed == 'true'`.
+
+Apply the same `if:` combination rule for steps that already have `if: always()` etc.
+
+The change-detection step block to insert:
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: services docker-compose.yml nginx .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Set `fetch-depth: 50` on the checkout.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate compose-smoke (python) on services/** + compose changes"
+```
+
+---
+
+### Task 6: compose-smoke-go — gate on go/** + compose
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `compose-smoke-go:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find `compose-smoke-go:` (currently around line 532). Look near the top of the job for the docker-compose file path it references (commonly `docker-compose.go.yml` or similar — observe the actual filename when reading the job).
+
+Apply the same pattern as Task 5: checkout with fetch-depth 50, `Check for changes` step with `paths: go <go-compose-file> .github/workflows/ci.yml .github/actions/check-changes/action.yml`, gate all subsequent steps on `if: steps.changes.outputs.changed == 'true'`.
+
+The change-detection step block (replace `<go-compose-file>` with the actual path the job uses; if it's `docker-compose.go.yml`, use that):
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: go docker-compose.go.yml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+If the job uses a different compose file name, substitute it. If there is no separate compose file (the job uses `docker-compose.yml`), use that instead.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate compose-smoke-go on go/** + compose changes"
+```
+
+---
+
+### Task 7: compose-smoke-java — gate on java/** + compose
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `compose-smoke-java:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find `compose-smoke-java:` (currently around line 648). Same pattern as Task 6.
+
+Insert this block right after the checkout (set `fetch-depth: 50`):
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: java docker-compose.java.yml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+(Substitute the actual Java compose file name if different.)
+
+Gate all subsequent steps on `if: steps.changes.outputs.changed == 'true'`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate compose-smoke-java on java/** + compose changes"
+```
+
+---
+
+### Task 8: security-pip-audit — gate by per-service paths
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `security-pip-audit:` job)
+
+- [ ] **Step 1: Replace the security-pip-audit job**
+
+Find `security-pip-audit:` (currently around line 748). Read its body to capture the exact pip-audit command. Then replace the matrix and add path gating using the same pattern as Task 1 (`python-tests`) — same per-service `paths:` value (`services/<name> services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml`).
+
+Convert the matrix to `include:` form:
+
+```yaml
+    strategy:
+      matrix:
+        include:
+          - service: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Add checkout with `fetch-depth: 50`, the `Check for changes` step, and gate every other step on `if: steps.changes.outputs.changed == 'true'`. Preserve the existing pip-audit command verbatim.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate security-pip-audit matrix on per-service path changes"
+```
+
+---
+
+### Task 9: security-hadolint — gate per Dockerfile path
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `security-hadolint:` job)
+
+- [ ] **Step 1: Convert hadolint matrix to per-Dockerfile path entries**
+
+Find `security-hadolint:` (currently around line 850). It uses a matrix of `dockerfile` paths. Convert each entry to `include:` form with a `paths:` key equal to the Dockerfile path itself, plus the workflow safeguard:
+
+```yaml
+    strategy:
+      matrix:
+        include:
+          - dockerfile: <path/to/Dockerfile>
+            paths: <path/to/Dockerfile> .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          # ... one entry per Dockerfile in the existing matrix
+```
+
+Read the current matrix to enumerate all Dockerfile paths. For each existing entry like `dockerfile: services/ingestion/Dockerfile`, the new entry becomes:
+
+```yaml
+          - dockerfile: services/ingestion/Dockerfile
+            paths: services/ingestion/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Add checkout with `fetch-depth: 50` and the `Check for changes` step. Gate the hadolint-action invocation on `if: steps.changes.outputs.changed == 'true'`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate security-hadolint matrix on per-Dockerfile changes"
+```
+
+---
+
+### Task 10: k8s-validation — gate on k8s/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `k8s-validation` job — find by name "K8s Manifest Validation")
+
+- [ ] **Step 1: Add change detection**
+
+Find the K8s validation job (currently around line 399). Add `Check for changes` after the checkout with:
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: k8s .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Set `fetch-depth: 50` on the checkout. Gate every subsequent step on `if: steps.changes.outputs.changed == 'true'`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate k8s-validation on k8s/** changes"
+```
+
+---
+
+### Task 11: go-migration-test — gate on go/*/migrations/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `go-migration-test:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find `go-migration-test:` (currently around line 235). The job sets up Postgres and runs migrations for several services. Insert the `Check for changes` step right after the checkout, gating on migration paths:
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: go/auth-service/migrations go/auth-service/seed.sql go/order-service/migrations go/order-service/seed.sql go/product-service/migrations go/product-service/seed.sql go/order-projector/migrations .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Set `fetch-depth: 50` on the checkout. Gate every subsequent step on `if: steps.changes.outputs.changed == 'true'`. The Postgres `services:` block is part of the job spec (not a step) so it remains; the `services` block only spins up the Postgres container when at least one step actually runs (GitHub Actions does this implicitly when all gated steps skip — verify by observing the job runs as success-with-skipped on a no-migration-change push).
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate go-migration-test on migration path changes"
+```
+
+Note: GitHub Actions will still spin up the Postgres `services:` container even when all steps skip — this is a known limitation. The waste is small (5-10s pod startup) compared to the ~60-90s the job's actual steps take. If observed cost becomes meaningful, follow-up PR could move the Postgres setup behind the gate as the first conditional step.
+
+---
+
+### Task 12: Verify YAML still parses end-to-end
+
+**Files:** No file changes — verification only.
+
+- [ ] **Step 1: Final YAML parse**
+
+```bash
+python3 -c "import yaml; data = yaml.safe_load(open('.github/workflows/ci.yml')); print('jobs defined:', len(data['jobs']))"
+```
+
+Expected: prints the same total number of jobs that existed before this PR (no jobs accidentally deleted).
+
+- [ ] **Step 2: Inspect the diff against main**
+
+```bash
+git diff main..HEAD -- .github/workflows/ci.yml | grep -cE '^\+\s+- name: Check for changes'
+```
+
+Expected: at least 11 (one Check-for-changes step added per gated job).
+
+---
+
+### Task 13: Push, observe, PR
+
+**Files:** No file changes.
+
+- [ ] **Step 1: Push the feature branch**
+
+```bash
+git push -u origin agent/feat-ci-change-detection-expansion
+```
+
+(Or whichever branch name you create the worktree with.)
+
+- [ ] **Step 2: Open the PR against qa**
+
+```bash
+gh pr create --base qa --title "ci: extend change detection to remaining matrix jobs" --body "$(cat <<'EOF'
+## Summary
+Extends the `./.github/actions/check-changes` composite action (introduced in PR #164) to the remaining matrix and always-on jobs: python-tests, java-unit-tests, java-integration-tests, frontend-checks, compose-smoke (3 stacks), security-pip-audit, security-hadolint, k8s-validation, go-migration-test.
+
+Spec: docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md (Initiative A)
+Plan: docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md
+
+## Net effect
+A docs-only push or single-stack push skips unrelated matrix entries entirely. Workflow file edits trigger every matrix entry (safeguard against silent pipeline regressions).
+
+## Test plan
+- [ ] After merge, push a docs-only commit and verify these jobs show as success-with-skipped: python-tests, java-unit-tests, java-integration-tests, frontend-checks, compose-smoke (all 3), security-pip-audit, security-hadolint, k8s-validation, go-migration-test
+- [ ] Push a Python-only commit and verify Java + frontend + Go matrices skip
+- [ ] Edit ci.yml and verify all matrices re-run regardless of which subtree the test commit modifies
+EOF
+)"
+```
+
+- [ ] **Step 3: Notify Kyle**
+
+Tell Kyle the PR is open. Do not watch CI per CLAUDE.md feature-branch rules.
+
+## Self-Review
+
+### Spec coverage check (Initiative A acceptance criteria)
+
+| Spec criterion | Plan task |
+| --- | --- |
+| Pushing docs-only commit shows ten gated jobs as green-with-skipped | Tasks 1-11 + verification in Task 13 |
+| Python-only commit skips Java tests, frontend, k8s, Go migration, compose-go/-java | Tasks 2, 3, 4, 6, 7, 10, 11 |
+| Workflow edit triggers every matrix entry | Workflow safeguard included in every `paths:` value |
+| `services/shared` change triggers every Python service | All Python entries (Tasks 1, 8) include `services/shared` |
+| Composite action invocation is identical to PR #164 | Same `uses: ./.github/actions/check-changes` everywhere |
+
+No gaps detected.
+
+### Placeholder scan
+
+No "TBD"/"TODO"/"implement later" content. The notes about "if the compose file is named differently, substitute" are deliberate flexibility — the engineer reads the actual filename and applies it. The hadolint matrix instruction tells the engineer to enumerate from the existing entries; this is reasonable because the current set of Dockerfiles is enumerable.
+
+### Type / identifier consistency
+
+- `steps.changes.outputs.changed` referenced consistently in all `if:` conditions.
+- `id: changes` used on every Check-for-changes step.
+- `fetch-depth: 50` used on every gated checkout.
+- `paths:` key used consistently in matrix entries.
+
+All consistent.

--- a/docs/superpowers/plans/2026-04-27-ci-hardening-B-image-scanning.md
+++ b/docs/superpowers/plans/2026-04-27-ci-hardening-B-image-scanning.md
@@ -1,0 +1,358 @@
+# CI Hardening — Initiative B: Container Image Vulnerability Scanning (Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Trivy image scan job between `build-and-push-images` and the deploy jobs. Block deploys when CRITICAL/HIGH CVEs are found in any rebuilt image, with `.trivyignore` as the only escape hatch. Upload findings to the GitHub Security tab via SARIF.
+
+**Architecture:** New `image-scan` matrix job with one entry per service (mirroring `build-and-push-images`). Reuses the `./.github/actions/check-changes` composite action so unchanged services skip the scan. SARIF output uploaded via `github/codeql-action/upload-sarif`. Deploy jobs add `image-scan` to their `needs:` array.
+
+**Tech Stack:** `aquasecurity/trivy-action@master`, `github/codeql-action/upload-sarif@v3`, the existing `./.github/actions/check-changes` composite action.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` — Initiative B.
+
+**File structure:**
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | Modify | Add `image-scan` job; extend `deploy-qa` and `deploy-prod` `needs:` |
+| `.trivyignore` | Create | Empty allowlist file with header comment explaining the format |
+
+**Verification per task:** YAML syntax check + a local Trivy scan against the latest QA image to surface findings before they block CI on first run.
+
+**Risk-handling note:** The first run after merge is likely to surface previously-invisible CVEs in built images. Task 4 runs Trivy locally against an existing GHCR image *before* the PR opens so any unavoidable findings can be added to `.trivyignore` in the same PR.
+
+---
+
+### Task 1: Create the `.trivyignore` allowlist file
+
+**Files:**
+- Create: `.trivyignore`
+
+- [ ] **Step 1: Create the file**
+
+```bash
+cat > .trivyignore <<'EOF'
+# .trivyignore — known-acknowledged CVEs for image vulnerability scanning.
+#
+# Format: one CVE ID per line. Use comment lines starting with `#` to
+# explain why each entry is here (false positive, accepted risk, awaiting
+# upstream fix, etc.) — entries without justification will be reverted
+# during code review.
+#
+# CRITICAL and HIGH severity CVEs fail the build by default; adding an
+# entry here is the only way to dismiss a finding without fixing it.
+# MEDIUM/LOW are reported but don't fail.
+#
+# Trivy reference: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+EOF
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .trivyignore
+git -c commit.gpgsign=false commit -m "ci: add empty .trivyignore allowlist for image scanning"
+```
+
+---
+
+### Task 2: Add the `image-scan` job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (add new job after `build-and-push-images`)
+
+- [ ] **Step 1: Locate the end of `build-and-push-images`**
+
+Find the existing `build-and-push-images:` job (currently around line 896). Identify its last step. The new `image-scan:` job will be inserted as a new top-level job entry after it.
+
+- [ ] **Step 2: Insert the image-scan job**
+
+Add this new job at the same indentation level as `build-and-push-images` (i.e. as a sibling job under `jobs:`), positioned immediately after `build-and-push-images`:
+
+```yaml
+  image-scan:
+    name: Image Scan (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    needs: build-and-push-images
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: ingestion
+            image: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: chat
+            image: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: debug
+            image: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: eval
+            image: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-task-service
+            image: java-task-service
+            paths: java/task-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-activity-service
+            image: java-activity-service
+            paths: java/activity-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-notification-service
+            image: java-notification-service
+            paths: java/notification-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-gateway-service
+            image: java-gateway-service
+            paths: java/gateway-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-auth-service
+            image: go-auth-service
+            paths: go/auth-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-order-service
+            image: go-order-service
+            paths: go/order-service go/product-service go/cart-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-ai-service
+            image: go-ai-service
+            paths: go/ai-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-analytics-service
+            image: go-analytics-service
+            paths: go/analytics-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-product-service
+            image: go-product-service
+            paths: go/product-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-cart-service
+            image: go-cart-service
+            paths: go/cart-service go/product-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-payment-service
+            image: go-payment-service
+            paths: go/payment-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-order-projector
+            image: go-order-projector
+            paths: go/order-projector go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
+
+      - name: Log in to GHCR
+        if: steps.changes.outputs.changed == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        if: steps.changes.outputs.changed == 'true'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.sha }}
+          format: sarif
+          output: trivy-${{ matrix.service }}.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && steps.changes.outputs.changed == 'true'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.service }}.sarif
+          category: trivy-${{ matrix.service }}
+```
+
+The `paths:` per entry intentionally mirror the equivalent entries in `build-and-push-images`. If those drift in the future (e.g., a new path is added to a Go service in `build-and-push-images`), it must also be added here.
+
+- [ ] **Step 3: Validate YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+```
+
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: add Trivy image-scan job with SARIF upload"
+```
+
+---
+
+### Task 3: Wire `image-scan` into deploy jobs' `needs:`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (`deploy-qa` and `deploy-prod` jobs)
+
+- [ ] **Step 1: Update `deploy-qa` needs**
+
+Find the `deploy-qa:` job (currently around line 1100). Locate its `needs:` block and add `image-scan` to the list (preserve all existing entries).
+
+Example (the existing `needs:` block plus the new entry — your actual existing entries may differ; preserve them all):
+
+```yaml
+  deploy-qa:
+    name: Deploy QA
+    ...
+    needs:
+      - build-and-push-images
+      - image-scan      # NEW
+      # ... preserve all other existing needs entries
+```
+
+- [ ] **Step 2: Update `deploy-prod` needs**
+
+Find the `deploy-prod:` job (currently around line 1291). Same change — add `image-scan` to its `needs:` list, preserving everything else.
+
+- [ ] **Step 3: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate deploys on image-scan job completion"
+```
+
+---
+
+### Task 4: Local pre-merge scan to surface findings
+
+**Files:** No file changes — risk mitigation only.
+
+- [ ] **Step 1: Confirm Trivy is installed locally**
+
+```bash
+which trivy || brew install trivy
+trivy --version
+```
+
+If Trivy isn't installed, run the brew install. If on Linux, follow https://aquasecurity.github.io/trivy/latest/getting-started/installation/.
+
+- [ ] **Step 2: Authenticate with GHCR**
+
+```bash
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u kabradshaw1 --password-stdin
+```
+
+(`GITHUB_TOKEN` here is a personal access token with `read:packages` scope — generate one if needed at https://github.com/settings/tokens.)
+
+- [ ] **Step 3: Pick a recent QA image to scan**
+
+```bash
+# Use the most recent image tag for any single service, e.g.:
+LATEST_TAG=$(gh api /users/kabradshaw1/packages/container/go-auth-service/versions --jq '.[0].metadata.container.tags[0]')
+echo "Latest tag: $LATEST_TAG"
+```
+
+- [ ] **Step 4: Scan it with the same flags CI will use**
+
+```bash
+trivy image \
+  --severity HIGH,CRITICAL \
+  --ignore-unfixed \
+  --ignorefile .trivyignore \
+  --exit-code 1 \
+  ghcr.io/kabradshaw1/go-auth-service:$LATEST_TAG
+```
+
+Expected outcomes:
+- **Exit 0:** No HIGH/CRITICAL findings. CI will pass on first run for this image.
+- **Exit 1 with findings listed:** Each finding is either a real CVE (open an issue or fix the dependency) or a false-positive / accepted-risk (add the CVE ID to `.trivyignore` with a justification comment).
+
+- [ ] **Step 5: Repeat for representative images from each language stack**
+
+Scan one Python service (e.g., `chat`), one Java service (e.g., `java-task-service`), and one Go service if the previous scans passed. The goal is to surface any baseline findings before merge so CI doesn't block the first deploy.
+
+- [ ] **Step 6: If findings exist, update `.trivyignore` with justifications**
+
+For each finding kept as accepted risk:
+
+```
+# CVE-XXXX-YYYY — <one-line justification, e.g., "openssl detected version is wrong on alpine 3.19, fixed on 3.20 — base-image upgrade tracked in #123">
+CVE-XXXX-YYYY
+```
+
+Commit any `.trivyignore` updates as part of this PR before merging:
+
+```bash
+git add .trivyignore
+git -c commit.gpgsign=false commit -m "ci: pre-populate .trivyignore with acknowledged baseline CVEs"
+```
+
+If no findings exist, the `.trivyignore` stays empty — this task is satisfied.
+
+---
+
+### Task 5: Push and PR
+
+**Files:** No file changes.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin agent/feat-ci-image-scanning
+```
+
+(Or whichever branch name the worktree uses.)
+
+- [ ] **Step 2: Open the PR against qa**
+
+```bash
+gh pr create --base qa --title "ci: add Trivy image vulnerability scanning" --body "$(cat <<'EOF'
+## Summary
+Adds a `image-scan` job that scans every freshly-built GHCR image with Trivy, blocking deploys when HIGH or CRITICAL CVEs are found. Findings upload to the GitHub Security tab as SARIF. The same `.github/actions/check-changes` composite action gates the matrix so unchanged services skip the scan.
+
+Spec: docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md (Initiative B)
+Plan: docs/superpowers/plans/2026-04-27-ci-hardening-B-image-scanning.md
+
+## Configuration
+- Severity threshold: HIGH, CRITICAL fail the build; MEDIUM/LOW reported only
+- `ignore-unfixed: true` — CVEs without an upstream fix don't block (can't be acted on)
+- `.trivyignore` is the only escape hatch for acknowledged findings; entries require justification comments
+
+## Pre-merge verification
+A local Trivy scan was run against representative images from each language stack to surface baseline findings before this PR opens. Any unavoidable acknowledged-risk CVEs are pre-populated in `.trivyignore` with justifications.
+
+## Test plan
+- [ ] After merge, push a Go-service code change and verify only that service's image-scan runs
+- [ ] Check the Security tab on the qa branch for SARIF results from the run
+- [ ] Verify deploy-qa shows `image-scan` as a dependency in the workflow graph
+- [ ] If a deliberate test CVE is introduced (e.g., pin a vulnerable base image), the deploy is blocked
+EOF
+)"
+```
+
+- [ ] **Step 3: Notify Kyle**
+
+Tell Kyle the PR is open. Note in the comment any pre-populated `.trivyignore` entries so they aren't silently merged. Do not watch CI.
+
+## Self-Review
+
+### Spec coverage check (Initiative B acceptance criteria)
+
+| Spec criterion | Plan task |
+| --- | --- |
+| New high-severity CVE fails the deploy on next build | Task 2 (`exit-code: '1'` on HIGH/CRITICAL) + Task 3 (deploy `needs:` extended) |
+| Findings appear under repository Security tab | Task 2 (SARIF upload step) |
+| `.trivyignore` is the only dismissal path | Task 1 (file) + Task 2 (`trivyignores:` flag points at it) |
+| Unchanged services skip the scan | Task 2 (composite action gating, mirrored paths) |
+
+No gaps detected.
+
+### Placeholder scan
+
+No "TBD"/"TODO" content. Task 4's "if findings exist, update `.trivyignore`" is a documented escape hatch with explicit justification format, not a placeholder.
+
+### Type / identifier consistency
+
+- Service names match `build-and-push-images` matrix exactly (cross-checked entry by entry).
+- `image-scan` referenced consistently in deploy `needs:` updates.
+- `trivyignores:` (plural) is the trivy-action input name — verified against the action's documentation.

--- a/docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md
+++ b/docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md
@@ -1,0 +1,345 @@
+# CI Hardening — Initiative C: Pre-commit Hook Backfill (Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `.pre-commit-config.yaml` so local hooks cover the same surface CI catches today: add bandit (Python SAST), hadolint (Dockerfile lint), and full Go service coverage. Add a `make install-pre-commit` target. Update `CLAUDE.md` to point new contributors at it.
+
+**Architecture:** Three additions to `.pre-commit-config.yaml`. New target in `Makefile`. Documentation update in `CLAUDE.md`. No CI workflow changes.
+
+**Tech Stack:** `pre-commit` framework, `bandit`, `hadolint`, `golangci-lint`.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` — Initiative C.
+
+**File structure:**
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `.pre-commit-config.yaml` | Modify | Add bandit hook, hadolint hook, full Go service loop |
+| `Makefile` | Modify | Add `install-pre-commit` target |
+| `CLAUDE.md` | Modify | Document `make install-pre-commit` in Pre-commit Requirements section |
+
+---
+
+### Task 1: Add bandit hook for Python SAST
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Add the bandit hook**
+
+Read `.pre-commit-config.yaml` to see its current shape. Add this block at the top of the `repos:` list, immediately after the `gitleaks` repo entry (so secret detection runs first, then Python SAST, then formatting):
+
+```yaml
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+        files: ^services/
+```
+
+- [ ] **Step 2: Verify pyproject.toml exists at the repo root and configures bandit**
+
+```bash
+grep -A 5 '\[tool.bandit\]' pyproject.toml 2>/dev/null
+```
+
+If the output is empty (no `[tool.bandit]` section), the bandit hook will use defaults — that's fine for now. The hook still works; it just won't honor any per-project skip rules. If the existing CI bandit job uses a config file, mirror its config in `pyproject.toml` so local and CI behave identically. If there's no `pyproject.toml` at the repo root, create one with:
+
+```toml
+[tool.bandit]
+exclude_dirs = ["tests", "venv", ".venv"]
+```
+
+Skip this sub-step if `pyproject.toml` already exists with appropriate config.
+
+- [ ] **Step 3: Test the hook**
+
+```bash
+pre-commit run bandit --all-files
+```
+
+Expected: passes. If it fails on existing code, the failures are real findings that should be fixed inline (or excluded with `# nosec` comments on specific lines, with justifications). Do not bypass with `--no-verify`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .pre-commit-config.yaml pyproject.toml 2>/dev/null
+git -c commit.gpgsign=false commit -m "chore(pre-commit): add bandit Python SAST hook"
+```
+
+(`pyproject.toml` is included only if it was created/modified — `git add` will silently no-op if it doesn't exist.)
+
+---
+
+### Task 2: Add hadolint hook for Dockerfile lint
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Add the hadolint hook**
+
+Add this block to `.pre-commit-config.yaml` after the bandit entry from Task 1:
+
+```yaml
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        files: Dockerfile(\..+)?$
+```
+
+The regex matches `Dockerfile`, `Dockerfile.dev`, `Dockerfile.prod`, etc.
+
+- [ ] **Step 2: Test the hook**
+
+```bash
+pre-commit run hadolint --all-files
+```
+
+Expected: passes. If it fails on existing Dockerfiles, the failures are real findings — fix them inline. Common issues:
+- `DL3008`: pin apt package versions
+- `DL3009`: clean apt cache after install
+- `DL3018`: pin alpine package versions
+- `DL3025`: use JSON-array form for CMD/ENTRYPOINT
+
+If a finding is genuinely a false positive or unfixable in this context, add an inline ignore comment in the Dockerfile:
+
+```dockerfile
+# hadolint ignore=DL3008
+RUN apt-get install -y curl
+```
+
+Do not bypass globally.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git -c commit.gpgsign=false commit -m "chore(pre-commit): add hadolint Dockerfile lint hook"
+```
+
+If any Dockerfiles were edited to fix findings, also stage them:
+
+```bash
+git add <Dockerfile path>
+git -c commit.gpgsign=false commit --amend --no-edit
+```
+
+(Amend allowed here only because the previous commit is unpushed and entirely about the same change. If pushed already, instead create a new commit.)
+
+---
+
+### Task 3: Replace the partial go-lint hook with full service coverage
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Read the current go-lint entry**
+
+The existing entry hardcodes `auth-service` and `order-service` only. The full service list is `auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector`.
+
+- [ ] **Step 2: Replace the existing go-lint local hook**
+
+Find the existing `id: go-lint` entry under the `- repo: local` block. Replace its `entry:` field with a loop over all 8 services:
+
+```yaml
+      - id: go-lint
+        name: Go Lint (all services)
+        entry: bash -c 'set -e; for svc in auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector; do echo "--- $svc ---"; (cd "go/$svc" && ~/go/bin/golangci-lint run ./...); done'
+        language: system
+        files: ^go/.*\.go$
+        pass_filenames: false
+```
+
+Keep the rest of the entry (`name`, `language`, `files`, `pass_filenames`) unchanged.
+
+- [ ] **Step 3: Test the hook**
+
+```bash
+pre-commit run go-lint --all-files
+```
+
+Expected: passes. If it fails on previously-uncovered services (`ai-service`, `analytics-service`, `product-service`, `cart-service`, `payment-service`, `order-projector`), the failures are real lint findings that should be fixed before this PR merges. The CI Go lint matrix already passes (per PR #164 work), so any failures here would be lint rules that were enforced in CI but not locally — fix them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git -c commit.gpgsign=false commit -m "chore(pre-commit): expand go-lint to all 8 services"
+```
+
+If any Go source files were edited to fix lint findings, stage and amend (same caveat as Task 2 — only if previous commit is unpushed):
+
+```bash
+git add go/
+git -c commit.gpgsign=false commit --amend --no-edit
+```
+
+---
+
+### Task 4: Add `make install-pre-commit` target
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Locate the `.PHONY` declaration**
+
+Read `Makefile` and find the existing `.PHONY:` declaration line. Verify the existing target list (the Bash tool's `head` output already showed `preflight preflight-python preflight-frontend preflight-e2e preflight-java preflight-java-integration preflight-go preflight-go-integration preflight-go-migrations preflight-security preflight-compose-config preflight-ai-service preflight-ai-service-evals grafana-sync grafana-sync-check worktree-cleanup`).
+
+- [ ] **Step 2: Add `install-pre-commit` to `.PHONY`**
+
+Append `install-pre-commit` to the `.PHONY:` list (one space-separated word).
+
+- [ ] **Step 3: Add the target body**
+
+Add this target near related developer tooling targets (the file likely has a section for setup/install — if not, append at the end):
+
+```makefile
+# --- Developer setup ---
+.PHONY: install-pre-commit
+install-pre-commit:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Install pre-commit first: pip install pre-commit"; exit 1; }
+	pre-commit install --install-hooks
+	pre-commit install --hook-type pre-push --install-hooks
+	@echo "✅ pre-commit hooks installed (commit + pre-push stages)"
+```
+
+(Note: if `.PHONY: install-pre-commit` already appears in the consolidated `.PHONY:` line at the top, you can drop the duplicate inline `.PHONY:` declaration above the target body. Keep one or the other, not both.)
+
+- [ ] **Step 4: Verify the target runs**
+
+```bash
+make install-pre-commit
+```
+
+Expected: succeeds. If `pre-commit` isn't on `PATH`, the target's first line tells you to install it. The hooks should now be active in `.git/hooks/pre-commit` and `.git/hooks/pre-push`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile
+git -c commit.gpgsign=false commit -m "chore(make): add install-pre-commit target"
+```
+
+---
+
+### Task 5: Update `CLAUDE.md` with the install instruction
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Find the "Pre-commit Requirements" section**
+
+Open `CLAUDE.md`. Locate the heading `## Pre-commit Requirements`. The section currently lists `make preflight-*` commands.
+
+- [ ] **Step 2: Add a new top sub-section about local hook installation**
+
+Insert this block immediately after the `## Pre-commit Requirements` heading (before the existing list):
+
+```markdown
+**First-time setup:** New clones must install the pre-commit hook framework once:
+
+```bash
+make install-pre-commit
+```
+
+This installs both commit-stage hooks (gitleaks, ruff, bandit, hadolint, java-checkstyle, frontend tsc/lint, go-lint) and pre-push-stage hooks (frontend `next build`). After this, every commit triggers the relevant subset based on what files changed.
+
+```
+
+(The trailing blank line + existing content stays.)
+
+- [ ] **Step 3: Sanity-check the markdown renders**
+
+```bash
+grep -A 10 "## Pre-commit Requirements" CLAUDE.md | head -15
+```
+
+Expected: shows the new "First-time setup" block followed by the original content.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git -c commit.gpgsign=false commit -m "docs: document make install-pre-commit in CLAUDE.md"
+```
+
+---
+
+### Task 6: Final preflight + push + PR
+
+**Files:** No file changes.
+
+- [ ] **Step 1: Run the full pre-commit suite to confirm everything passes**
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: every hook either passes or reports "(no files to check) Skipped". No FAILED entries. If anything fails, fix the underlying issue before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin agent/feat-ci-precommit-backfill
+```
+
+(Or whichever branch name the worktree uses.)
+
+- [ ] **Step 3: Open the PR against qa**
+
+```bash
+gh pr create --base qa --title "ci: backfill pre-commit hooks to match CI coverage" --body "$(cat <<'EOF'
+## Summary
+Extends `.pre-commit-config.yaml` so local hooks cover the same surface CI catches today:
+- Adds bandit (Python SAST) — mirrors the CI `security-bandit` job
+- Adds hadolint (Dockerfile lint) — mirrors the CI `security-hadolint` matrix
+- Replaces the partial 2-service go-lint with full 8-service coverage
+
+Adds `make install-pre-commit` for first-time setup. Documents in CLAUDE.md.
+
+Spec: docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md (Initiative C)
+Plan: docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md
+
+## Risk
+Pre-commit hooks run locally on developer machines — no CI workflow changes. CI continues to act as the safety net. The only failure mode is a developer needing to fix a finding that previously was caught only in CI; that's the desired behavior.
+
+## Test plan
+- [ ] On a fresh clone: `make install-pre-commit` succeeds and installs both stages
+- [ ] `pre-commit run --all-files` passes on a clean main
+- [ ] Modifying a Python file with a hardcoded password fails the bandit hook locally
+- [ ] Modifying a Dockerfile with a `latest` tag fails the hadolint hook locally
+- [ ] Modifying a Go file in `payment-service` fails locally if it has lint issues (was previously CI-only)
+EOF
+)"
+```
+
+- [ ] **Step 4: Notify Kyle**
+
+Tell Kyle the PR is open. Do not watch CI.
+
+## Self-Review
+
+### Spec coverage check (Initiative C acceptance criteria)
+
+| Spec criterion | Plan task |
+| --- | --- |
+| `pre-commit run --all-files` passes on a clean main | Task 6 Step 1 (verification) |
+| Hardcoded password caught locally | Task 1 (bandit) |
+| Dockerfile with `latest` tag fails locally | Task 2 (hadolint) |
+| Lint error in `go/payment-service` caught locally | Task 3 (full service loop) |
+| `make install-pre-commit` is one-liner for new clone | Task 4 |
+
+No gaps detected.
+
+### Placeholder scan
+
+No "TBD"/"TODO" content. Task 1 Step 2's "skip if `pyproject.toml` exists" is conditional logic, not a placeholder. Task 2's "fix findings inline" lists the actual common rule codes the engineer will see.
+
+### Type / identifier consistency
+
+- Hook IDs (`bandit`, `hadolint`, `go-lint`) match the upstream tool's `id:` exactly.
+- Service list in Task 3 matches the spec's stated 8-service list.
+- `pre-commit run <hook-id>` calls match registered IDs.

--- a/docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md
@@ -1,0 +1,346 @@
+# CI/CD Pipeline Hardening
+
+- **Date:** 2026-04-27
+- **Status:** Approved
+- **Spec marker:** `ci-pipeline-hardening-design`
+
+## Context
+
+The CI/CD pipeline (`.github/workflows/ci.yml`, currently 1,567 lines) handles all quality gates and deployment for the portfolio. PR #164 introduced a composite action `./.github/actions/check-changes` that resolves an exact compare base from `github.event.before` (push) or `github.event.pull_request.base.sha` (PR), with `HEAD~5` as a fallback. That action was wired into three jobs: `build-and-push-images`, `go-tests`, and `go-lint`.
+
+The same overshoot still affects ten other matrix or always-on jobs. Three independent improvements close the remaining gaps:
+
+1. **Extend the composite action** to the rest of the matrix and always-on jobs that should be path-gated.
+2. **Add container image vulnerability scanning** between build and deploy. The pipeline currently lints Dockerfiles (`hadolint`) and audits source dependencies (`pip-audit`, `npm audit`) but never scans the *built* images for CVEs in OS packages or transitive dependencies that don't appear in lockfiles.
+3. **Backfill pre-commit hooks** so the local "shift-left" framework catches the issues CI catches today, not a strict subset of them. Currently pre-commit lints Python via ruff, lints partial Go (auth + order only), runs Java checkstyle, and runs frontend tsc/lint/build — but misses bandit, hadolint, and 5 of 7 Go services.
+
+These three initiatives are thematically related (CI hardening) but independently shippable. This spec covers the design for all three; implementation will land as three separate PRs.
+
+## Goals
+
+- A docs-only or single-stack push completes CI faster by skipping unrelated matrix entries.
+- Built images are vulnerability-scanned before they reach QA or production.
+- Local pre-commit hooks cover the same surface as CI for the cheap, fast checks (lint, SAST, style).
+
+## Non-goals
+
+- No new orchestration platforms or CI providers.
+- No reusable workflow refactor for `compose-smoke-*` or `build-and-push-images` (mentioned as "lower ROI" in the audit; out of scope here).
+- No additional security tooling beyond image scanning (no Snyk, no CodeQL, no SBOM generation, no license scanning).
+- No changes to deploy steps, smoke tests, or Cloudflare/Vercel integration.
+- No changes to which services exist in which matrix (`payment-service` not being in `go-tests` / `go-lint` is flagged elsewhere as a separate item).
+
+## Initiative A — Extend change-detection composite action
+
+### Scope
+
+Apply `./.github/actions/check-changes` (already shipped in PR #164) to eleven more jobs that currently run unconditionally on every push:
+
+| Job | Per-entry path strategy |
+| --- | --- |
+| `python-tests` (matrix of 4) | `services/<name>` + `services/shared` |
+| `security-pip-audit` (matrix of 4) | `services/<name>` + `services/shared` |
+| `java-unit-tests` (matrix of 4) | `java/<service>` + `java/build.gradle` + `java/settings.gradle` |
+| `java-integration-tests` (single job) | `java/**` |
+| `frontend-checks` | `frontend/**` |
+| `compose-smoke-python` | `services/**` + `docker-compose.yml` + nginx routing |
+| `compose-smoke-go` | `go/**` + Go compose file (if separate) |
+| `compose-smoke-java` | `java/**` + Java compose file |
+| `k8s-validation` | `k8s/**` |
+| `go-migration-test` | `go/*/migrations/**` + relevant migration tooling |
+| `security-hadolint` (matrix per Dockerfile) | the specific Dockerfile path |
+
+`grafana-dashboard-sync`, `python-lint`, `java-lint`, `buf-breaking`, `security-bandit`, `security-npm-audit`, `security-gitleaks`, `security-cors-guardrail` are deliberately left **always-on** — they are either fast (sub-30s), specifically gated by content type already (e.g. `buf-breaking` runs `git diff` for proto changes inline), or perform repo-wide checks where path-gating would create a false sense of safety (e.g. gitleaks must scan whatever is being pushed regardless of which subtree it touches).
+
+### Pattern
+
+Each gated job converts its matrix to use `include:` with explicit `paths:` per entry, mirroring the existing `build-and-push-images` style:
+
+```yaml
+strategy:
+  matrix:
+    include:
+      - service: ingestion
+        paths: services/ingestion services/shared
+      - service: chat
+        paths: services/chat services/shared
+      ...
+```
+
+Each gated job adds a `Check for changes` step using the composite action and conditions all subsequent steps on `if: steps.changes.outputs.changed == 'true'`.
+
+`fetch-depth: 50` is required on the checkout so the PR base / push before SHA is reachable in the shallow clone.
+
+### Workflow-file safeguard
+
+A change to `.github/workflows/ci.yml` or anything under `.github/actions/**` should trigger **every** matrix entry to run, not skip them. Without this safeguard a refactor to the workflow could ship without exercising the matrix paths it altered.
+
+The `paths` for every gated entry is therefore extended to include `.github/workflows/ci.yml .github/actions/**`. This is a small, mechanical addition per entry and makes pipeline-validation runs explicit.
+
+### Path-set discipline
+
+For each gated job, the `paths` value must encompass:
+1. The service's own source tree
+2. Any shared libraries the service imports (`services/shared`, `go/pkg`, `java/build.gradle`, etc.)
+3. The workflow safeguard paths (`.github/workflows/ci.yml`, `.github/actions/**`)
+
+Every entry in `python-tests` and `security-pip-audit` for the same service uses the **identical** paths. Drift between sibling matrices is the failure mode that ADR 07 was originally trying to prevent — same path-set per service across all gated jobs avoids it.
+
+### Acceptance criteria
+
+- Pushing a docs-only commit shows all ten gated jobs as green with their main steps skipped (matrix instances themselves stay green; downstream `needs:` consumers are not blocked).
+- Pushing a Python-only commit (e.g. `services/chat/...`) skips Java unit tests, frontend checks, k8s validation, Go migration test, compose-smoke-go, and compose-smoke-java.
+- Editing `.github/workflows/ci.yml` triggers every matrix entry, regardless of which application paths were touched.
+- A change to `services/shared` triggers every Python service's tests, pip-audit, and the Python compose smoke (because every service entry includes `services/shared`).
+- Composite action invocation is identical to PR #164 — same inputs, same outputs.
+
+## Initiative B — Container image vulnerability scanning
+
+### Tool selection
+
+**Trivy** via `aquasecurity/trivy-action`. Reasons:
+
+- Most-adopted OSS scanner; broad CVE database (NVD, GitHub Advisory, OS-specific feeds).
+- First-party GHA action; mature, actively maintained.
+- Native SARIF output that uploads to GitHub Security tab via `github/codeql-action/upload-sarif`, so findings appear on PRs without separate UI.
+- Faster than Grype on equivalent scans; comparable accuracy.
+- No vendor account, no licence, no API key — runs entirely in-action.
+
+**Rejected alternatives:**
+
+- **Grype** (Anchore): comparable feature set, slightly slower, smaller community.
+- **Snyk Container**: requires account + token, free tier rate-limited, vendor lock-in for advisory data.
+- **Docker Scout**: tied to Docker Hub authentication patterns, less ergonomic for GHCR.
+
+### Pipeline placement
+
+A new job `image-scan` runs **after** `build-and-push-images` and **before** `deploy-qa` / `deploy-prod`. It scans the freshly-pushed GHCR image (not the source tree), gated by the same `check-changes` composite action used by `build-and-push-images` so unchanged services skip the scan too.
+
+```yaml
+image-scan:
+  name: Image Scan (${{ matrix.service }})
+  runs-on: ubuntu-latest
+  needs: build-and-push-images
+  permissions:
+    contents: read
+    packages: read
+    security-events: write   # required for SARIF upload
+  strategy:
+    fail-fast: false
+    matrix:
+      include:
+        # Same matrix as build-and-push-images; reuse via YAML anchor or duplicate.
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 50
+    - name: Check for changes
+      id: changes
+      uses: ./.github/actions/check-changes
+      with:
+        paths: ${{ matrix.paths }}
+    - name: Log in to GHCR
+      if: steps.changes.outputs.changed == 'true'
+      ...
+    - name: Run Trivy
+      if: steps.changes.outputs.changed == 'true'
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.sha }}
+        format: sarif
+        output: trivy-${{ matrix.service }}.sarif
+        severity: HIGH,CRITICAL
+        exit-code: '1'
+        ignore-unfixed: true
+        trivyignores: .trivyignore
+    - name: Upload SARIF
+      if: always() && steps.changes.outputs.changed == 'true'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: trivy-${{ matrix.service }}.sarif
+        category: trivy-${{ matrix.service }}
+```
+
+The deploy jobs (`deploy-qa`, `deploy-prod`) extend their `needs:` array to include `image-scan`. If the scan fails, deploys do not run.
+
+### Severity policy
+
+- **CRITICAL, HIGH** → fail the build (`exit-code: '1'`)
+- **MEDIUM, LOW, UNKNOWN** → reported in SARIF output but do not fail
+- **`ignore-unfixed: true`** → CVEs without an upstream patch are noise; an unfixable HIGH in a base-image library can't be acted on, so don't block on them
+
+### Allowlist mechanism
+
+A `.trivyignore` file at the repo root holds known acknowledged CVEs. Each entry is one CVE ID with a comment explaining why it's ignored:
+
+```
+# .trivyignore
+# CVE-XXXX-YYYY — false positive, openssl version detected by trivy is wrong (#issue-link)
+CVE-XXXX-YYYY
+# CVE-AAAA-BBBB — accepted risk, only triggered by configurable feature we don't use
+CVE-AAAA-BBBB
+```
+
+Adding a CVE to `.trivyignore` is a code change, reviewed in PR. There is no other path to dismissing a finding.
+
+### Concurrency / cost
+
+The matrix runs in parallel; per-image scan time is 30-90s. Total wall-clock added to the pipeline is bounded by the slowest single image scan, not the cumulative time. Skipped (unchanged) services don't add anything.
+
+### Acceptance criteria
+
+- A new high-severity CVE in any built image fails the deploy on the next build.
+- Findings appear under the repository's Security tab, scoped per service.
+- Adding a CVE to `.trivyignore` with a justification comment unblocks the build without code changes elsewhere.
+- Running on an unchanged service shows the scan job as green-with-skipped, not failed.
+
+## Initiative C — Pre-commit hook backfill
+
+### Current state
+
+`.pre-commit-config.yaml` defines:
+- `gitleaks` (secrets) — repo-wide
+- `ruff` + `ruff-format` — `services/**`
+- `java-checkstyle` — `java/**/*.java`
+- `frontend-typecheck` (`tsc --noEmit`) — `frontend/**/*.{ts,tsx}`
+- `frontend-lint` (`npm run lint`) — `frontend/**/*.{ts,tsx,js,jsx}`
+- `frontend-build` (`next build`) — pre-push only
+- `go-lint` — only `auth-service` and `order-service` (5 services missing)
+
+### Add
+
+#### bandit (Python SAST)
+
+```yaml
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.9
+  hooks:
+    - id: bandit
+      args: ["-c", "pyproject.toml"]
+      additional_dependencies: ["bandit[toml]"]
+      files: ^services/
+```
+
+Mirrors the CI `security-bandit` job. Bandit is fast (sub-5s on this repo's surface) and catches Python anti-patterns before CI does.
+
+#### hadolint (Dockerfile lint)
+
+```yaml
+- repo: https://github.com/hadolint/hadolint
+  rev: v2.12.0
+  hooks:
+    - id: hadolint
+      files: Dockerfile(\..+)?$
+```
+
+Mirrors the CI `security-hadolint` matrix. Catches Dockerfile issues (latest tag, missing USER, etc.) at commit time.
+
+#### Full go-lint coverage
+
+Replace the existing hardcoded `auth-service + order-service` entry with one entry per Go service. Loop pattern in the local hook:
+
+```yaml
+- id: go-lint
+  name: Go Lint (all services)
+  entry: bash -c 'set -e; for svc in auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector; do
+    echo "--- $svc ---"
+    (cd "go/$svc" && ~/go/bin/golangci-lint run ./...)
+  done'
+  language: system
+  files: ^go/.*\.go$
+  pass_filenames: false
+```
+
+Note `payment-service` is included even though it's missing from CI's `go-tests` / `go-lint` matrices — covering it locally costs nothing and surfaces issues earlier.
+
+### Don't add
+
+- **pip-audit / npm audit** — network-dependent, slow (10-60s), gated to CI.
+- **trivy** — scans built images, not source. CI-only.
+- **prettier** for frontend — `eslint-config-next` already covers formatting; adding prettier would create dual-source-of-truth.
+
+### Onboarding
+
+Add a Make target so new contributors install the hooks once:
+
+```makefile
+.PHONY: install-pre-commit
+install-pre-commit:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Install pre-commit first: pip install pre-commit"; exit 1; }
+	pre-commit install --install-hooks
+	pre-commit install --hook-type pre-push --install-hooks
+	@echo "✅ pre-commit hooks installed (commit + pre-push stages)"
+```
+
+Document in `CLAUDE.md` under "Pre-commit Requirements" section.
+
+### Acceptance criteria
+
+- `pre-commit run --all-files` passes on a clean main branch.
+- Adding a hardcoded password to a Python file is caught locally, not in CI.
+- A Dockerfile change with a `latest` tag fails locally.
+- A lint error in `go/payment-service` is caught locally.
+- `make install-pre-commit` is a one-liner for a new clone.
+
+## Implementation phasing
+
+Three independent PRs against `qa`. Order doesn't matter; each is shippable on its own.
+
+### PR 1 — Initiative A (composite action expansion)
+
+- Convert ten matrices to `include:` with `paths:` entries
+- Add `Check for changes` step + `if:` gates per job
+- Bump `fetch-depth: 50` on each affected checkout
+- Touches only `.github/workflows/ci.yml`
+- Risk: low (mechanical change, same pattern as PR #164)
+
+### PR 2 — Initiative B (image scanning)
+
+- Add `image-scan` job with Trivy + SARIF upload
+- Wire `image-scan` into `needs:` for `deploy-qa` and `deploy-prod`
+- Add empty `.trivyignore` with comment header explaining the format
+- Touches `.github/workflows/ci.yml` and creates `.trivyignore`
+- Risk: medium (new job; first run will surface previously-invisible CVEs and may immediately need entries in `.trivyignore` before merging — implementation will run the scan locally first to surface findings)
+
+### PR 3 — Initiative C (pre-commit backfill)
+
+- Update `.pre-commit-config.yaml` with bandit, hadolint, full go-lint
+- Add `make install-pre-commit` target to `Makefile`
+- Update `CLAUDE.md` "Pre-commit Requirements" section
+- Touches `.pre-commit-config.yaml`, `Makefile`, `CLAUDE.md`
+- Risk: low (developer tooling only — CI is unaffected)
+
+## Documentation
+
+Single ADR `docs/adr/ci-cd-pipeline-evolution.md` records the design decisions: change-detection compare-base strategy, image-scan policy, and the local-vs-CI split for security tooling. Written after all three PRs land, so it reflects the final state.
+
+`CLAUDE.md` updated in PR 3 to include:
+- The new `image-scan` job in the CI/CD pipeline table
+- `make install-pre-commit` in the "Pre-commit Requirements" section
+- Note that pushing a docs-only commit will skip most matrix jobs (so the user knows the green-with-skipped state is normal)
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Path-set drift between sibling matrices (e.g. `python-tests` and `security-pip-audit` for the same service) | Identical `paths:` value reused per service across all gated jobs. Spec-level rule. |
+| Workflow refactor accidentally breaks change-detection without exercising the changed matrices | Workflow path safeguard: every gated entry includes `.github/workflows/ci.yml .github/actions/**` so a CI change re-runs everything. |
+| First Trivy run reveals undismissable CRITICAL CVEs that block deploy | Run scan locally before merging PR 2. Pre-populate `.trivyignore` with any acknowledged-and-justified findings. Open issues for fixable findings before merging. |
+| `payment-service` is locally linted by pre-commit but not CI-tested | Documented as known gap (separate spec). Pre-commit catch-rate is best-effort, not a substitute for CI. |
+| Hadolint findings on existing Dockerfiles fail pre-commit on first install | Run `pre-commit run hadolint --all-files` locally as part of PR 3, fix findings inline. |
+
+## Out of scope (deliberately)
+
+- Reusable workflows for `compose-smoke-*` (lower-ROI cleanup, not blocking anything).
+- `payment-service` addition to `go-tests` / `go-lint` matrices (correctness, not speed; separate spec).
+- Path filtering for `python-lint`, `java-lint`, `security-bandit`, `security-npm-audit`, `security-gitleaks`, `security-cors-guardrail`, `grafana-dashboard-sync`, `buf-breaking` — fast or repo-wide, gating buys little.
+- SBOM generation, license scanning, supply-chain attestation (Sigstore / cosign).
+- CodeQL or other deep SAST.
+- Per-PR vulnerability comments (Trivy's SARIF output already surfaces in the Security tab and PR checks).
+
+## Acceptance criteria summary (cross-cutting)
+
+- A docs-only push on `qa` finishes CI in noticeably less time (target: most matrix jobs green-with-skipped, only repo-wide checks running).
+- A Python-only PR doesn't run Java unit tests, Go test/lint, k8s validation, or compose-smoke-go/-java.
+- New CVEs in built images fail the deploy with allowlist as the only escape hatch.
+- A new contributor can clone, run `make install-pre-commit`, and commit with full local lint coverage.


### PR DESCRIPTION
## Summary
Extends the `./.github/actions/check-changes` composite action (introduced in PR #164) to the remaining matrix and always-on jobs:
- `python-tests` (matrix of 4)
- `java-unit-tests` (matrix of 4)
- `java-integration-tests` (single job)
- `go-migration-test` (single job, gated on migration paths)
- `frontend-checks` (single job)
- `k8s-manifest-validation` (single job)
- `compose-smoke`, `compose-smoke-go`, `compose-smoke-java` (3 stacks)
- `security-pip-audit` (matrix of 4)
- `security-hadolint` (matrix of 16 Dockerfiles)

Spec: `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md`
Plan: `docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md`

## Net effect
A docs-only push or single-stack push skips unrelated matrix entries entirely. Every gated entry's `paths:` value includes `.github/workflows/ci.yml` and `.github/actions/check-changes/action.yml`, so workflow refactors trigger every matrix entry as a safeguard against silent pipeline regressions.

`fetch-depth: 50` on every gated checkout ensures the PR base SHA / push-before SHA is reachable in shallow clones.

## Depends on
PR #164 (composite action). This branch is based on PR #164's branch — once #164 merges to `qa`, this PR's diff cleans up to just the gating changes.

## Test plan
- [ ] After merge, push a docs-only commit and verify these jobs show as success-with-skipped: python-tests, java-unit-tests, java-integration-tests, frontend-checks, compose-smoke (3), security-pip-audit, security-hadolint, k8s-manifest-validation, go-migration-test
- [ ] Push a Python-only commit and verify Java + frontend + Go matrices skip
- [ ] Edit `ci.yml` and verify all matrices re-run regardless of which subtree the test commit modifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)