### PR TITLE
chore(pre-commit): backfill bandit, hadolint, full Go coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,17 @@ repos:
     rev: v8.24.3
     hooks:
       - id: gitleaks
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: ["-ll"]
+        files: ^services/.*\.py$
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.13.1-beta
+    hooks:
+      - id: hadolint-docker
+        files: (^|/)Dockerfile(\..+)?$
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.6
     hooks:
@@ -39,8 +50,8 @@ repos:
         pass_filenames: false
         stages: [pre-push]
       - id: go-lint
-        name: Go Lint
-        entry: bash -c 'cd go/auth-service && ~/go/bin/golangci-lint run ./... && cd ../order-service && ~/go/bin/golangci-lint run ./...'
+        name: Go Lint (all services)
+        entry: bash -c 'set -e; for svc in auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector; do echo "--- $svc ---"; (cd "go/$svc" && ~/go/bin/golangci-lint run ./...); done'
         language: system
         files: ^go/.*\.go$
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,14 @@ Claude Code determines the current branch via `git branch --show-current` and fo
 
 ## Pre-commit Requirements
 
+**First-time setup:** New clones must install the pre-commit hook framework once:
+
+```bash
+make install-pre-commit
+```
+
+This installs both commit-stage hooks (gitleaks, bandit, hadolint, ruff, java-checkstyle, frontend tsc/lint, go-lint covering all 8 services) and pre-push-stage hooks (frontend `next build`). After this, every commit triggers the relevant subset based on what files changed.
+
 Before every commit, run the relevant preflight checks and fix any failures. Only escalate to Kyle if you can't resolve the issue.
 
 - **Python changes:** `make preflight-python` and `make preflight-security`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: preflight preflight-python preflight-frontend preflight-e2e preflight-java preflight-java-integration preflight-go preflight-go-integration preflight-go-migrations preflight-security preflight-compose-config preflight-ai-service preflight-ai-service-evals grafana-sync grafana-sync-check worktree-cleanup
+.PHONY: preflight preflight-python preflight-frontend preflight-e2e preflight-java preflight-java-integration preflight-go preflight-go-integration preflight-go-migrations preflight-security preflight-compose-config preflight-ai-service preflight-ai-service-evals grafana-sync grafana-sync-check worktree-cleanup install-pre-commit
 
 # Run all CI checks locally before pushing
 preflight: grafana-sync-check preflight-python preflight-frontend preflight-security preflight-java preflight-go preflight-compose-config
@@ -208,3 +208,10 @@ worktree-cleanup:
 	done
 	@git worktree prune
 	@echo "Done"
+
+# --- Developer setup ---
+install-pre-commit:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Install pre-commit first: pip install pre-commit"; exit 1; }
+	pre-commit install --install-hooks
+	pre-commit install --hook-type pre-push --install-hooks
+	@echo "✅ pre-commit hooks installed (commit + pre-push stages)"

--- a/docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md
+++ b/docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md
@@ -1,0 +1,604 @@
+# CI Hardening — Initiative A: Change-Detection Expansion (Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the existing `./.github/actions/check-changes` composite action to eleven more matrix and always-on jobs in `.github/workflows/ci.yml` so that unrelated subsystems skip work on pushes that don't touch them.
+
+**Architecture:** Pure CI workflow edit. Each gated job converts its matrix to `include:` with explicit `paths:` per entry, adds a `Check for changes` step using the composite action, and conditions all subsequent steps on `if: steps.changes.outputs.changed == 'true'`. The composite action itself (shipped in PR #164) is unchanged.
+
+**Tech Stack:** GitHub Actions YAML, the existing `aquasecurity`-style `actions/checkout@v4` + composite action invocation pattern.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` — Initiative A.
+
+**File structure:**
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | Modify | Eleven jobs converted to use composite action + path-gated matrices |
+
+No other files change in this PR.
+
+**Verification per task:** YAML syntax check (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`). Final verification: push to a feature branch and observe matrix instances skipping correctly on a docs-only follow-up commit (covered in Task 13).
+
+**Workflow safeguard rule:** Every gated entry's `paths` value must include `.github/workflows/ci.yml .github/actions/check-changes/action.yml` so that pipeline edits re-run all matrices.
+
+---
+
+### Task 1: python-tests — gate by per-service paths
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `python-tests:` job)
+
+- [ ] **Step 1: Replace the python-tests job**
+
+Find the existing `python-tests:` job (currently around line 52-96). Replace its body with:
+
+```yaml
+  python-tests:
+    name: Python Tests (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
+
+      - name: Set up Python
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache virtualenv
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/cache@v4
+        id: venv-cache
+        with:
+          path: .venv
+          key: venv-${{ matrix.service }}-${{ hashFiles(format('services/{0}/requirements.txt', matrix.service), 'services/shared/pyproject.toml') }}
+
+      - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true' && steps.venv-cache.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install services/shared/
+          pip install -r services/${{ matrix.service }}/requirements.txt
+
+      - name: Run tests with coverage
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          PYTHONPATH: services
+        run: |
+          source .venv/bin/activate
+          pytest services/${{ matrix.service }}/tests/ -v \
+            --cov=services/${{ matrix.service }}/app \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage-${{ matrix.service }}.xml
+
+      - name: Upload coverage report
+        if: steps.changes.outputs.changed == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.service }}
+          path: coverage-${{ matrix.service }}.xml
+```
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate python-tests matrix on per-service path changes"
+```
+
+---
+
+### Task 2: java-unit-tests — gate by per-service paths
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `java-unit-tests:` job)
+
+- [ ] **Step 1: Replace the java-unit-tests job**
+
+Find the existing `java-unit-tests:` job (currently around line 115-144). Replace its body with:
+
+```yaml
+  java-unit-tests:
+    name: Java Unit Tests (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: task-service
+            paths: java/task-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: activity-service
+            paths: java/activity-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: notification-service
+            paths: java/notification-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: gateway-service
+            paths: java/gateway-service java/build.gradle java/settings.gradle java/checkstyle.xml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
+
+      - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Run unit tests
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: java
+        run: ./gradlew :${{ matrix.service }}:test --no-daemon --stacktrace
+
+      - name: Upload test report
+        if: steps.changes.outputs.changed == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-test-report-${{ matrix.service }}
+          path: java/${{ matrix.service }}/build/reports/tests/
+```
+
+Note: if `java/checkstyle.xml` doesn't exist at the listed path, omit it from the `paths` value. The path is included defensively because checkstyle config affects test compilation.
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate java-unit-tests matrix on per-service path changes"
+```
+
+---
+
+### Task 3: java-integration-tests — gate on java/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `java-integration-tests:` job)
+
+- [ ] **Step 1: Add change detection to java-integration-tests**
+
+Find the existing `java-integration-tests:` job (currently around line 146-168). It is a single job (no matrix). Add the change-detection step and condition the subsequent steps. The new body:
+
+```yaml
+  java-integration-tests:
+    name: Java Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: java .github/workflows/ci.yml .github/actions/check-changes/action.yml
+
+      - name: Set up JDK 21
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: java
+        run: ./gradlew :task-service:integrationTest --no-daemon --stacktrace
+
+      - name: Upload test report
+        if: steps.changes.outputs.changed == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java-test-report-integration
+          path: java/task-service/build/reports/tests/
+```
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate java-integration-tests on java/** changes"
+```
+
+---
+
+### Task 4: frontend-checks — gate on frontend/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `frontend-checks:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find the `frontend-checks:` job (currently around line 336). Read its full body, then add a `Check for changes` step **after** the checkout but **before** the setup-node step. Add `if: steps.changes.outputs.changed == 'true'` to every subsequent step that uses Node, runs lint, runs tsc, or runs the build.
+
+The pattern to apply (modify in place — preserve all existing flags and commands):
+
+```yaml
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: frontend .github/workflows/ci.yml .github/actions/check-changes/action.yml
+
+      # ALL existing subsequent steps below get: if: steps.changes.outputs.changed == 'true'
+      # (combined with any existing if: condition using &&)
+      - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        ... (preserve rest verbatim)
+```
+
+Apply the `if: steps.changes.outputs.changed == 'true'` gate to **every** step in the job after the change-detection step. If a step already has an `if:` (e.g., `if: always()`), combine: `if: steps.changes.outputs.changed == 'true' && always()`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate frontend-checks on frontend/** changes"
+```
+
+---
+
+### Task 5: compose-smoke (Python stack) — gate on services/** + compose
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `compose-smoke:` job — Python smoke)
+
+- [ ] **Step 1: Add change detection**
+
+Find `compose-smoke:` (currently around line 459). Add a `Check for changes` step right after the checkout, with `paths: services docker-compose.yml nginx .github/workflows/ci.yml .github/actions/check-changes/action.yml`. Gate every subsequent step on `if: steps.changes.outputs.changed == 'true'`.
+
+Apply the same `if:` combination rule for steps that already have `if: always()` etc.
+
+The change-detection step block to insert:
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: services docker-compose.yml nginx .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Set `fetch-depth: 50` on the checkout.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate compose-smoke (python) on services/** + compose changes"
+```
+
+---
+
+### Task 6: compose-smoke-go — gate on go/** + compose
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `compose-smoke-go:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find `compose-smoke-go:` (currently around line 532). Look near the top of the job for the docker-compose file path it references (commonly `docker-compose.go.yml` or similar — observe the actual filename when reading the job).
+
+Apply the same pattern as Task 5: checkout with fetch-depth 50, `Check for changes` step with `paths: go <go-compose-file> .github/workflows/ci.yml .github/actions/check-changes/action.yml`, gate all subsequent steps on `if: steps.changes.outputs.changed == 'true'`.
+
+The change-detection step block (replace `<go-compose-file>` with the actual path the job uses; if it's `docker-compose.go.yml`, use that):
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: go docker-compose.go.yml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+If the job uses a different compose file name, substitute it. If there is no separate compose file (the job uses `docker-compose.yml`), use that instead.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate compose-smoke-go on go/** + compose changes"
+```
+
+---
+
+### Task 7: compose-smoke-java — gate on java/** + compose
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `compose-smoke-java:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find `compose-smoke-java:` (currently around line 648). Same pattern as Task 6.
+
+Insert this block right after the checkout (set `fetch-depth: 50`):
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: java docker-compose.java.yml .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+(Substitute the actual Java compose file name if different.)
+
+Gate all subsequent steps on `if: steps.changes.outputs.changed == 'true'`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate compose-smoke-java on java/** + compose changes"
+```
+
+---
+
+### Task 8: security-pip-audit — gate by per-service paths
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `security-pip-audit:` job)
+
+- [ ] **Step 1: Replace the security-pip-audit job**
+
+Find `security-pip-audit:` (currently around line 748). Read its body to capture the exact pip-audit command. Then replace the matrix and add path gating using the same pattern as Task 1 (`python-tests`) — same per-service `paths:` value (`services/<name> services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml`).
+
+Convert the matrix to `include:` form:
+
+```yaml
+    strategy:
+      matrix:
+        include:
+          - service: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          - service: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Add checkout with `fetch-depth: 50`, the `Check for changes` step, and gate every other step on `if: steps.changes.outputs.changed == 'true'`. Preserve the existing pip-audit command verbatim.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate security-pip-audit matrix on per-service path changes"
+```
+
+---
+
+### Task 9: security-hadolint — gate per Dockerfile path
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `security-hadolint:` job)
+
+- [ ] **Step 1: Convert hadolint matrix to per-Dockerfile path entries**
+
+Find `security-hadolint:` (currently around line 850). It uses a matrix of `dockerfile` paths. Convert each entry to `include:` form with a `paths:` key equal to the Dockerfile path itself, plus the workflow safeguard:
+
+```yaml
+    strategy:
+      matrix:
+        include:
+          - dockerfile: <path/to/Dockerfile>
+            paths: <path/to/Dockerfile> .github/workflows/ci.yml .github/actions/check-changes/action.yml
+          # ... one entry per Dockerfile in the existing matrix
+```
+
+Read the current matrix to enumerate all Dockerfile paths. For each existing entry like `dockerfile: services/ingestion/Dockerfile`, the new entry becomes:
+
+```yaml
+          - dockerfile: services/ingestion/Dockerfile
+            paths: services/ingestion/Dockerfile .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Add checkout with `fetch-depth: 50` and the `Check for changes` step. Gate the hadolint-action invocation on `if: steps.changes.outputs.changed == 'true'`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate security-hadolint matrix on per-Dockerfile changes"
+```
+
+---
+
+### Task 10: k8s-validation — gate on k8s/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `k8s-validation` job — find by name "K8s Manifest Validation")
+
+- [ ] **Step 1: Add change detection**
+
+Find the K8s validation job (currently around line 399). Add `Check for changes` after the checkout with:
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: k8s .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Set `fetch-depth: 50` on the checkout. Gate every subsequent step on `if: steps.changes.outputs.changed == 'true'`.
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate k8s-validation on k8s/** changes"
+```
+
+---
+
+### Task 11: go-migration-test — gate on go/*/migrations/**
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `go-migration-test:` job)
+
+- [ ] **Step 1: Add change detection**
+
+Find `go-migration-test:` (currently around line 235). The job sets up Postgres and runs migrations for several services. Insert the `Check for changes` step right after the checkout, gating on migration paths:
+
+```yaml
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: go/auth-service/migrations go/auth-service/seed.sql go/order-service/migrations go/order-service/seed.sql go/product-service/migrations go/product-service/seed.sql go/order-projector/migrations .github/workflows/ci.yml .github/actions/check-changes/action.yml
+```
+
+Set `fetch-depth: 50` on the checkout. Gate every subsequent step on `if: steps.changes.outputs.changed == 'true'`. The Postgres `services:` block is part of the job spec (not a step) so it remains; the `services` block only spins up the Postgres container when at least one step actually runs (GitHub Actions does this implicitly when all gated steps skip — verify by observing the job runs as success-with-skipped on a no-migration-change push).
+
+- [ ] **Step 2: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate go-migration-test on migration path changes"
+```
+
+Note: GitHub Actions will still spin up the Postgres `services:` container even when all steps skip — this is a known limitation. The waste is small (5-10s pod startup) compared to the ~60-90s the job's actual steps take. If observed cost becomes meaningful, follow-up PR could move the Postgres setup behind the gate as the first conditional step.
+
+---
+
+### Task 12: Verify YAML still parses end-to-end
+
+**Files:** No file changes — verification only.
+
+- [ ] **Step 1: Final YAML parse**
+
+```bash
+python3 -c "import yaml; data = yaml.safe_load(open('.github/workflows/ci.yml')); print('jobs defined:', len(data['jobs']))"
+```
+
+Expected: prints the same total number of jobs that existed before this PR (no jobs accidentally deleted).
+
+- [ ] **Step 2: Inspect the diff against main**
+
+```bash
+git diff main..HEAD -- .github/workflows/ci.yml | grep -cE '^\+\s+- name: Check for changes'
+```
+
+Expected: at least 11 (one Check-for-changes step added per gated job).
+
+---
+
+### Task 13: Push, observe, PR
+
+**Files:** No file changes.
+
+- [ ] **Step 1: Push the feature branch**
+
+```bash
+git push -u origin agent/feat-ci-change-detection-expansion
+```
+
+(Or whichever branch name you create the worktree with.)
+
+- [ ] **Step 2: Open the PR against qa**
+
+```bash
+gh pr create --base qa --title "ci: extend change detection to remaining matrix jobs" --body "$(cat <<'EOF'
+## Summary
+Extends the `./.github/actions/check-changes` composite action (introduced in PR #164) to the remaining matrix and always-on jobs: python-tests, java-unit-tests, java-integration-tests, frontend-checks, compose-smoke (3 stacks), security-pip-audit, security-hadolint, k8s-validation, go-migration-test.
+
+Spec: docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md (Initiative A)
+Plan: docs/superpowers/plans/2026-04-27-ci-hardening-A-change-detection-expansion.md
+
+## Net effect
+A docs-only push or single-stack push skips unrelated matrix entries entirely. Workflow file edits trigger every matrix entry (safeguard against silent pipeline regressions).
+
+## Test plan
+- [ ] After merge, push a docs-only commit and verify these jobs show as success-with-skipped: python-tests, java-unit-tests, java-integration-tests, frontend-checks, compose-smoke (all 3), security-pip-audit, security-hadolint, k8s-validation, go-migration-test
+- [ ] Push a Python-only commit and verify Java + frontend + Go matrices skip
+- [ ] Edit ci.yml and verify all matrices re-run regardless of which subtree the test commit modifies
+EOF
+)"
+```
+
+- [ ] **Step 3: Notify Kyle**
+
+Tell Kyle the PR is open. Do not watch CI per CLAUDE.md feature-branch rules.
+
+## Self-Review
+
+### Spec coverage check (Initiative A acceptance criteria)
+
+| Spec criterion | Plan task |
+| --- | --- |
+| Pushing docs-only commit shows ten gated jobs as green-with-skipped | Tasks 1-11 + verification in Task 13 |
+| Python-only commit skips Java tests, frontend, k8s, Go migration, compose-go/-java | Tasks 2, 3, 4, 6, 7, 10, 11 |
+| Workflow edit triggers every matrix entry | Workflow safeguard included in every `paths:` value |
+| `services/shared` change triggers every Python service | All Python entries (Tasks 1, 8) include `services/shared` |
+| Composite action invocation is identical to PR #164 | Same `uses: ./.github/actions/check-changes` everywhere |
+
+No gaps detected.
+
+### Placeholder scan
+
+No "TBD"/"TODO"/"implement later" content. The notes about "if the compose file is named differently, substitute" are deliberate flexibility — the engineer reads the actual filename and applies it. The hadolint matrix instruction tells the engineer to enumerate from the existing entries; this is reasonable because the current set of Dockerfiles is enumerable.
+
+### Type / identifier consistency
+
+- `steps.changes.outputs.changed` referenced consistently in all `if:` conditions.
+- `id: changes` used on every Check-for-changes step.
+- `fetch-depth: 50` used on every gated checkout.
+- `paths:` key used consistently in matrix entries.
+
+All consistent.

--- a/docs/superpowers/plans/2026-04-27-ci-hardening-B-image-scanning.md
+++ b/docs/superpowers/plans/2026-04-27-ci-hardening-B-image-scanning.md
@@ -1,0 +1,358 @@
+# CI Hardening — Initiative B: Container Image Vulnerability Scanning (Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Trivy image scan job between `build-and-push-images` and the deploy jobs. Block deploys when CRITICAL/HIGH CVEs are found in any rebuilt image, with `.trivyignore` as the only escape hatch. Upload findings to the GitHub Security tab via SARIF.
+
+**Architecture:** New `image-scan` matrix job with one entry per service (mirroring `build-and-push-images`). Reuses the `./.github/actions/check-changes` composite action so unchanged services skip the scan. SARIF output uploaded via `github/codeql-action/upload-sarif`. Deploy jobs add `image-scan` to their `needs:` array.
+
+**Tech Stack:** `aquasecurity/trivy-action@master`, `github/codeql-action/upload-sarif@v3`, the existing `./.github/actions/check-changes` composite action.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` — Initiative B.
+
+**File structure:**
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | Modify | Add `image-scan` job; extend `deploy-qa` and `deploy-prod` `needs:` |
+| `.trivyignore` | Create | Empty allowlist file with header comment explaining the format |
+
+**Verification per task:** YAML syntax check + a local Trivy scan against the latest QA image to surface findings before they block CI on first run.
+
+**Risk-handling note:** The first run after merge is likely to surface previously-invisible CVEs in built images. Task 4 runs Trivy locally against an existing GHCR image *before* the PR opens so any unavoidable findings can be added to `.trivyignore` in the same PR.
+
+---
+
+### Task 1: Create the `.trivyignore` allowlist file
+
+**Files:**
+- Create: `.trivyignore`
+
+- [ ] **Step 1: Create the file**
+
+```bash
+cat > .trivyignore <<'EOF'
+# .trivyignore — known-acknowledged CVEs for image vulnerability scanning.
+#
+# Format: one CVE ID per line. Use comment lines starting with `#` to
+# explain why each entry is here (false positive, accepted risk, awaiting
+# upstream fix, etc.) — entries without justification will be reverted
+# during code review.
+#
+# CRITICAL and HIGH severity CVEs fail the build by default; adding an
+# entry here is the only way to dismiss a finding without fixing it.
+# MEDIUM/LOW are reported but don't fail.
+#
+# Trivy reference: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+EOF
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .trivyignore
+git -c commit.gpgsign=false commit -m "ci: add empty .trivyignore allowlist for image scanning"
+```
+
+---
+
+### Task 2: Add the `image-scan` job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (add new job after `build-and-push-images`)
+
+- [ ] **Step 1: Locate the end of `build-and-push-images`**
+
+Find the existing `build-and-push-images:` job (currently around line 896). Identify its last step. The new `image-scan:` job will be inserted as a new top-level job entry after it.
+
+- [ ] **Step 2: Insert the image-scan job**
+
+Add this new job at the same indentation level as `build-and-push-images` (i.e. as a sibling job under `jobs:`), positioned immediately after `build-and-push-images`:
+
+```yaml
+  image-scan:
+    name: Image Scan (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    needs: build-and-push-images
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: ingestion
+            image: ingestion
+            paths: services/ingestion services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: chat
+            image: chat
+            paths: services/chat services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: debug
+            image: debug
+            paths: services/debug services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: eval
+            image: eval
+            paths: services/eval services/shared .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-task-service
+            image: java-task-service
+            paths: java/task-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-activity-service
+            image: java-activity-service
+            paths: java/activity-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-notification-service
+            image: java-notification-service
+            paths: java/notification-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: java-gateway-service
+            image: java-gateway-service
+            paths: java/gateway-service java/build.gradle java/settings.gradle .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-auth-service
+            image: go-auth-service
+            paths: go/auth-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-order-service
+            image: go-order-service
+            paths: go/order-service go/product-service go/cart-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-ai-service
+            image: go-ai-service
+            paths: go/ai-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-analytics-service
+            image: go-analytics-service
+            paths: go/analytics-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-product-service
+            image: go-product-service
+            paths: go/product-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-cart-service
+            image: go-cart-service
+            paths: go/cart-service go/product-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-payment-service
+            image: go-payment-service
+            paths: go/payment-service go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+          - service: go-order-projector
+            image: go-order-projector
+            paths: go/order-projector go/pkg go/go.work .github/workflows/ci.yml .github/actions/check-changes/action.yml .trivyignore
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - name: Check for changes
+        id: changes
+        uses: ./.github/actions/check-changes
+        with:
+          paths: ${{ matrix.paths }}
+
+      - name: Log in to GHCR
+        if: steps.changes.outputs.changed == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        if: steps.changes.outputs.changed == 'true'
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.sha }}
+          format: sarif
+          output: trivy-${{ matrix.service }}.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && steps.changes.outputs.changed == 'true'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.service }}.sarif
+          category: trivy-${{ matrix.service }}
+```
+
+The `paths:` per entry intentionally mirror the equivalent entries in `build-and-push-images`. If those drift in the future (e.g., a new path is added to a Go service in `build-and-push-images`), it must also be added here.
+
+- [ ] **Step 3: Validate YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+```
+
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: add Trivy image-scan job with SARIF upload"
+```
+
+---
+
+### Task 3: Wire `image-scan` into deploy jobs' `needs:`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (`deploy-qa` and `deploy-prod` jobs)
+
+- [ ] **Step 1: Update `deploy-qa` needs**
+
+Find the `deploy-qa:` job (currently around line 1100). Locate its `needs:` block and add `image-scan` to the list (preserve all existing entries).
+
+Example (the existing `needs:` block plus the new entry — your actual existing entries may differ; preserve them all):
+
+```yaml
+  deploy-qa:
+    name: Deploy QA
+    ...
+    needs:
+      - build-and-push-images
+      - image-scan      # NEW
+      # ... preserve all other existing needs entries
+```
+
+- [ ] **Step 2: Update `deploy-prod` needs**
+
+Find the `deploy-prod:` job (currently around line 1291). Same change — add `image-scan` to its `needs:` list, preserving everything else.
+
+- [ ] **Step 3: Validate YAML and commit**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+git add .github/workflows/ci.yml
+git -c commit.gpgsign=false commit -m "ci: gate deploys on image-scan job completion"
+```
+
+---
+
+### Task 4: Local pre-merge scan to surface findings
+
+**Files:** No file changes — risk mitigation only.
+
+- [ ] **Step 1: Confirm Trivy is installed locally**
+
+```bash
+which trivy || brew install trivy
+trivy --version
+```
+
+If Trivy isn't installed, run the brew install. If on Linux, follow https://aquasecurity.github.io/trivy/latest/getting-started/installation/.
+
+- [ ] **Step 2: Authenticate with GHCR**
+
+```bash
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u kabradshaw1 --password-stdin
+```
+
+(`GITHUB_TOKEN` here is a personal access token with `read:packages` scope — generate one if needed at https://github.com/settings/tokens.)
+
+- [ ] **Step 3: Pick a recent QA image to scan**
+
+```bash
+# Use the most recent image tag for any single service, e.g.:
+LATEST_TAG=$(gh api /users/kabradshaw1/packages/container/go-auth-service/versions --jq '.[0].metadata.container.tags[0]')
+echo "Latest tag: $LATEST_TAG"
+```
+
+- [ ] **Step 4: Scan it with the same flags CI will use**
+
+```bash
+trivy image \
+  --severity HIGH,CRITICAL \
+  --ignore-unfixed \
+  --ignorefile .trivyignore \
+  --exit-code 1 \
+  ghcr.io/kabradshaw1/go-auth-service:$LATEST_TAG
+```
+
+Expected outcomes:
+- **Exit 0:** No HIGH/CRITICAL findings. CI will pass on first run for this image.
+- **Exit 1 with findings listed:** Each finding is either a real CVE (open an issue or fix the dependency) or a false-positive / accepted-risk (add the CVE ID to `.trivyignore` with a justification comment).
+
+- [ ] **Step 5: Repeat for representative images from each language stack**
+
+Scan one Python service (e.g., `chat`), one Java service (e.g., `java-task-service`), and one Go service if the previous scans passed. The goal is to surface any baseline findings before merge so CI doesn't block the first deploy.
+
+- [ ] **Step 6: If findings exist, update `.trivyignore` with justifications**
+
+For each finding kept as accepted risk:
+
+```
+# CVE-XXXX-YYYY — <one-line justification, e.g., "openssl detected version is wrong on alpine 3.19, fixed on 3.20 — base-image upgrade tracked in #123">
+CVE-XXXX-YYYY
+```
+
+Commit any `.trivyignore` updates as part of this PR before merging:
+
+```bash
+git add .trivyignore
+git -c commit.gpgsign=false commit -m "ci: pre-populate .trivyignore with acknowledged baseline CVEs"
+```
+
+If no findings exist, the `.trivyignore` stays empty — this task is satisfied.
+
+---
+
+### Task 5: Push and PR
+
+**Files:** No file changes.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin agent/feat-ci-image-scanning
+```
+
+(Or whichever branch name the worktree uses.)
+
+- [ ] **Step 2: Open the PR against qa**
+
+```bash
+gh pr create --base qa --title "ci: add Trivy image vulnerability scanning" --body "$(cat <<'EOF'
+## Summary
+Adds a `image-scan` job that scans every freshly-built GHCR image with Trivy, blocking deploys when HIGH or CRITICAL CVEs are found. Findings upload to the GitHub Security tab as SARIF. The same `.github/actions/check-changes` composite action gates the matrix so unchanged services skip the scan.
+
+Spec: docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md (Initiative B)
+Plan: docs/superpowers/plans/2026-04-27-ci-hardening-B-image-scanning.md
+
+## Configuration
+- Severity threshold: HIGH, CRITICAL fail the build; MEDIUM/LOW reported only
+- `ignore-unfixed: true` — CVEs without an upstream fix don't block (can't be acted on)
+- `.trivyignore` is the only escape hatch for acknowledged findings; entries require justification comments
+
+## Pre-merge verification
+A local Trivy scan was run against representative images from each language stack to surface baseline findings before this PR opens. Any unavoidable acknowledged-risk CVEs are pre-populated in `.trivyignore` with justifications.
+
+## Test plan
+- [ ] After merge, push a Go-service code change and verify only that service's image-scan runs
+- [ ] Check the Security tab on the qa branch for SARIF results from the run
+- [ ] Verify deploy-qa shows `image-scan` as a dependency in the workflow graph
+- [ ] If a deliberate test CVE is introduced (e.g., pin a vulnerable base image), the deploy is blocked
+EOF
+)"
+```
+
+- [ ] **Step 3: Notify Kyle**
+
+Tell Kyle the PR is open. Note in the comment any pre-populated `.trivyignore` entries so they aren't silently merged. Do not watch CI.
+
+## Self-Review
+
+### Spec coverage check (Initiative B acceptance criteria)
+
+| Spec criterion | Plan task |
+| --- | --- |
+| New high-severity CVE fails the deploy on next build | Task 2 (`exit-code: '1'` on HIGH/CRITICAL) + Task 3 (deploy `needs:` extended) |
+| Findings appear under repository Security tab | Task 2 (SARIF upload step) |
+| `.trivyignore` is the only dismissal path | Task 1 (file) + Task 2 (`trivyignores:` flag points at it) |
+| Unchanged services skip the scan | Task 2 (composite action gating, mirrored paths) |
+
+No gaps detected.
+
+### Placeholder scan
+
+No "TBD"/"TODO" content. Task 4's "if findings exist, update `.trivyignore`" is a documented escape hatch with explicit justification format, not a placeholder.
+
+### Type / identifier consistency
+
+- Service names match `build-and-push-images` matrix exactly (cross-checked entry by entry).
+- `image-scan` referenced consistently in deploy `needs:` updates.
+- `trivyignores:` (plural) is the trivy-action input name — verified against the action's documentation.

--- a/docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md
+++ b/docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md
@@ -1,0 +1,345 @@
+# CI Hardening — Initiative C: Pre-commit Hook Backfill (Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `.pre-commit-config.yaml` so local hooks cover the same surface CI catches today: add bandit (Python SAST), hadolint (Dockerfile lint), and full Go service coverage. Add a `make install-pre-commit` target. Update `CLAUDE.md` to point new contributors at it.
+
+**Architecture:** Three additions to `.pre-commit-config.yaml`. New target in `Makefile`. Documentation update in `CLAUDE.md`. No CI workflow changes.
+
+**Tech Stack:** `pre-commit` framework, `bandit`, `hadolint`, `golangci-lint`.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` — Initiative C.
+
+**File structure:**
+
+| File | Status | Responsibility |
+| --- | --- | --- |
+| `.pre-commit-config.yaml` | Modify | Add bandit hook, hadolint hook, full Go service loop |
+| `Makefile` | Modify | Add `install-pre-commit` target |
+| `CLAUDE.md` | Modify | Document `make install-pre-commit` in Pre-commit Requirements section |
+
+---
+
+### Task 1: Add bandit hook for Python SAST
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Add the bandit hook**
+
+Read `.pre-commit-config.yaml` to see its current shape. Add this block at the top of the `repos:` list, immediately after the `gitleaks` repo entry (so secret detection runs first, then Python SAST, then formatting):
+
+```yaml
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+        files: ^services/
+```
+
+- [ ] **Step 2: Verify pyproject.toml exists at the repo root and configures bandit**
+
+```bash
+grep -A 5 '\[tool.bandit\]' pyproject.toml 2>/dev/null
+```
+
+If the output is empty (no `[tool.bandit]` section), the bandit hook will use defaults — that's fine for now. The hook still works; it just won't honor any per-project skip rules. If the existing CI bandit job uses a config file, mirror its config in `pyproject.toml` so local and CI behave identically. If there's no `pyproject.toml` at the repo root, create one with:
+
+```toml
+[tool.bandit]
+exclude_dirs = ["tests", "venv", ".venv"]
+```
+
+Skip this sub-step if `pyproject.toml` already exists with appropriate config.
+
+- [ ] **Step 3: Test the hook**
+
+```bash
+pre-commit run bandit --all-files
+```
+
+Expected: passes. If it fails on existing code, the failures are real findings that should be fixed inline (or excluded with `# nosec` comments on specific lines, with justifications). Do not bypass with `--no-verify`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .pre-commit-config.yaml pyproject.toml 2>/dev/null
+git -c commit.gpgsign=false commit -m "chore(pre-commit): add bandit Python SAST hook"
+```
+
+(`pyproject.toml` is included only if it was created/modified — `git add` will silently no-op if it doesn't exist.)
+
+---
+
+### Task 2: Add hadolint hook for Dockerfile lint
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Add the hadolint hook**
+
+Add this block to `.pre-commit-config.yaml` after the bandit entry from Task 1:
+
+```yaml
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        files: Dockerfile(\..+)?$
+```
+
+The regex matches `Dockerfile`, `Dockerfile.dev`, `Dockerfile.prod`, etc.
+
+- [ ] **Step 2: Test the hook**
+
+```bash
+pre-commit run hadolint --all-files
+```
+
+Expected: passes. If it fails on existing Dockerfiles, the failures are real findings — fix them inline. Common issues:
+- `DL3008`: pin apt package versions
+- `DL3009`: clean apt cache after install
+- `DL3018`: pin alpine package versions
+- `DL3025`: use JSON-array form for CMD/ENTRYPOINT
+
+If a finding is genuinely a false positive or unfixable in this context, add an inline ignore comment in the Dockerfile:
+
+```dockerfile
+# hadolint ignore=DL3008
+RUN apt-get install -y curl
+```
+
+Do not bypass globally.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git -c commit.gpgsign=false commit -m "chore(pre-commit): add hadolint Dockerfile lint hook"
+```
+
+If any Dockerfiles were edited to fix findings, also stage them:
+
+```bash
+git add <Dockerfile path>
+git -c commit.gpgsign=false commit --amend --no-edit
+```
+
+(Amend allowed here only because the previous commit is unpushed and entirely about the same change. If pushed already, instead create a new commit.)
+
+---
+
+### Task 3: Replace the partial go-lint hook with full service coverage
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Read the current go-lint entry**
+
+The existing entry hardcodes `auth-service` and `order-service` only. The full service list is `auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector`.
+
+- [ ] **Step 2: Replace the existing go-lint local hook**
+
+Find the existing `id: go-lint` entry under the `- repo: local` block. Replace its `entry:` field with a loop over all 8 services:
+
+```yaml
+      - id: go-lint
+        name: Go Lint (all services)
+        entry: bash -c 'set -e; for svc in auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector; do echo "--- $svc ---"; (cd "go/$svc" && ~/go/bin/golangci-lint run ./...); done'
+        language: system
+        files: ^go/.*\.go$
+        pass_filenames: false
+```
+
+Keep the rest of the entry (`name`, `language`, `files`, `pass_filenames`) unchanged.
+
+- [ ] **Step 3: Test the hook**
+
+```bash
+pre-commit run go-lint --all-files
+```
+
+Expected: passes. If it fails on previously-uncovered services (`ai-service`, `analytics-service`, `product-service`, `cart-service`, `payment-service`, `order-projector`), the failures are real lint findings that should be fixed before this PR merges. The CI Go lint matrix already passes (per PR #164 work), so any failures here would be lint rules that were enforced in CI but not locally — fix them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git -c commit.gpgsign=false commit -m "chore(pre-commit): expand go-lint to all 8 services"
+```
+
+If any Go source files were edited to fix lint findings, stage and amend (same caveat as Task 2 — only if previous commit is unpushed):
+
+```bash
+git add go/
+git -c commit.gpgsign=false commit --amend --no-edit
+```
+
+---
+
+### Task 4: Add `make install-pre-commit` target
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Locate the `.PHONY` declaration**
+
+Read `Makefile` and find the existing `.PHONY:` declaration line. Verify the existing target list (the Bash tool's `head` output already showed `preflight preflight-python preflight-frontend preflight-e2e preflight-java preflight-java-integration preflight-go preflight-go-integration preflight-go-migrations preflight-security preflight-compose-config preflight-ai-service preflight-ai-service-evals grafana-sync grafana-sync-check worktree-cleanup`).
+
+- [ ] **Step 2: Add `install-pre-commit` to `.PHONY`**
+
+Append `install-pre-commit` to the `.PHONY:` list (one space-separated word).
+
+- [ ] **Step 3: Add the target body**
+
+Add this target near related developer tooling targets (the file likely has a section for setup/install — if not, append at the end):
+
+```makefile
+# --- Developer setup ---
+.PHONY: install-pre-commit
+install-pre-commit:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Install pre-commit first: pip install pre-commit"; exit 1; }
+	pre-commit install --install-hooks
+	pre-commit install --hook-type pre-push --install-hooks
+	@echo "✅ pre-commit hooks installed (commit + pre-push stages)"
+```
+
+(Note: if `.PHONY: install-pre-commit` already appears in the consolidated `.PHONY:` line at the top, you can drop the duplicate inline `.PHONY:` declaration above the target body. Keep one or the other, not both.)
+
+- [ ] **Step 4: Verify the target runs**
+
+```bash
+make install-pre-commit
+```
+
+Expected: succeeds. If `pre-commit` isn't on `PATH`, the target's first line tells you to install it. The hooks should now be active in `.git/hooks/pre-commit` and `.git/hooks/pre-push`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile
+git -c commit.gpgsign=false commit -m "chore(make): add install-pre-commit target"
+```
+
+---
+
+### Task 5: Update `CLAUDE.md` with the install instruction
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Find the "Pre-commit Requirements" section**
+
+Open `CLAUDE.md`. Locate the heading `## Pre-commit Requirements`. The section currently lists `make preflight-*` commands.
+
+- [ ] **Step 2: Add a new top sub-section about local hook installation**
+
+Insert this block immediately after the `## Pre-commit Requirements` heading (before the existing list):
+
+```markdown
+**First-time setup:** New clones must install the pre-commit hook framework once:
+
+```bash
+make install-pre-commit
+```
+
+This installs both commit-stage hooks (gitleaks, ruff, bandit, hadolint, java-checkstyle, frontend tsc/lint, go-lint) and pre-push-stage hooks (frontend `next build`). After this, every commit triggers the relevant subset based on what files changed.
+
+```
+
+(The trailing blank line + existing content stays.)
+
+- [ ] **Step 3: Sanity-check the markdown renders**
+
+```bash
+grep -A 10 "## Pre-commit Requirements" CLAUDE.md | head -15
+```
+
+Expected: shows the new "First-time setup" block followed by the original content.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git -c commit.gpgsign=false commit -m "docs: document make install-pre-commit in CLAUDE.md"
+```
+
+---
+
+### Task 6: Final preflight + push + PR
+
+**Files:** No file changes.
+
+- [ ] **Step 1: Run the full pre-commit suite to confirm everything passes**
+
+```bash
+pre-commit run --all-files
+```
+
+Expected: every hook either passes or reports "(no files to check) Skipped". No FAILED entries. If anything fails, fix the underlying issue before pushing.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin agent/feat-ci-precommit-backfill
+```
+
+(Or whichever branch name the worktree uses.)
+
+- [ ] **Step 3: Open the PR against qa**
+
+```bash
+gh pr create --base qa --title "ci: backfill pre-commit hooks to match CI coverage" --body "$(cat <<'EOF'
+## Summary
+Extends `.pre-commit-config.yaml` so local hooks cover the same surface CI catches today:
+- Adds bandit (Python SAST) — mirrors the CI `security-bandit` job
+- Adds hadolint (Dockerfile lint) — mirrors the CI `security-hadolint` matrix
+- Replaces the partial 2-service go-lint with full 8-service coverage
+
+Adds `make install-pre-commit` for first-time setup. Documents in CLAUDE.md.
+
+Spec: docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md (Initiative C)
+Plan: docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md
+
+## Risk
+Pre-commit hooks run locally on developer machines — no CI workflow changes. CI continues to act as the safety net. The only failure mode is a developer needing to fix a finding that previously was caught only in CI; that's the desired behavior.
+
+## Test plan
+- [ ] On a fresh clone: `make install-pre-commit` succeeds and installs both stages
+- [ ] `pre-commit run --all-files` passes on a clean main
+- [ ] Modifying a Python file with a hardcoded password fails the bandit hook locally
+- [ ] Modifying a Dockerfile with a `latest` tag fails the hadolint hook locally
+- [ ] Modifying a Go file in `payment-service` fails locally if it has lint issues (was previously CI-only)
+EOF
+)"
+```
+
+- [ ] **Step 4: Notify Kyle**
+
+Tell Kyle the PR is open. Do not watch CI.
+
+## Self-Review
+
+### Spec coverage check (Initiative C acceptance criteria)
+
+| Spec criterion | Plan task |
+| --- | --- |
+| `pre-commit run --all-files` passes on a clean main | Task 6 Step 1 (verification) |
+| Hardcoded password caught locally | Task 1 (bandit) |
+| Dockerfile with `latest` tag fails locally | Task 2 (hadolint) |
+| Lint error in `go/payment-service` caught locally | Task 3 (full service loop) |
+| `make install-pre-commit` is one-liner for new clone | Task 4 |
+
+No gaps detected.
+
+### Placeholder scan
+
+No "TBD"/"TODO" content. Task 1 Step 2's "skip if `pyproject.toml` exists" is conditional logic, not a placeholder. Task 2's "fix findings inline" lists the actual common rule codes the engineer will see.
+
+### Type / identifier consistency
+
+- Hook IDs (`bandit`, `hadolint`, `go-lint`) match the upstream tool's `id:` exactly.
+- Service list in Task 3 matches the spec's stated 8-service list.
+- `pre-commit run <hook-id>` calls match registered IDs.

--- a/docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md
@@ -1,0 +1,346 @@
+# CI/CD Pipeline Hardening
+
+- **Date:** 2026-04-27
+- **Status:** Approved
+- **Spec marker:** `ci-pipeline-hardening-design`
+
+## Context
+
+The CI/CD pipeline (`.github/workflows/ci.yml`, currently 1,567 lines) handles all quality gates and deployment for the portfolio. PR #164 introduced a composite action `./.github/actions/check-changes` that resolves an exact compare base from `github.event.before` (push) or `github.event.pull_request.base.sha` (PR), with `HEAD~5` as a fallback. That action was wired into three jobs: `build-and-push-images`, `go-tests`, and `go-lint`.
+
+The same overshoot still affects ten other matrix or always-on jobs. Three independent improvements close the remaining gaps:
+
+1. **Extend the composite action** to the rest of the matrix and always-on jobs that should be path-gated.
+2. **Add container image vulnerability scanning** between build and deploy. The pipeline currently lints Dockerfiles (`hadolint`) and audits source dependencies (`pip-audit`, `npm audit`) but never scans the *built* images for CVEs in OS packages or transitive dependencies that don't appear in lockfiles.
+3. **Backfill pre-commit hooks** so the local "shift-left" framework catches the issues CI catches today, not a strict subset of them. Currently pre-commit lints Python via ruff, lints partial Go (auth + order only), runs Java checkstyle, and runs frontend tsc/lint/build — but misses bandit, hadolint, and 5 of 7 Go services.
+
+These three initiatives are thematically related (CI hardening) but independently shippable. This spec covers the design for all three; implementation will land as three separate PRs.
+
+## Goals
+
+- A docs-only or single-stack push completes CI faster by skipping unrelated matrix entries.
+- Built images are vulnerability-scanned before they reach QA or production.
+- Local pre-commit hooks cover the same surface as CI for the cheap, fast checks (lint, SAST, style).
+
+## Non-goals
+
+- No new orchestration platforms or CI providers.
+- No reusable workflow refactor for `compose-smoke-*` or `build-and-push-images` (mentioned as "lower ROI" in the audit; out of scope here).
+- No additional security tooling beyond image scanning (no Snyk, no CodeQL, no SBOM generation, no license scanning).
+- No changes to deploy steps, smoke tests, or Cloudflare/Vercel integration.
+- No changes to which services exist in which matrix (`payment-service` not being in `go-tests` / `go-lint` is flagged elsewhere as a separate item).
+
+## Initiative A — Extend change-detection composite action
+
+### Scope
+
+Apply `./.github/actions/check-changes` (already shipped in PR #164) to eleven more jobs that currently run unconditionally on every push:
+
+| Job | Per-entry path strategy |
+| --- | --- |
+| `python-tests` (matrix of 4) | `services/<name>` + `services/shared` |
+| `security-pip-audit` (matrix of 4) | `services/<name>` + `services/shared` |
+| `java-unit-tests` (matrix of 4) | `java/<service>` + `java/build.gradle` + `java/settings.gradle` |
+| `java-integration-tests` (single job) | `java/**` |
+| `frontend-checks` | `frontend/**` |
+| `compose-smoke-python` | `services/**` + `docker-compose.yml` + nginx routing |
+| `compose-smoke-go` | `go/**` + Go compose file (if separate) |
+| `compose-smoke-java` | `java/**` + Java compose file |
+| `k8s-validation` | `k8s/**` |
+| `go-migration-test` | `go/*/migrations/**` + relevant migration tooling |
+| `security-hadolint` (matrix per Dockerfile) | the specific Dockerfile path |
+
+`grafana-dashboard-sync`, `python-lint`, `java-lint`, `buf-breaking`, `security-bandit`, `security-npm-audit`, `security-gitleaks`, `security-cors-guardrail` are deliberately left **always-on** — they are either fast (sub-30s), specifically gated by content type already (e.g. `buf-breaking` runs `git diff` for proto changes inline), or perform repo-wide checks where path-gating would create a false sense of safety (e.g. gitleaks must scan whatever is being pushed regardless of which subtree it touches).
+
+### Pattern
+
+Each gated job converts its matrix to use `include:` with explicit `paths:` per entry, mirroring the existing `build-and-push-images` style:
+
+```yaml
+strategy:
+  matrix:
+    include:
+      - service: ingestion
+        paths: services/ingestion services/shared
+      - service: chat
+        paths: services/chat services/shared
+      ...
+```
+
+Each gated job adds a `Check for changes` step using the composite action and conditions all subsequent steps on `if: steps.changes.outputs.changed == 'true'`.
+
+`fetch-depth: 50` is required on the checkout so the PR base / push before SHA is reachable in the shallow clone.
+
+### Workflow-file safeguard
+
+A change to `.github/workflows/ci.yml` or anything under `.github/actions/**` should trigger **every** matrix entry to run, not skip them. Without this safeguard a refactor to the workflow could ship without exercising the matrix paths it altered.
+
+The `paths` for every gated entry is therefore extended to include `.github/workflows/ci.yml .github/actions/**`. This is a small, mechanical addition per entry and makes pipeline-validation runs explicit.
+
+### Path-set discipline
+
+For each gated job, the `paths` value must encompass:
+1. The service's own source tree
+2. Any shared libraries the service imports (`services/shared`, `go/pkg`, `java/build.gradle`, etc.)
+3. The workflow safeguard paths (`.github/workflows/ci.yml`, `.github/actions/**`)
+
+Every entry in `python-tests` and `security-pip-audit` for the same service uses the **identical** paths. Drift between sibling matrices is the failure mode that ADR 07 was originally trying to prevent — same path-set per service across all gated jobs avoids it.
+
+### Acceptance criteria
+
+- Pushing a docs-only commit shows all ten gated jobs as green with their main steps skipped (matrix instances themselves stay green; downstream `needs:` consumers are not blocked).
+- Pushing a Python-only commit (e.g. `services/chat/...`) skips Java unit tests, frontend checks, k8s validation, Go migration test, compose-smoke-go, and compose-smoke-java.
+- Editing `.github/workflows/ci.yml` triggers every matrix entry, regardless of which application paths were touched.
+- A change to `services/shared` triggers every Python service's tests, pip-audit, and the Python compose smoke (because every service entry includes `services/shared`).
+- Composite action invocation is identical to PR #164 — same inputs, same outputs.
+
+## Initiative B — Container image vulnerability scanning
+
+### Tool selection
+
+**Trivy** via `aquasecurity/trivy-action`. Reasons:
+
+- Most-adopted OSS scanner; broad CVE database (NVD, GitHub Advisory, OS-specific feeds).
+- First-party GHA action; mature, actively maintained.
+- Native SARIF output that uploads to GitHub Security tab via `github/codeql-action/upload-sarif`, so findings appear on PRs without separate UI.
+- Faster than Grype on equivalent scans; comparable accuracy.
+- No vendor account, no licence, no API key — runs entirely in-action.
+
+**Rejected alternatives:**
+
+- **Grype** (Anchore): comparable feature set, slightly slower, smaller community.
+- **Snyk Container**: requires account + token, free tier rate-limited, vendor lock-in for advisory data.
+- **Docker Scout**: tied to Docker Hub authentication patterns, less ergonomic for GHCR.
+
+### Pipeline placement
+
+A new job `image-scan` runs **after** `build-and-push-images` and **before** `deploy-qa` / `deploy-prod`. It scans the freshly-pushed GHCR image (not the source tree), gated by the same `check-changes` composite action used by `build-and-push-images` so unchanged services skip the scan too.
+
+```yaml
+image-scan:
+  name: Image Scan (${{ matrix.service }})
+  runs-on: ubuntu-latest
+  needs: build-and-push-images
+  permissions:
+    contents: read
+    packages: read
+    security-events: write   # required for SARIF upload
+  strategy:
+    fail-fast: false
+    matrix:
+      include:
+        # Same matrix as build-and-push-images; reuse via YAML anchor or duplicate.
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 50
+    - name: Check for changes
+      id: changes
+      uses: ./.github/actions/check-changes
+      with:
+        paths: ${{ matrix.paths }}
+    - name: Log in to GHCR
+      if: steps.changes.outputs.changed == 'true'
+      ...
+    - name: Run Trivy
+      if: steps.changes.outputs.changed == 'true'
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ github.sha }}
+        format: sarif
+        output: trivy-${{ matrix.service }}.sarif
+        severity: HIGH,CRITICAL
+        exit-code: '1'
+        ignore-unfixed: true
+        trivyignores: .trivyignore
+    - name: Upload SARIF
+      if: always() && steps.changes.outputs.changed == 'true'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: trivy-${{ matrix.service }}.sarif
+        category: trivy-${{ matrix.service }}
+```
+
+The deploy jobs (`deploy-qa`, `deploy-prod`) extend their `needs:` array to include `image-scan`. If the scan fails, deploys do not run.
+
+### Severity policy
+
+- **CRITICAL, HIGH** → fail the build (`exit-code: '1'`)
+- **MEDIUM, LOW, UNKNOWN** → reported in SARIF output but do not fail
+- **`ignore-unfixed: true`** → CVEs without an upstream patch are noise; an unfixable HIGH in a base-image library can't be acted on, so don't block on them
+
+### Allowlist mechanism
+
+A `.trivyignore` file at the repo root holds known acknowledged CVEs. Each entry is one CVE ID with a comment explaining why it's ignored:
+
+```
+# .trivyignore
+# CVE-XXXX-YYYY — false positive, openssl version detected by trivy is wrong (#issue-link)
+CVE-XXXX-YYYY
+# CVE-AAAA-BBBB — accepted risk, only triggered by configurable feature we don't use
+CVE-AAAA-BBBB
+```
+
+Adding a CVE to `.trivyignore` is a code change, reviewed in PR. There is no other path to dismissing a finding.
+
+### Concurrency / cost
+
+The matrix runs in parallel; per-image scan time is 30-90s. Total wall-clock added to the pipeline is bounded by the slowest single image scan, not the cumulative time. Skipped (unchanged) services don't add anything.
+
+### Acceptance criteria
+
+- A new high-severity CVE in any built image fails the deploy on the next build.
+- Findings appear under the repository's Security tab, scoped per service.
+- Adding a CVE to `.trivyignore` with a justification comment unblocks the build without code changes elsewhere.
+- Running on an unchanged service shows the scan job as green-with-skipped, not failed.
+
+## Initiative C — Pre-commit hook backfill
+
+### Current state
+
+`.pre-commit-config.yaml` defines:
+- `gitleaks` (secrets) — repo-wide
+- `ruff` + `ruff-format` — `services/**`
+- `java-checkstyle` — `java/**/*.java`
+- `frontend-typecheck` (`tsc --noEmit`) — `frontend/**/*.{ts,tsx}`
+- `frontend-lint` (`npm run lint`) — `frontend/**/*.{ts,tsx,js,jsx}`
+- `frontend-build` (`next build`) — pre-push only
+- `go-lint` — only `auth-service` and `order-service` (5 services missing)
+
+### Add
+
+#### bandit (Python SAST)
+
+```yaml
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.9
+  hooks:
+    - id: bandit
+      args: ["-c", "pyproject.toml"]
+      additional_dependencies: ["bandit[toml]"]
+      files: ^services/
+```
+
+Mirrors the CI `security-bandit` job. Bandit is fast (sub-5s on this repo's surface) and catches Python anti-patterns before CI does.
+
+#### hadolint (Dockerfile lint)
+
+```yaml
+- repo: https://github.com/hadolint/hadolint
+  rev: v2.12.0
+  hooks:
+    - id: hadolint
+      files: Dockerfile(\..+)?$
+```
+
+Mirrors the CI `security-hadolint` matrix. Catches Dockerfile issues (latest tag, missing USER, etc.) at commit time.
+
+#### Full go-lint coverage
+
+Replace the existing hardcoded `auth-service + order-service` entry with one entry per Go service. Loop pattern in the local hook:
+
+```yaml
+- id: go-lint
+  name: Go Lint (all services)
+  entry: bash -c 'set -e; for svc in auth-service order-service ai-service analytics-service product-service cart-service payment-service order-projector; do
+    echo "--- $svc ---"
+    (cd "go/$svc" && ~/go/bin/golangci-lint run ./...)
+  done'
+  language: system
+  files: ^go/.*\.go$
+  pass_filenames: false
+```
+
+Note `payment-service` is included even though it's missing from CI's `go-tests` / `go-lint` matrices — covering it locally costs nothing and surfaces issues earlier.
+
+### Don't add
+
+- **pip-audit / npm audit** — network-dependent, slow (10-60s), gated to CI.
+- **trivy** — scans built images, not source. CI-only.
+- **prettier** for frontend — `eslint-config-next` already covers formatting; adding prettier would create dual-source-of-truth.
+
+### Onboarding
+
+Add a Make target so new contributors install the hooks once:
+
+```makefile
+.PHONY: install-pre-commit
+install-pre-commit:
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Install pre-commit first: pip install pre-commit"; exit 1; }
+	pre-commit install --install-hooks
+	pre-commit install --hook-type pre-push --install-hooks
+	@echo "✅ pre-commit hooks installed (commit + pre-push stages)"
+```
+
+Document in `CLAUDE.md` under "Pre-commit Requirements" section.
+
+### Acceptance criteria
+
+- `pre-commit run --all-files` passes on a clean main branch.
+- Adding a hardcoded password to a Python file is caught locally, not in CI.
+- A Dockerfile change with a `latest` tag fails locally.
+- A lint error in `go/payment-service` is caught locally.
+- `make install-pre-commit` is a one-liner for a new clone.
+
+## Implementation phasing
+
+Three independent PRs against `qa`. Order doesn't matter; each is shippable on its own.
+
+### PR 1 — Initiative A (composite action expansion)
+
+- Convert ten matrices to `include:` with `paths:` entries
+- Add `Check for changes` step + `if:` gates per job
+- Bump `fetch-depth: 50` on each affected checkout
+- Touches only `.github/workflows/ci.yml`
+- Risk: low (mechanical change, same pattern as PR #164)
+
+### PR 2 — Initiative B (image scanning)
+
+- Add `image-scan` job with Trivy + SARIF upload
+- Wire `image-scan` into `needs:` for `deploy-qa` and `deploy-prod`
+- Add empty `.trivyignore` with comment header explaining the format
+- Touches `.github/workflows/ci.yml` and creates `.trivyignore`
+- Risk: medium (new job; first run will surface previously-invisible CVEs and may immediately need entries in `.trivyignore` before merging — implementation will run the scan locally first to surface findings)
+
+### PR 3 — Initiative C (pre-commit backfill)
+
+- Update `.pre-commit-config.yaml` with bandit, hadolint, full go-lint
+- Add `make install-pre-commit` target to `Makefile`
+- Update `CLAUDE.md` "Pre-commit Requirements" section
+- Touches `.pre-commit-config.yaml`, `Makefile`, `CLAUDE.md`
+- Risk: low (developer tooling only — CI is unaffected)
+
+## Documentation
+
+Single ADR `docs/adr/ci-cd-pipeline-evolution.md` records the design decisions: change-detection compare-base strategy, image-scan policy, and the local-vs-CI split for security tooling. Written after all three PRs land, so it reflects the final state.
+
+`CLAUDE.md` updated in PR 3 to include:
+- The new `image-scan` job in the CI/CD pipeline table
+- `make install-pre-commit` in the "Pre-commit Requirements" section
+- Note that pushing a docs-only commit will skip most matrix jobs (so the user knows the green-with-skipped state is normal)
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Path-set drift between sibling matrices (e.g. `python-tests` and `security-pip-audit` for the same service) | Identical `paths:` value reused per service across all gated jobs. Spec-level rule. |
+| Workflow refactor accidentally breaks change-detection without exercising the changed matrices | Workflow path safeguard: every gated entry includes `.github/workflows/ci.yml .github/actions/**` so a CI change re-runs everything. |
+| First Trivy run reveals undismissable CRITICAL CVEs that block deploy | Run scan locally before merging PR 2. Pre-populate `.trivyignore` with any acknowledged-and-justified findings. Open issues for fixable findings before merging. |
+| `payment-service` is locally linted by pre-commit but not CI-tested | Documented as known gap (separate spec). Pre-commit catch-rate is best-effort, not a substitute for CI. |
+| Hadolint findings on existing Dockerfiles fail pre-commit on first install | Run `pre-commit run hadolint --all-files` locally as part of PR 3, fix findings inline. |
+
+## Out of scope (deliberately)
+
+- Reusable workflows for `compose-smoke-*` (lower-ROI cleanup, not blocking anything).
+- `payment-service` addition to `go-tests` / `go-lint` matrices (correctness, not speed; separate spec).
+- Path filtering for `python-lint`, `java-lint`, `security-bandit`, `security-npm-audit`, `security-gitleaks`, `security-cors-guardrail`, `grafana-dashboard-sync`, `buf-breaking` — fast or repo-wide, gating buys little.
+- SBOM generation, license scanning, supply-chain attestation (Sigstore / cosign).
+- CodeQL or other deep SAST.
+- Per-PR vulnerability comments (Trivy's SARIF output already surfaces in the Security tab and PR checks).
+
+## Acceptance criteria summary (cross-cutting)
+
+- A docs-only push on `qa` finishes CI in noticeably less time (target: most matrix jobs green-with-skipped, only repo-wide checks running).
+- A Python-only PR doesn't run Java unit tests, Go test/lint, k8s validation, or compose-smoke-go/-java.
+- New CVEs in built images fail the deploy with allowlist as the only escape hatch.
+- A new contributor can clone, run `make install-pre-commit`, and commit with full local lint coverage.

--- a/docs/superpowers/specs/2026-04-27-migration-lint-design.md
+++ b/docs/superpowers/specs/2026-04-27-migration-lint-design.md
@@ -1,0 +1,229 @@
+# Design: PostgreSQL Migration Linter & Safe-Migration Playbook
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Roadmap position:** Item 2 of 10 in the `db-roadmap` GitHub label
+- **GitHub issue:** [#156 — Online migration patterns + safe-migration lint](https://github.com/kabradshaw1/portfolio/issues/156)
+- **Builds on:**
+  - `go/Makefile` `preflight-go-migrations` target (existing)
+  - `golang-migrate` setup across all Go services
+  - `docs/adr/ecommerce/go-sql-optimization-reporting.md` (the partitioning migration that taught the project why migration safety matters)
+
+## Context
+
+Every Go service uses `golang-migrate` with `NNN_name.up.sql` / `NNN_name.down.sql` pairs. Migrations run as K8s Jobs on every deploy. The project already has a Makefile target (`make preflight-go-migrations`) that spins up Postgres in Docker and runs the migrations end-to-end — that catches *syntactic* failures.
+
+What it doesn't catch is *operationally unsafe* migrations: ones that compile and run fine on an empty database but would lock a busy production table for minutes, rewrite millions of rows during DDL, or cause cascading replica lag. These patterns are the single most common backend-interview topic ("how do you add a NOT NULL column to a 100M-row table without downtime?") and the single most common cause of preventable production incidents.
+
+The partitioning migration in 2026-04-22 surfaced this directly — three CI failures from index name collisions and FK constraints on a partitioned table, only caught because the migration ran end-to-end against real Postgres. The right next step is to push the safety check earlier in the pipeline: detect unsafe patterns at lint time, before they ever reach Postgres.
+
+## Goals
+
+- Detect unsafe migration patterns at lint time, not at Postgres runtime.
+- Encode *which* patterns are unsafe (and why) in checked-in Go code that anyone can read and reason about.
+- Provide a written playbook of the safe alternatives — not just "the linter said no" but "here's the multi-step recipe."
+- Integrate with `make preflight-go-migrations` so unsafe patterns fail CI.
+- Demonstrate the safe pattern with a real migration in the codebase.
+
+## Non-goals
+
+- Linting Java migrations (Spring/JPA owns the schema; no DDL files to lint).
+- Reaching `squawk` parity on rule count — we want a curated, well-documented set, not exhaustive coverage.
+- Replacing or duplicating the existing `make preflight-go-migrations` runtime checks. Both layers stay.
+- Atlas / pg-osc-style online migration tooling — overkill at portfolio scale.
+- Linting CREATE TABLE on first-migration-of-a-service files — those run against an empty schema and the patterns that are unsafe on existing tables are fine here.
+
+## Architecture
+
+```
+go/cmd/migration-lint/
+├── main.go                  CLI entry — globs migrations, applies rules, exits non-zero on errors
+└── lint/
+    ├── lint.go              Lint(files []string) ([]Violation, error)
+    ├── rule.go              Rule interface, Violation struct, Severity enum
+    ├── parser.go            thin wrapper around pganalyze/pg_query_go for parsing + statement walking
+    ├── ignore.go            parses `-- migration-lint: ignore=MIG00X reason="…"` directives from comments
+    └── rules/
+        ├── mig001_concurrent_index.go     CREATE INDEX without CONCURRENTLY on existing table
+        ├── mig002_nonnull_default.go      ALTER TABLE … ADD COLUMN … NOT NULL DEFAULT (non-static)
+        ├── mig003_alter_column_type.go    ALTER COLUMN TYPE causing table rewrite
+        ├── mig004_check_not_valid.go      ADD CONSTRAINT … CHECK without NOT VALID
+        ├── mig005_drop_column.go          DROP COLUMN — require explicit confirm directive
+        ├── mig006_rename_column.go        RENAME COLUMN — require explicit confirm directive
+        ├── mig007_concurrent_in_tx.go     CONCURRENTLY mixed with other DDL in the same file
+        └── mig008_lock_table.go           LOCK TABLE — require documented purpose
+```
+
+The linter is a single Go binary that takes a list of `.sql` files (or a glob) and prints findings. Exit codes: `0` clean, `1` error-severity violation, `2` parse failure or invocation error.
+
+Why CGO via `pg_query_go`? Postgres SQL is genuinely hard to parse — multi-line statements, dollar-quoted strings, comment placement, complex expressions. Regex linters fall over on real-world migrations. `pganalyze/pg_query_go` wraps `libpg_query`, which is *the* Postgres parser extracted from the server source. It's the only correct way to walk the statement tree. The CGO dep is acceptable; the linter is a developer-tool binary, not a runtime dependency.
+
+## Rule design
+
+Every rule implements:
+
+```go
+type Rule interface {
+    ID() string                                              // e.g., "MIG001"
+    Description() string                                      // human-readable purpose
+    Severity() Severity                                       // Error | Warning
+    Check(stmt *pg_query.RawStmt, ctx *FileContext) []Violation
+}
+```
+
+`FileContext` carries: the filename, line offsets for accurate error reporting, statements seen earlier in the same file (so MIG001 can know whether `CREATE INDEX` targets a table created by an earlier `CREATE TABLE` in the same migration), and the file's parsed ignore directives.
+
+### MIG001 — `CREATE INDEX` without `CONCURRENTLY` on an existing table
+
+`CREATE INDEX` takes an `ACCESS EXCLUSIVE` lock on the table for the duration of the build. On a busy production table this can lock writers for minutes. `CREATE INDEX CONCURRENTLY` builds the index without blocking writes (slower but online).
+
+Heuristic for "existing table": if the file contains a `CREATE TABLE foo` earlier than the `CREATE INDEX … ON foo`, it's a same-migration index — allow non-CONCURRENT. Otherwise the table is presumed to exist in a prior migration → require `CONCURRENTLY`. (Heuristic is conservative — false positives are easy to silence with the ignore directive.)
+
+### MIG002 — `ADD COLUMN ... NOT NULL` with a non-constant default
+
+PG 11+ supports fast-path `ADD COLUMN ... NOT NULL DEFAULT <constant>` without a table rewrite. But a *volatile* default (`now()`, `uuid_generate_v4()`, a function call) still rewrites every row. Detect any non-constant default expression on a NOT NULL `ADD COLUMN`.
+
+### MIG003 — `ALTER COLUMN ... TYPE`
+
+Type changes generally rewrite every row unless the conversion is binary-compatible. The safe pattern is expand-and-contract (add new column → backfill → switch reads/writes → drop old). Always flag.
+
+### MIG004 — `ADD CONSTRAINT ... CHECK` without `NOT VALID`
+
+A plain `ADD CONSTRAINT … CHECK` scans the entire table to validate. The two-step pattern (`ADD … NOT VALID` → `VALIDATE CONSTRAINT`) avoids the long lock during the initial DDL.
+
+### MIG005 — `DROP COLUMN`
+
+Linters can't know whether the application has stopped using the column. Require an explicit per-statement directive: `-- migration-lint: ignore=MIG005 reason="app deploy 2026-05-01 stopped writing this column; verified empty in pg_stat_user_tables"`. Without that comment, the rule fails.
+
+### MIG006 — `RENAME COLUMN`
+
+In code-driven systems, a column rename is rarely safe in one shot — old code paths still reference the old name. Same opt-in directive pattern as MIG005.
+
+### MIG007 — `CREATE INDEX CONCURRENTLY` mixed with other statements
+
+`golang-migrate` wraps each migration in a transaction by default. `CREATE INDEX CONCURRENTLY` cannot run inside a transaction and will fail. The standard convention is one `CREATE INDEX CONCURRENTLY` statement per migration file, with no other statements. Detect: any file that contains both `CONCURRENTLY` and any other statement (CREATE TABLE, ALTER, INSERT, etc.).
+
+### MIG008 — `LOCK TABLE` without a documented purpose
+
+Explicit `LOCK TABLE` calls are rarely correct in migrations. Require an inline comment on the statement explaining why the lock is needed. Default severity: Warning (not Error) — there are legitimate uses, but each one should have its rationale checked in.
+
+## Ignore directives
+
+Single-line comments in migration files can opt out of specific rules:
+
+```sql
+-- migration-lint: ignore=MIG001 reason="initial table creation, table is empty"
+CREATE INDEX idx_users_email ON users (email);
+```
+
+The directive applies to the *next* SQL statement only. Multiple rules can be listed: `ignore=MIG001,MIG004`. The `reason="…"` is required — this is the senior-engineer convention: every exception checks in *why* it's safe.
+
+`pg_query_go` reports each statement's byte range in the source (`RawStmt.StmtLocation` / `StmtLen`); the ignore-directive parser scans the original SQL text for comment lines that fall immediately above each statement's range, so attribution is exact even when statements are interleaved.
+
+## Worked example: a new migration demonstrating the safe pattern
+
+Rather than rewriting historical migrations (`golang-migrate` tracks by number, not content — modifying an applied migration is unsafe), the spec ships a *new* migration in `go/product-service/migrations/` that adds a useful index using the safe pattern:
+
+```sql
+-- 004_add_product_search_index.up.sql
+-- See docs/runbooks/postgres-migrations.md (recipe 4) for why this pattern is required.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_products_name_trgm
+  ON products USING gin (name gin_trgm_ops);
+```
+
+The exact target table and index will be picked during implementation, but the requirements are: (a) addresses a real query path that benefits from the index, (b) the file contains exactly one `CREATE INDEX CONCURRENTLY` statement and nothing else, (c) the down migration drops the index with `IF EXISTS`.
+
+This proves the linter doesn't trip on the *correct* pattern, and the migration file itself becomes the canonical reference cited from the playbook.
+
+## Playbook content
+
+`docs/runbooks/postgres-migrations.md` — eight recipes, each section structured the same way:
+
+1. **What you want to do** (e.g., "Add a non-null column to a busy table")
+2. **The unsafe one-shot version** (the SQL that would lock prod)
+3. **Why it's unsafe** (one or two sentences on the failure mode)
+4. **The safe multi-step version** (one SQL block per migration file in the sequence, with `golang-migrate` numbering example)
+5. **Linter rule that catches the unsafe form** (e.g., MIG002)
+6. **Cross-references** (related ADRs, related rules)
+
+The eight recipes:
+
+| # | Title | Linter rule |
+|---|---|---|
+| 1 | Add a NOT NULL column | MIG002 |
+| 2 | Drop a column | MIG005 |
+| 3 | Rename a column (expand-and-contract) | MIG006 |
+| 4 | Add an index (`CONCURRENTLY` in its own file) | MIG001, MIG007 |
+| 5 | Add a CHECK constraint (`NOT VALID` + `VALIDATE`) | MIG004 |
+| 6 | Rename a table (`CREATE VIEW` compat shim) | — |
+| 7 | Change a column type (expand-and-contract) | MIG003 |
+| 8 | Partition an existing table | cross-references the partitioning ADR |
+
+## Integration with preflight
+
+`make preflight-go-migrations` currently:
+1. Spins up Postgres via Docker
+2. Runs `migrate up` for each Go service
+3. Verifies tables exist
+
+The new step runs *before* (1) — fast-fail before any container starts:
+
+```makefile
+preflight-go-migrations:
+	@cd go && go build -o /tmp/migration-lint ./cmd/migration-lint
+	@/tmp/migration-lint go/*/migrations/*.sql
+	@# (existing Postgres up + migrate up steps continue here)
+```
+
+The linter binary is built fresh each run from the worktree to avoid stale binaries.
+
+## Testing
+
+**Per-rule tests** in `go/cmd/migration-lint/lint/lint_test.go` (or one file per rule, sibling to the rule source). Each rule has at least three SQL fixtures:
+
+- A positive case (migration that should trigger the rule) → asserts violation reported with correct line/severity
+- A negative case (migration that should NOT trigger the rule) → asserts no violation
+- An ignore case (positive case with a `-- migration-lint: ignore=` directive) → asserts violation suppressed
+
+**Snapshot test** — run the linter against the entire `go/*/migrations/*.sql` tree as it stands after the worked-example refactor and assert zero violations. This becomes the regression net for future migrations.
+
+**Preflight integration test** — `make preflight-go-migrations` is the integration check; once the linter is wired in, any unsafe migration commit fails preflight.
+
+## Rollout
+
+Each step is an independently mergeable PR.
+
+1. Land the linter binary + rules + tests with no preflight wiring (zero blast radius).
+2. Run it locally over existing migrations, file an inventory of *current* violations and add ignore directives where safe (initial-empty-table cases).
+3. Wire into `make preflight-go-migrations` (this is the gate that enforces it going forward).
+4. Add the worked-example migration.
+5. Land the playbook.
+6. Land the companion ADR.
+
+## ADR
+
+A companion ADR will be written at `docs/adr/database/migration-lint.md` (new directory — no DB-specific ADR home currently exists; previous DB ADRs lived under `ecommerce/` and `infrastructure/` for historical reasons). The ADR documents:
+
+- Why custom Go over `squawk`/`atlas`/regex (the AST + portfolio narrative argument)
+- Rule selection criteria — why these eight, why not more
+- Ignore-directive design — why `reason="…"` is mandatory
+- The "no historical rewrites" decision and its implications for the worked example
+
+## Consequences
+
+**Positive:**
+- Unsafe migrations fail at lint time, before Docker spin-up or CI runtime.
+- The rule set becomes a checked-in answer to "which patterns are unsafe and why" — strong interview talking point.
+- The playbook covers eight scenarios any backend engineer will hit.
+- The worked-example migration leaves a real-world reference in the codebase.
+
+**Trade-offs:**
+- CGO build dep via `pg_query_go`. Acceptable — the linter is a developer tool, not runtime.
+- Curated rule set is narrower than `squawk`'s ~30 rules. Acceptable — depth over breadth, and additional rules can be added incrementally.
+- Heuristics (especially MIG001's "existing table" detection) will produce occasional false positives. The ignore-directive pattern handles these without weakening the rule.
+- Java migrations are not covered. Acceptable — Spring/JPA-managed schemas don't have DDL files to lint.
+
+**Phase 2 (future):**
+- Add `MIG009` — backfill detection (update statements that touch unbounded row counts).
+- Pre-commit hook that runs the linter on staged `.sql` files for faster feedback than `make preflight-go-migrations`.
+- IDE integration via a custom diagnostic LSP, if the linter sees enough use to justify it.

--- a/docs/superpowers/specs/2026-04-27-pg-query-observability-design.md
+++ b/docs/superpowers/specs/2026-04-27-pg-query-observability-design.md
@@ -1,0 +1,280 @@
+# Design: PostgreSQL Query Observability (`pg_stat_statements` + `auto_explain`)
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Roadmap position:** Item 1 of 10 in the `db-roadmap` GitHub label
+- **Related issues:** #155–#163 (db-roadmap items 2–10)
+- **Builds on:**
+  - `docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md` (postgres_exporter, dashboards, alerts)
+  - `docs/adr/ecommerce/go-database-optimization.md` (existing benchmarks)
+  - `docs/adr/ecommerce/go-sql-optimization-reporting.md` (CTEs, materialized views)
+
+## Context
+
+The shared PostgreSQL 17 instance hosts databases for every Go and Java service. The existing observability stack covers *system-level* health (connections, cache hit ratio overall, deadlocks, backup freshness) but has no view into individual *query* performance:
+
+- We don't know which queries are slow, called most often, or consume the most CPU.
+- We can't detect plan regressions when data shape changes.
+- We have no way to inspect actual execution plans for production traffic.
+- After running optimization work (batch INSERTs, CTEs, partitioning), we have no production-side proof that those queries are still fast.
+
+This is the measurement layer that any further database optimization or replication work needs as a foundation. It is also a baseline backend-engineer skill: "How do you find slow queries?" is one of the most commonly asked Postgres interview questions.
+
+## Goals
+
+- Identify the slowest queries (by mean and total exec time) in a live, browseable view.
+- Track per-query latency over time so plan regressions show up as Prometheus alerts.
+- Capture full `EXPLAIN ANALYZE` output for any query that exceeds 500ms, with the plan readable inline in Grafana.
+- Provide alerting that catches both hard latency ceilings and slow drifts.
+- Add no new infrastructure components — extend the existing observability stack.
+
+## Non-goals
+
+- Cluster-wide query views via `postgres_fdw` / `dblink` — per-database datasource is sufficient at current scale.
+- Statement-level CPU/IO accounting via `pg_stat_kcache` — out of scope.
+- Query rewriting recommendations (pgBadger, pganalyze) — paid/heavyweight tools, not justified here.
+- Production sampling tuning — `auto_explain.sample_rate = 1.0` is fine at portfolio scale.
+- Authoring queries that *use* the data (this is the measurement layer; optimization work it enables is tracked separately).
+
+## Architecture
+
+```
+Postgres (java-tasks namespace, single replica, Recreate strategy)
+├── pg_stat_statements    extension, in shared_preload_libraries
+├── auto_explain          extension, in shared_preload_libraries
+└── grafana_reader role   pg_monitor predefined role
+
+       │ (5432, in-pod)
+       ├──▶ postgres_exporter (existing sidecar) ──▶ Prometheus
+       │      • new pg_stat_statements queries in custom-queries ConfigMap
+       │      • exports top-50 queries: calls, mean, stddev, total, rows
+       │      • exports top-50 by IO: shared_blks_hit/read/dirtied
+       │
+       ├──▶ Grafana PostgreSQL data source ──▶ Grafana
+       │      • read-only via grafana_reader
+       │      • powers live "top slow queries" table panels
+       │      • per-DB datasource: productdb, orderdb, paymentdb
+       │
+       └──▶ Postgres logs ─▶ Promtail ─▶ Loki
+              • auto_explain writes JSON plans for queries > 500ms
+              • Grafana logs panel renders plans inline by queryid
+```
+
+Data flows through three independent paths: time-series metrics (Prometheus), live query inspection (Grafana PostgreSQL data source), and execution plans (Loki). Each is reversible on its own.
+
+## PostgreSQL configuration
+
+Set in the Postgres ConfigMap (`java/k8s/configmaps/postgres-config.yml`):
+
+```ini
+shared_preload_libraries = 'pg_stat_statements,auto_explain'
+
+# pg_stat_statements
+pg_stat_statements.max           = 5000
+pg_stat_statements.track         = top
+pg_stat_statements.track_utility = off
+
+# auto_explain
+auto_explain.log_min_duration = 500ms
+auto_explain.log_analyze      = true
+auto_explain.log_buffers      = true
+auto_explain.log_timing       = true
+auto_explain.log_format       = json
+auto_explain.sample_rate      = 1.0
+```
+
+**Restart implication:** changing `shared_preload_libraries` requires restarting Postgres. The existing `Recreate` deployment strategy handles this — the next deploy that ships this config picks up the change cleanly.
+
+**Tradeoffs:**
+- `auto_explain.log_analyze = true` adds modest overhead because Postgres has to instrument every plan to capture actual row counts. At portfolio request volume this is negligible; the tradeoff would be revisited at scale.
+- `pg_stat_statements.track = top` (not `all`) means nested statement calls inside functions/triggers don't show up as separate entries. We have very little stored-procedure code, so `top` is correct.
+- `track_utility = off` skips `CREATE`/`ALTER`/`VACUUM`-style statements, which would otherwise crowd out application queries in the top-N.
+
+## Extensions per database
+
+Postgres extensions are per-database. Two paths:
+
+1. **For new databases:** add `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` to `java/k8s/configmaps/postgres-initdb.yml`, executed during fresh PVC initialization.
+2. **For existing databases:** a one-shot K8s Job (`postgres-extensions-bootstrap`) that connects to each prod DB and runs `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`. Idempotent; safe to re-run.
+
+`auto_explain` is a server-side extension loaded via `shared_preload_libraries` and does not require `CREATE EXTENSION` per database.
+
+Databases targeted: `authdb`, `productdb`, `orderdb`, `cartdb`, `paymentdb`, `ecommercedb`, `taskdb` (and the `_qa` equivalents).
+
+## Metrics layer (postgres_exporter)
+
+Two custom queries appended to the postgres_exporter custom-queries ConfigMap.
+
+### `pg_stat_statements` (latency)
+
+```yaml
+pg_stat_statements:
+  query: |
+    SELECT
+      pss.queryid,
+      LEFT(pss.query, 200) AS query_text,
+      pss.calls,
+      pss.total_exec_time,
+      pss.mean_exec_time,
+      pss.stddev_exec_time,
+      pss.rows
+    FROM pg_stat_statements pss
+    WHERE pss.calls > 10
+    ORDER BY pss.mean_exec_time DESC
+    LIMIT 50
+  master: true
+  metrics:
+    - queryid:           { usage: LABEL,   description: "pg_stat_statements query ID" }
+    - query_text:        { usage: LABEL,   description: "Truncated query text (200 chars)" }
+    - calls:             { usage: COUNTER, description: "Number of times executed" }
+    - total_exec_time:   { usage: COUNTER, description: "Total time in milliseconds" }
+    - mean_exec_time:    { usage: GAUGE,   description: "Mean execution time in milliseconds" }
+    - stddev_exec_time:  { usage: GAUGE,   description: "Std dev of execution time" }
+    - rows:              { usage: COUNTER, description: "Total rows returned" }
+```
+
+### `pg_stat_statements_io` (cache behavior)
+
+```yaml
+pg_stat_statements_io:
+  query: |
+    SELECT
+      pss.queryid,
+      pss.shared_blks_hit,
+      pss.shared_blks_read,
+      pss.shared_blks_dirtied
+    FROM pg_stat_statements pss
+    WHERE pss.calls > 10
+    ORDER BY pss.shared_blks_read DESC
+    LIMIT 50
+  master: true
+  metrics:
+    - queryid:             { usage: LABEL }
+    - shared_blks_hit:     { usage: COUNTER, description: "Buffer hits per query" }
+    - shared_blks_read:    { usage: COUNTER, description: "Disk reads per query" }
+    - shared_blks_dirtied: { usage: COUNTER, description: "Buffers dirtied per query" }
+```
+
+**Cardinality budget:** 50 queries × 8 metrics × 30s scrape ≈ 13 samples/sec ingest. Well below any concern. The `query_text` label is bounded to 200 chars to keep label storage manageable. The `WHERE calls > 10` filter excludes one-off queries (test fixtures, ad-hoc queries) that would otherwise churn the top-N.
+
+## Inspection layer (Grafana PostgreSQL data source)
+
+### Read-only role
+
+Migration applied to the Postgres instance:
+
+```sql
+CREATE ROLE grafana_reader LOGIN PASSWORD :'GRAFANA_READER_PASSWORD';
+GRANT pg_monitor TO grafana_reader;
+GRANT CONNECT ON DATABASE productdb, orderdb, paymentdb, cartdb, authdb TO grafana_reader;
+```
+
+`pg_monitor` is a predefined Postgres role that grants `SELECT` on monitoring views including `pg_stat_statements`, `pg_stat_activity`, `pg_stat_user_tables`, `pg_stat_replication`. Preferred over hand-rolled GRANTs because it tracks upstream when new views are added.
+
+The password is stored in the existing `postgres-secret` Kubernetes Secret as a new key `grafana-reader-password`. Grafana reads it via secret reference in the data source provisioning manifest.
+
+### Data sources
+
+Three Grafana data sources (one per high-traffic database), defined in `k8s/monitoring/configmaps/grafana-datasources.yml`:
+
+- `postgres-productdb`
+- `postgres-orderdb`
+- `postgres-paymentdb`
+
+The dashboard uses a `Database` template variable to switch between them. Adding `cartdb`, `authdb`, etc. is additive and one-line if needed later.
+
+**Why per-DB rather than a `monitoring` DB with `postgres_fdw`?** At three high-traffic DBs, three datasources are simpler than maintaining foreign tables. The cluster-wide pattern is justified once you have ten or more DBs.
+
+## Plan capture (auto_explain → Loki)
+
+`auto_explain` writes plans to standard Postgres logs. Postgres logs already flow to Loki via the existing Promtail config. Because `auto_explain.log_format = json`, plan log lines are parseable JSON.
+
+A new Promtail pipeline stage extracts:
+- `query_id` (as a structured field, not a label — high cardinality)
+- `duration_ms` (as a structured field)
+- `database` (as a label — bounded set)
+
+The dashboard's plan-viewer panel queries Loki:
+
+```
+{namespace="java-tasks", app="postgres"} |= "auto_explain" | json | duration_ms > 500
+```
+
+A second panel filters by a `queryid` template variable so the user can drill from the metrics top-N table into the plan that matches.
+
+## Dashboard
+
+New dashboard `pg-query-performance.json` deployed via the existing Grafana provisioning ConfigMap pattern. Cross-linked from the existing Postgres health dashboard via a "Drill into queries →" link.
+
+| Panel | Type | Source | Purpose |
+|---|---|---|---|
+| Top 10 slowest queries (mean) | Table | Grafana PostgreSQL DS | Live triage |
+| Top 10 slowest queries (total time) | Table | Grafana PostgreSQL DS | "What's eating CPU" |
+| p95 latency per queryid (top 5) | Time series | Prometheus | Regression detection |
+| Slow-query rate (calls with mean > 500ms) | Time series | Prometheus | Volume trend |
+| Cache hit ratio per query | Table | Grafana PostgreSQL DS | I/O hotspots |
+| Recent slow plans (last 1h) | Logs | Loki | Plan deep-dive |
+| Plan viewer (filter by queryid) | Logs | Loki, var-driven | Interview demo |
+
+Template variables:
+- `Database` — switches between productdb / orderdb / paymentdb
+- `queryid` — multi-select, drives the plan-viewer filter
+
+## Alerts
+
+Four new alert rules, all `noDataState: OK` (per the project-wide pattern from the data-integrity ADR).
+
+| Alert | Threshold | Why |
+|---|---|---|
+| `PgQueryMeanExecTimeHigh` | tracked queryid mean_exec_time > 1000ms for 10m | Hard ceiling on individual query latency |
+| `PgQueryMeanRegression` | tracked queryid mean > 2× its 7-day moving baseline for 15m | Catches plan flips and data-driven regressions that don't trip the hard ceiling |
+| `PgSlowQueryRateSpike` | rate of slow-query calls > 3× the 1h baseline for 10m | Volume-based incident signal |
+| `PgAutoExplainStalled` | no auto_explain log line received in Loki for 24h | Misconfig protection — a silent failure here would hide regressions |
+
+The regression alert is the differentiator: hard thresholds miss the realistic failure mode, which is a query that quietly drifts from 50ms to 200ms after a planner change.
+
+## Testing
+
+**Integration test** (testcontainers, build-tagged `//go:build integration`):
+- Start Postgres with `pg_stat_statements` and `auto_explain` preloaded
+- Run a deliberately slow query: `SELECT pg_sleep(0.6)`
+- Assert it appears in `pg_stat_statements`
+- Assert the Postgres log contains a JSON `auto_explain` plan for it
+
+**Existing benchmark suite** gets a follow-up assertion: after the slow benchmarks run (e.g., `BenchmarkOrderCreate_20Items`), `pg_stat_statements` must return non-zero rows for the underlying SQL.
+
+**Alert smoke test** in QA:
+- Temporarily lower `PgQueryMeanExecTimeHigh` to 1ms
+- Run any production-style request
+- Verify Telegram alert fires within 10 minutes
+- Restore threshold
+
+## Rollout
+
+Each step is an independently mergeable PR. Steps 1–2 are the only ones that touch the running Postgres pod; the rest are observability-only and safe.
+
+1. Add extensions to `postgres-initdb.yml` + ship the one-shot bootstrap Job for existing DBs.
+2. Update the Postgres ConfigMap (`shared_preload_libraries` + `auto_explain.*` settings). Deploy → `Recreate` restart picks it up.
+3. Append the two custom queries to the postgres_exporter ConfigMap; redeploy exporter.
+4. Add `grafana_reader` role + secret + Grafana data source provisioning manifests.
+5. Add the dashboard ConfigMap.
+6. Add the alert rules ConfigMap.
+7. Verify in QA → promote to prod.
+
+## ADR
+
+A companion ADR will be written at `docs/adr/observability/2026-04-27-pg-query-observability.md` after rollout, documenting the cardinality math, the regression-alert design, the per-DB datasource decision, and one screenshot of a real production plan caught by `auto_explain`.
+
+## Consequences
+
+**Positive:**
+- Production query performance is observable for the first time — both real-time (table panels) and longitudinally (Prometheus).
+- Plan regressions become detectable as alerts, not just user complaints.
+- The roadmap's remaining nine items (replication, retention, vacuum tuning, full-text search, etc.) all depend on a measurement layer; this is that layer.
+- Strong interview demo: walk into a Grafana panel, point at a real slow query, click into its plan, explain what `auto_explain` showed.
+
+**Trade-offs:**
+- `shared_preload_libraries` change requires a Postgres restart. Acceptable given the existing `Recreate` posture.
+- `auto_explain.log_analyze = true` has overhead. Negligible at portfolio scale; would be sampled at higher load.
+- Per-DB Grafana data sources don't give a single cluster-wide view. Acceptable — the dashboard variable handles switching, and adding a `monitoring` DB with `postgres_fdw` is reversible if scale demands it.
+- `query_text` as a Prometheus label is bounded to 200 chars. Long queries get truncated; the full text remains visible in the Grafana PostgreSQL data source panels.


### PR DESCRIPTION
## Summary
Extends `.pre-commit-config.yaml` so local hooks cover the same surface CI catches today:
- Adds **bandit** (Python SAST) — mirrors the CI `security-bandit` job
- Adds **hadolint** (Dockerfile lint via `hadolint-docker`) — mirrors the CI `security-hadolint` matrix
- Replaces the partial 2-service `go-lint` (only `auth-service` + `order-service`) with full 8-service coverage including `payment-service`

Adds `make install-pre-commit` target for one-shot first-time setup, and documents it in `CLAUDE.md` under "Pre-commit Requirements".

Spec: `docs/superpowers/specs/2026-04-27-ci-pipeline-hardening-design.md` (Initiative C)
Plan: `docs/superpowers/plans/2026-04-27-ci-hardening-C-precommit-backfill.md`

## Verified locally
All three new/updated hooks pass against the current `main` source tree:
- `pre-commit run bandit --all-files` → Passed
- `pre-commit run hadolint-docker --all-files` → Passed (no Dockerfile findings)
- `pre-commit run go-lint --all-files` → Passed (all 8 services)

So this PR shouldn't break anyone's commits on first run after `make install-pre-commit`.

## Risk
Pre-commit hooks run locally on developer machines — no CI workflow changes. CI continues to act as the safety net. If a developer skips installation, behavior is unchanged.

## Test plan
- [ ] On a fresh clone: `make install-pre-commit` succeeds and installs both stages
- [ ] `pre-commit run --all-files` passes on a clean main
- [ ] Modifying a Python file with a hardcoded password fails the bandit hook locally
- [ ] Modifying a Dockerfile with a `latest` tag fails the hadolint hook locally
- [ ] Modifying a Go file in `payment-service` fails locally if it has lint issues (was previously CI-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)