### PR TITLE
Highlight MCP server on /ai page

### DIFF
--- a/docs/superpowers/plans/2026-04-27-ai-mcp-highlight.md
+++ b/docs/superpowers/plans/2026-04-27-ai-mcp-highlight.md
@@ -1,0 +1,714 @@
+# `/ai` Page MCP Highlight — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lead the `/ai` portfolio page with a new MCP Server section that explains the official-SDK MCP server, reuses the 12-tool catalog as a shared component, links to the existing `/go` interactive demo, and provides connect-your-own-client snippets for Claude Desktop, Codex CLI, and MCP Inspector.
+
+**Architecture:** Pure frontend change — no backend touched. One shared React component (`MCPToolCatalog`) extracts the existing tool-catalog Mermaid chart out of `AiAssistantTab.tsx` so both `/ai` and `/go` render the same source of truth. Section ordering on `/ai` is reorganized so MCP leads, RAG Evaluation moves up to position 2, and existing Document Q&A and Debug sections move down without copy changes. Verification uses Playwright mocked e2e tests against the standard `frontend/e2e/mocked/` pattern (no unit-test framework exists for this project).
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Tailwind, Mermaid v10 via the existing `<MermaidDiagram />` component, Playwright for e2e verification.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-ai-mcp-highlight-design.md` (read before starting — this plan defers definitions to the spec rather than repeating them).
+
+**Public MCP endpoint (verified):** `https://api.kylebradshaw.dev/ai-api/mcp` — `go/k8s/ingress.yml` rewrites `/ai-api/(.*)` → `/$1` on `go-ai-service:8093`, hitting the `/mcp` handler in `go/ai-service/cmd/server/routes.go:75`. Confirmed by `frontend/e2e/smoke-prod/smoke-health.spec.ts:26-30`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/components/ai/MCPToolCatalog.tsx` *(NEW)* | Shared 12-tool Mermaid catalog. Renders the same diagram in both `/ai` and `/go` Shopping Assistant. No props. |
+| `frontend/src/components/ai/MCPArchitectureDiagram.tsx` *(NEW)* | New Mermaid diagram showing the external MCP-client request path (distinct from in-app agent diagrams in `AiAssistantTab.tsx`). |
+| `frontend/src/components/ai/MCPSection.tsx` *(NEW)* | Composes the entire MCP-Server section: copy, both diagrams, CTA to `/go`, connection-instruction snippets, GitHub link. Keeps `frontend/src/app/ai/page.tsx` from ballooning. |
+| `frontend/src/app/ai/page.tsx` *(MODIFY)* | Add `<MCPSection />` at the top, reorder remaining sections (RAG Eval up to position 2), update one bio paragraph to mention MCP. |
+| `frontend/src/components/go/tabs/AiAssistantTab.tsx` *(MODIFY)* | Replace inline tool-catalog `flowchart LR` chart string with `<MCPToolCatalog />` import. Other diagrams in this file stay as-is — they describe the in-app agent path. |
+| `frontend/e2e/mocked/ai-mcp-section.spec.ts` *(NEW)* | Playwright tests verifying the MCP section renders on `/ai`, the shared tool catalog renders on both `/ai` and `/go` (Shopping Assistant tab), and the connection snippets are visible. |
+| `docs/superpowers/specs/2026-04-27-ai-mcp-highlight-design.md` | Already updated on this branch with verified ingress path. No further changes needed. |
+
+---
+
+## Task 1: Create the failing Playwright test for the new `/ai` MCP section
+
+**Files:**
+- Create: `frontend/e2e/mocked/ai-mcp-section.spec.ts`
+
+This test drives every visible piece of the MCP section. Other tasks make it pass.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/e2e/mocked/ai-mcp-section.spec.ts`:
+
+```typescript
+import { test, expect } from "./fixtures";
+
+test.describe("/ai MCP Server section", () => {
+  test("MCP Server is the first section heading on /ai", async ({ page }) => {
+    await page.goto("/ai");
+    const sectionHeadings = page.locator("section h2");
+    await expect(sectionHeadings.first()).toHaveText("MCP Server");
+  });
+
+  test("RAG Evaluation appears as the second section on /ai", async ({ page }) => {
+    await page.goto("/ai");
+    const sectionHeadings = page.locator("section h2");
+    await expect(sectionHeadings.nth(1)).toHaveText("RAG Evaluation");
+  });
+
+  test("MCP section shows the verified public endpoint", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByText("https://api.kylebradshaw.dev/ai-api/mcp", { exact: false }),
+    ).toBeVisible();
+  });
+
+  test("MCP section renders the Claude Desktop config snippet", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByRole("heading", { name: "Claude Desktop", exact: false }),
+    ).toBeVisible();
+    await expect(page.getByText('"mcpServers"', { exact: false })).toBeVisible();
+  });
+
+  test("MCP section renders the Codex CLI config snippet", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByRole("heading", { name: "Codex CLI", exact: false }),
+    ).toBeVisible();
+  });
+
+  test("MCP section renders the MCP Inspector command", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByText("npx @modelcontextprotocol/inspector", { exact: false }),
+    ).toBeVisible();
+  });
+
+  test("MCP section CTA links to the /go shopping assistant tab", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+    const cta = page.getByRole("link", { name: /Try it on the Go section/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/go");
+  });
+
+  test("MCP section links to the GitHub source for the MCP server", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+    const githubLink = page.getByRole("link", { name: /View source on GitHub/i });
+    await expect(githubLink).toBeVisible();
+    await expect(githubLink).toHaveAttribute(
+      "href",
+      /github\.com\/.*\/go\/ai-service\/internal\/mcp/,
+    );
+  });
+
+  test("Tool catalog renders on /ai (shared component, identifying caption)", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByText(/twelve tools/i, { exact: false }).first(),
+    ).toBeVisible();
+  });
+
+  test("Tool catalog renders on /go AI Assistant tab", async ({ page }) => {
+    await page.goto("/go");
+    await page.getByRole("button", { name: "AI Assistant" }).click();
+    await expect(page.getByText(/twelve tools/i, { exact: false })).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd frontend && npx playwright test e2e/mocked/ai-mcp-section.spec.ts --reporter=list
+```
+
+Expected: every test fails. The first test fails with the first `<h2>` in `<section>` reading "Document Q&A Assistant" (current top section), not "MCP Server."
+
+If Playwright browsers are not installed, run `npx playwright install chromium` first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/e2e/mocked/ai-mcp-section.spec.ts
+git commit -m "test(ai): failing e2e for new /ai MCP section"
+```
+
+---
+
+## Task 2: Extract the 12-tool catalog into `MCPToolCatalog` shared component
+
+**Files:**
+- Create: `frontend/src/components/ai/MCPToolCatalog.tsx`
+- Modify: `frontend/src/components/go/tabs/AiAssistantTab.tsx` (lines 17–58 — the `<h3>Tool Catalog</h3>` block + the `<MermaidDiagram chart={...} />` containing the `flowchart LR` with `AGENT`, `Catalog`, `Orders`, `CartReturns`, `Knowledge` subgraphs)
+
+The phrase **"twelve tools"** must appear in the component's prose so the e2e selector from Task 1 has something to bind to in both render locations.
+
+- [ ] **Step 1: Create the shared component**
+
+Create `frontend/src/components/ai/MCPToolCatalog.tsx`:
+
+```tsx
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const toolCatalogChart = `flowchart LR
+  AGENT((MCP client<br/>or in-app agent))
+  subgraph Catalog ["Catalog (public)"]
+    T1[search_products<br/>query + max_price]
+    T2[get_product<br/>full details by ID]
+    T3[check_inventory<br/>stock count]
+  end
+  subgraph Orders ["Orders (auth-scoped)"]
+    T4[list_orders<br/>last 20 orders]
+    T5[get_order<br/>single order detail]
+    T6[summarize_orders<br/>LLM-generated summary]
+  end
+  subgraph CartReturns ["Cart & Returns (auth-scoped)"]
+    T7[view_cart<br/>items + total]
+    T8[add_to_cart<br/>product + quantity]
+    T9[initiate_return<br/>order item + reason]
+  end
+  subgraph Knowledge ["Knowledge Base (public, RAG)"]
+    T10[search_documents<br/>semantic search + sources]
+    T11[ask_document<br/>natural-language Q&A]
+    T12[list_collections<br/>vector store inventory]
+  end
+  AGENT --> Catalog
+  AGENT --> Orders
+  AGENT --> CartReturns
+  AGENT --> Knowledge
+  X[place_order<br/>deliberately excluded]:::disabled
+  AGENT -.-x X
+  classDef disabled stroke-dasharray: 5 5,opacity:0.5`;
+
+export function MCPToolCatalog() {
+  return (
+    <div>
+      <h3 className="mt-10 text-xl font-semibold">Tool Catalog</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The MCP server exposes twelve tools across four domains. Catalog and
+        knowledge-base tools are public; order, cart, and return tools require a
+        Bearer JWT. Knowledge-base tools call the Python RAG pipeline through a
+        circuit-breaker HTTP bridge with a 30-second timeout. Checkout
+        (<code>place_order</code>) is deliberately excluded — the agent can advise
+        but not transact.
+      </p>
+      <div className="mt-6">
+        <MermaidDiagram chart={toolCatalogChart} />
+      </div>
+    </div>
+  );
+}
+```
+
+Note: the `AGENT` node label changed from `"Agent<br/>Qwen 2.5 14B"` to `"MCP client<br/>or in-app agent"` to keep the component honest at both render sites — an external MCP client doesn't run Qwen. The Go AI Assistant tab now describes the LLM separately in its surrounding copy.
+
+- [ ] **Step 2: Replace the inline diagram in `AiAssistantTab.tsx`**
+
+Open `frontend/src/components/go/tabs/AiAssistantTab.tsx`. Replace lines 17–58 (the `<h3>Tool Catalog</h3>` heading, the surrounding `<p>` paragraph, and the entire `<div className="mt-6"><MermaidDiagram chart={...} /></div>` block containing the `flowchart LR` chart) with a single `<MCPToolCatalog />` invocation.
+
+Final replacement block (replaces those lines exactly — keep `<p className="mt-4 ...">An LLM-powered shopping assistant ...</p>` from line 6 untouched):
+
+```tsx
+import { MCPToolCatalog } from "@/components/ai/MCPToolCatalog";
+```
+
+(at the top of the file, alongside the existing `import { MermaidDiagram } ...`)
+
+```tsx
+      <MCPToolCatalog />
+```
+
+(replacing the lines that previously held the heading, paragraph, and Mermaid block)
+
+After the change, `AiAssistantTab.tsx` should still describe the in-app Agent Loop, Product-search sequence, and Knowledge-query sequence diagrams — those stay as-is.
+
+- [ ] **Step 3: Run the `/go` tool-catalog test**
+
+```bash
+cd frontend && npx playwright test e2e/mocked/ai-mcp-section.spec.ts -g "Tool catalog renders on /go" --reporter=list
+```
+
+Expected: PASS. (The other tests still fail because `/ai` doesn't have the section yet.)
+
+- [ ] **Step 4: Run typecheck**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/ai/MCPToolCatalog.tsx \
+        frontend/src/components/go/tabs/AiAssistantTab.tsx
+git commit -m "refactor(ai): extract MCPToolCatalog shared component"
+```
+
+---
+
+## Task 3: Build the `MCPArchitectureDiagram` component
+
+**Files:**
+- Create: `frontend/src/components/ai/MCPArchitectureDiagram.tsx`
+
+This diagram must visibly differ from the existing in-app agent sequence diagrams in `AiAssistantTab.tsx`. No `Ollama` box. The external MCP client owns its own LLM.
+
+- [ ] **Step 1: Create the component**
+
+Create `frontend/src/components/ai/MCPArchitectureDiagram.tsx`:
+
+```tsx
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const mcpArchitectureChart = `flowchart LR
+  subgraph Clients ["External MCP clients"]
+    direction TB
+    CD[Claude Desktop]
+    CX[Codex CLI]
+    INS[MCP Inspector]
+  end
+  subgraph Server ["ai-service /mcp endpoint (Go)"]
+    direction TB
+    HTTP[HTTPS Streamable<br/>transport]
+    AUTH{Bearer JWT?}
+    REG[Tool registry<br/>12 tools]
+    HTTP --> AUTH
+    AUTH -->|valid token| REG
+    AUTH -->|absent| REG
+  end
+  subgraph Backends ["Backends (in-cluster)"]
+    direction TB
+    EC[Ecommerce<br/>REST + gRPC]
+    RAG[Python RAG bridge<br/>circuit breaker, OTel]
+    QD[(Qdrant)]
+    OLL[(Ollama)]
+    RAG --> QD
+    RAG --> OLL
+  end
+  CD -->|"public + auth-scoped<br/>tools"| HTTP
+  CX --> HTTP
+  INS -->|"discovery + invoke"| HTTP
+  REG --> EC
+  REG --> RAG`;
+
+export function MCPArchitectureDiagram() {
+  return <MermaidDiagram chart={mcpArchitectureChart} />;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ai/MCPArchitectureDiagram.tsx
+git commit -m "feat(ai): MCP architecture diagram for external-client path"
+```
+
+---
+
+## Task 4: Build the `MCPSection` component (composes the full section)
+
+**Files:**
+- Create: `frontend/src/components/ai/MCPSection.tsx`
+
+This component must contain the visible strings the Task 1 tests assert on:
+- `<h2>MCP Server</h2>`
+- `https://api.kylebradshaw.dev/ai-api/mcp` (visible somewhere in body text or code block)
+- `<h3>Claude Desktop</h3>` and `"mcpServers"` (in the JSON snippet)
+- `<h3>Codex CLI</h3>`
+- `npx @modelcontextprotocol/inspector` (in the Inspector snippet)
+- A link with text matching `/Try it on the Go section/i` and `href="/go"`
+- A link with text matching `/View source on GitHub/i` and `href` matching `github.com/.*/go/ai-service/internal/mcp`
+
+- [ ] **Step 1: Create the component**
+
+Create `frontend/src/components/ai/MCPSection.tsx`:
+
+```tsx
+import Link from "next/link";
+import { MCPArchitectureDiagram } from "./MCPArchitectureDiagram";
+import { MCPToolCatalog } from "./MCPToolCatalog";
+
+const claudeDesktopConfig = `{
+  "mcpServers": {
+    "kyle-portfolio": {
+      "transport": "http",
+      "url": "https://api.kylebradshaw.dev/ai-api/mcp"
+    }
+  }
+}`;
+
+const codexConfig = `[mcp_servers.kyle-portfolio]
+transport = "http"
+url = "https://api.kylebradshaw.dev/ai-api/mcp"`;
+
+const inspectorCommand = `npx @modelcontextprotocol/inspector https://api.kylebradshaw.dev/ai-api/mcp`;
+
+const githubMcpUrl =
+  "https://github.com/kabradshaw1/portfolio/tree/main/go/ai-service/internal/mcp";
+
+export function MCPSection() {
+  return (
+    <section className="mt-12">
+      <h2 className="text-2xl font-semibold">MCP Server</h2>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The Go ai-service exposes twelve tools to any{" "}
+        <a
+          href="https://modelcontextprotocol.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-foreground transition-colors"
+        >
+          Model Context Protocol
+        </a>{" "}
+        client over HTTPS. Built on the official{" "}
+        <code>modelcontextprotocol/go-sdk</code>, it fronts both the ecommerce
+        backend (REST + gRPC) and a Python RAG pipeline (HTTP, circuit breaker,
+        OTel trace propagation). Authentication is optional: catalog and
+        knowledge-base tools work anonymously; cart, order, and return tools
+        require a Bearer JWT.
+      </p>
+
+      <h3 className="mt-10 text-xl font-semibold">Architecture</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        External MCP clients connect over the HTTPS Streamable transport. The
+        Go server enforces optional JWT auth, then routes tool calls to either
+        the ecommerce backend or the Python RAG bridge. The bridge uses a
+        circuit breaker with a 30-second timeout and propagates OTel trace
+        context across the language boundary.
+      </p>
+      <div className="mt-6 rounded-xl border border-foreground/10 bg-card p-6">
+        <MCPArchitectureDiagram />
+      </div>
+
+      <MCPToolCatalog />
+
+      <h3 className="mt-10 text-xl font-semibold">Try it interactively</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The same tool registry powers an in-browser agent loop on the Go
+        section. The agent runs Qwen 2.5 14B locally and streams tool calls
+        and results live.
+      </p>
+      <div className="mt-6">
+        <Link
+          href="/go"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Try it on the Go section &rarr;
+        </Link>
+      </div>
+
+      <h3 className="mt-10 text-xl font-semibold">Connect your own client</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The MCP server is publicly reachable at{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-sm">
+          https://api.kylebradshaw.dev/ai-api/mcp
+        </code>
+        . Public tools (catalog search, RAG search,{" "}
+        <code>list_collections</code>) work without auth. Auth-scoped tools
+        require a Bearer JWT — register at{" "}
+        <Link href="/go/register" className="underline hover:text-foreground">
+          /go/register
+        </Link>
+        , log in, and copy the access token from the{" "}
+        <code>Authorization</code> header in DevTools.
+      </p>
+
+      <h4 className="mt-6 text-lg font-medium">Claude Desktop</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Add to{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+          ~/Library/Application Support/Claude/claude_desktop_config.json
+        </code>
+        :
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg border border-foreground/10 bg-card p-4 text-xs">
+        <code>{claudeDesktopConfig}</code>
+      </pre>
+
+      <h4 className="mt-6 text-lg font-medium">Codex CLI</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Add to{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+          ~/.codex/config.toml
+        </code>
+        :
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg border border-foreground/10 bg-card p-4 text-xs">
+        <code>{codexConfig}</code>
+      </pre>
+
+      <h4 className="mt-6 text-lg font-medium">MCP Inspector</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Browse and invoke tools directly:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg border border-foreground/10 bg-card p-4 text-xs">
+        <code>{inspectorCommand}</code>
+      </pre>
+
+      <p className="mt-8 text-sm">
+        <a
+          href={githubMcpUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-foreground transition-colors"
+        >
+          View source on GitHub &rarr;
+        </a>
+      </p>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ai/MCPSection.tsx
+git commit -m "feat(ai): MCPSection component with diagrams + connect snippets"
+```
+
+---
+
+## Task 5: Wire `MCPSection` into `/ai` and reorder existing sections
+
+**Files:**
+- Modify: `frontend/src/app/ai/page.tsx`
+
+Final section order on the page after this task:
+1. Header `<h1>` + bio paragraph (bio updated)
+2. `<MCPSection />` (NEW)
+3. RAG Evaluation `<section>` (moved up from position 4)
+4. Document Q&A Assistant `<section>` + How It Works diagram + demo CTA (moved down)
+5. Debug Assistant `<section>` + How It Works diagram + demo CTA (unchanged position relative to Document Q&A)
+
+The Eval Demo CTA and Document Q&A demo CTA stay attached to their respective sections — when reordering, drag each section together with its trailing diagram + CTA blocks.
+
+- [ ] **Step 1: Read the existing page in full to anchor the edit**
+
+```bash
+cat frontend/src/app/ai/page.tsx | head -200
+```
+
+Confirm the current order is: Document Q&A → Debug → RAG Evaluation. The reorder moves RAG Evaluation between the new MCP section and Document Q&A.
+
+- [ ] **Step 2: Edit `frontend/src/app/ai/page.tsx`**
+
+Replace the existing default-export function body with the new ordering. Concrete edits:
+
+a. **Add the import** at the top of the file, alongside the existing imports:
+
+```tsx
+import { MCPSection } from "@/components/ai/MCPSection";
+```
+
+b. **Update the bio paragraph** (currently lines 50–55). Change the first sentence so it leads with the MCP framing:
+
+```tsx
+          <p className="text-muted-foreground leading-relaxed">
+            Building intelligent systems with retrieval-augmented generation,
+            agentic architectures, and Model Context Protocol (MCP) servers
+            that any AI client can call. This section demonstrates an MCP
+            server fronting twelve tools, RAG pipelines with evaluation,
+            vector search, and tool-using agents — built with FastAPI, Qdrant,
+            Ollama, and Go, deployed on Kubernetes.
+          </p>
+```
+
+The Grafana paragraph immediately below stays as-is.
+
+c. **Insert `<MCPSection />`** as the first content section after the bio block. Place it before the existing `{/* Project Explanation */}` section.
+
+d. **Move the RAG Evaluation section** (currently the last `<section>` plus its "Try RAG Evaluation" CTA `<section>`) so they sit immediately after `<MCPSection />` and before the Document Q&A section.
+
+After the edit, the JSX body order should look like (comments only, not literal):
+
+```
+- Header (h1)
+- Bio section (updated copy)
+- <MCPSection />
+- RAG Evaluation section + Eval Demo CTA section
+- Document Q&A section + How It Works (architectureDiagram) + Demo CTA section
+- Debug Assistant section + How It Works (debugArchitectureDiagram) + Debug Demo CTA section
+```
+
+Leave the `architectureDiagram` and `debugArchitectureDiagram` constants at the top of the file untouched.
+
+- [ ] **Step 3: Run typecheck**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Run the `/ai` MCP tests**
+
+```bash
+cd frontend && npx playwright test e2e/mocked/ai-mcp-section.spec.ts --reporter=list
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Spot-check visually**
+
+```bash
+cd frontend && npm run dev
+```
+
+Open `http://localhost:3000/ai`. Confirm:
+- "MCP Server" is the first `<h2>` after the bio.
+- Architecture diagram and Tool Catalog render via Mermaid.
+- Three connection snippets appear with correct heading copy.
+- "Try it on the Go section →" links to `/go`.
+- "View source on GitHub →" link points at the `internal/mcp` directory.
+- RAG Evaluation appears immediately below MCP Server.
+- Document Q&A and Debug sections appear after, with their existing diagrams and CTAs intact.
+
+Stop the dev server after the spot-check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/app/ai/page.tsx
+git commit -m "feat(ai): lead /ai page with MCP Server section, reorder sections"
+```
+
+---
+
+## Task 6: Run the project's full frontend preflight
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run preflight-frontend**
+
+```bash
+make preflight-frontend
+```
+
+This runs `tsc`, `next build`, `eslint`. Expected: PASS.
+
+- [ ] **Step 2: Run mocked e2e**
+
+```bash
+make preflight-e2e
+```
+
+Expected: full mocked-e2e suite passes, including the new `ai-mcp-section.spec.ts`.
+
+If either preflight fails, fix the failure inline and re-run before proceeding. Type errors and lint errors are mechanical fixes; do not commit broken code through to push.
+
+- [ ] **Step 3: Commit any preflight-driven fixes**
+
+If Step 1 or Step 2 produced fixes, commit them with a focused message such as `chore(ai): fix lint/typecheck under MCP highlight`. If no fixes were needed, skip this step — no empty commit.
+
+---
+
+## Task 7: Push and open the PR to `qa`
+
+Per `CLAUDE.md` feature-branch flow: spec was already approved, plan execution proceeds to push without further approval, no CI watching.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent-feat-ai-mcp-highlight
+git push -u origin agent/feat-ai-mcp-highlight
+```
+
+- [ ] **Step 2: Open the PR against `qa`**
+
+```bash
+gh pr create --base qa --title "Highlight MCP server on /ai page" --body "$(cat <<'EOF'
+## Summary
+- Lead the /ai portfolio page with a new MCP Server section explaining the official-SDK MCP server, its architecture, and the 12-tool catalog.
+- Extract the tool catalog into a shared `<MCPToolCatalog />` component reused on both /ai and /go (Shopping Assistant tab).
+- Add connect-your-own-client snippets for Claude Desktop, Codex CLI, and MCP Inspector pointing at the verified public endpoint `https://api.kylebradshaw.dev/ai-api/mcp`.
+- Reorder /ai sections so RAG Evaluation sits immediately below the new MCP section.
+
+Closes #79 — RAG eval harness shipped under `services/eval/`.
+Closes #83 — Eval Service UI shipped at `/ai/eval`.
+
+## Test plan
+- [ ] `make preflight-frontend` passes (tsc + next build + eslint)
+- [ ] `make preflight-e2e` passes, including new `frontend/e2e/mocked/ai-mcp-section.spec.ts`
+- [ ] Visual check on QA: MCP Server is first `<h2>`, RAG Evaluation second; tool catalog renders on both /ai and /go
+- [ ] Public endpoint resolves: `curl -s -o /dev/null -w "%{http_code}\n" https://qa-api.kylebradshaw.dev/ai-api/mcp` returns a non-5xx response (MCP handshake will not accept a plain GET, but the server should respond)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Capture the PR URL**
+
+The previous step prints the PR URL. Save it to report back to Kyle.
+
+---
+
+## Task 8: Close completed roadmap issues
+
+Per spec, issues #79 and #83 represent work that has already shipped. Close them with reference comments so the open-issue list reflects reality.
+
+- [ ] **Step 1: Close #79 with a reference comment**
+
+```bash
+gh issue close 79 --comment "RAG evaluation harness shipped under \`services/eval/\` (see \`services/eval/app/evaluator.py\` and the corresponding tests). The interactive UI driving it landed at \`/ai/eval\` (tracked separately under #83). Per the 2026-04-27 \`/ai\` MCP highlight spec, this issue is closed as done."
+```
+
+- [ ] **Step 2: Close #83 with a reference comment**
+
+```bash
+gh issue close 83 --comment "Eval Service UI shipped at \`/ai/eval\` (see \`frontend/src/app/ai/eval/page.tsx\` and \`frontend/src/components/eval/\`). Datasets, Evaluate, and Results tabs are all implemented and the page is live in production. Closing as done per the 2026-04-27 \`/ai\` MCP highlight spec."
+```
+
+- [ ] **Step 3: Verify both are closed**
+
+```bash
+gh issue list --state open --search "in:title Phase 4a OR in:title Eval Service UI" --limit 5
+```
+
+Expected: empty result.
+
+---
+
+## Self-review — done before handoff to execution
+
+**Spec coverage:**
+- ✅ Section 1a (What & why) — Task 4 prose
+- ✅ Section 1b (Architecture diagram) — Task 3
+- ✅ Section 1c (Tool catalog) — Task 2 + reuse in Task 4
+- ✅ Section 1d (Try it interactively / link to /go) — Task 4 CTA
+- ✅ Section 1e (Connect your own client) — Task 4 snippets
+- ✅ Section 1f (GitHub link) — Task 4 footer
+- ✅ Bio paragraph update — Task 5b
+- ✅ Section reordering — Task 5d
+- ✅ Component changes table — Tasks 2–5
+- ✅ Issue cleanup — Task 8
+- ✅ Verification (preflight, MCP-section tests, public endpoint) — Tasks 6 + 7 PR test plan
+
+**Placeholders:** none. The Codex config and Inspector command are written verbatim using the formats both tools currently document. Codex `~/.codex/config.toml` `[mcp_servers.<name>]` block and Inspector `npx @modelcontextprotocol/inspector <url>` are stable. If the format has shifted by impl time, the executing agent updates the snippet rather than ships stale.
+
+**Type consistency:** `<MCPToolCatalog />`, `<MCPArchitectureDiagram />`, `<MCPSection />` — names used identically across all tasks. Imports use the `@/components/ai/...` alias matching the project's existing tsconfig pattern.

--- a/docs/superpowers/specs/2026-04-27-ai-mcp-highlight-design.md
+++ b/docs/superpowers/specs/2026-04-27-ai-mcp-highlight-design.md
@@ -1,0 +1,165 @@
+# Design: Highlight the MCP Server on the `/ai` Portfolio Page
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Builds on:**
+  - `go/ai-service/internal/mcp/` — existing MCP server using `modelcontextprotocol/go-sdk`
+  - `frontend/src/components/go/tabs/AiAssistantTab.tsx` — existing tool catalog diagram
+  - `frontend/src/app/ai/page.tsx` — current `/ai` portfolio landing page
+- **Related GitHub issues:**
+  - Close on completion: #79 (RAG eval harness — already shipped under `services/eval/`), #83 (eval UI — already shipped at `/ai/eval`)
+  - Future RAG section work: #80 (hybrid search), #81 (cross-encoder re-ranking)
+  - Future eval section work: #84 (compare/history endpoints), #85 (improvement-tracking dashboard)
+
+## Context
+
+The Go ai-service exposes 12 tools (8 ecommerce + 3 RAG + 1 returns) through two consumers of a single tool registry:
+
+1. The **in-app agent loop** in `internal/agent/` — drives the shopping-assistant chat and `/ai/rag` chat. Calls Ollama with tool schemas, dispatches tools, streams SSE.
+2. The **MCP server** in `internal/mcp/` — exposes the same registry to external MCP clients over HTTP Streamable transport at `/mcp`, with optional Bearer-JWT auth.
+
+Today the portfolio describes only consumer (1). The MCP-server story shows up briefly inside the Go section's "AI Assistant" tab but isn't framed as MCP, and the dedicated `/ai` page makes no mention of MCP at all. That is the most interview-relevant artifact in the AI section — an official-SDK MCP server that any MCP client can connect to — and it is currently invisible to anyone scanning the AI page.
+
+This spec adds an MCP-Server section at the top of `/ai`, reorders the existing sections, and gives visitors enough material to connect their own MCP client (Claude Desktop, Codex CLI, MCP Inspector) to the running server.
+
+## Goals
+
+- Lead the `/ai` page with the MCP server — the strongest artifact for a Gen AI Engineer audience.
+- Give visitors a concrete path to actually use the server from their own AI client (Claude Desktop, Codex, Inspector).
+- Reuse the existing tool-catalog diagram across `/ai` and `/go` rather than maintaining two copies.
+- Keep the MCP framing honest: an external MCP client does NOT trigger the in-app Go agent loop — it runs its own loop. Diagrams must not conflate the two.
+- Move RAG Evaluation up to the second slot, since it pairs naturally with the MCP framing.
+- Close issues that are already done (#79, #83) so the open-issue list reflects reality.
+
+## Non-goals
+
+- No new interactive demo on `/ai`. The Shopping Assistant on `/go` already exercises the same toolchain end-to-end; we link to it rather than duplicate it.
+- No backend changes to the MCP server. Auth, transport, and the tool set stay as they are.
+- No work on issues #80, #81, #84, #85. They land in the RAG / Eval sections in future cycles, not in this scope.
+- No reframing of the Document Q&A or Debug Assistant sections beyond reordering. Their copy stays as-is.
+
+## Page structure
+
+Final ordering of sections on `frontend/src/app/ai/page.tsx`:
+
+| # | Section | Status |
+|---|---|---|
+| 1 | **MCP Server** | NEW (top) |
+| 2 | RAG Evaluation | moved up from position 3 |
+| 3 | Document Q&A Assistant | unchanged content; new position 3 |
+| 4 | Debug Assistant | unchanged content; new position 4 |
+
+The Bio paragraph at the top of the page is updated to mention the MCP-server framing in one sentence. The existing Grafana-dashboard link stays.
+
+## Section 1: MCP Server — content breakdown
+
+### 1a. What & why (1 short paragraph)
+
+Describe the MCP server in plain terms: built on the official `modelcontextprotocol/go-sdk`, exposes 12 tools across ecommerce and RAG domains, runs over HTTP Streamable transport, optional Bearer-JWT auth (public tools work anonymously, scoped tools require a token). Mention OTel trace propagation and the Go→Python bridge (with circuit breaker) for the RAG tools, since those are the production-quality details that distinguish this from a tutorial-grade server.
+
+### 1b. Architecture diagram (NEW)
+
+A new Mermaid diagram showing the **external MCP client path** (distinct from the in-app agent path). High-level shape:
+
+```
+External MCP client (Claude Desktop / Codex / Inspector)
+   │  HTTPS Streamable transport, optional Bearer JWT
+   ▼
+ai-service /mcp endpoint  (Go, modelcontextprotocol/go-sdk)
+   │
+   ▼
+Tool registry (12 tools)
+   │
+   ├── Ecommerce backend  (REST/gRPC, OTel-propagated)
+   │
+   └── Python RAG bridge  (HTTP, circuit breaker, OTel)
+           │
+           ▼
+       Qdrant + Ollama
+```
+
+The diagram must visibly differ from the in-app agent diagrams in `AiAssistantTab.tsx` so a reader doesn't confuse the two paths. No "Ollama" box on the MCP path — the external client owns its own LLM.
+
+### 1c. Tool catalog (REUSED)
+
+Extract the existing `flowchart LR` tool-catalog diagram from `AiAssistantTab.tsx` into a shared component:
+
+- New file: `frontend/src/components/ai/MCPToolCatalog.tsx`
+- Default export: a component that renders the existing 12-tool catalog Mermaid chart wrapped in `<MermaidDiagram />`.
+- Replace the inline chart string in `AiAssistantTab.tsx` with `<MCPToolCatalog />`.
+- Render the same component in the new MCP section on `/ai`.
+
+The component takes no props. If we later want to vary the framing copy around the diagram between the two locations, we can add a prop, but YAGNI for now.
+
+### 1d. "Try it interactively" link
+
+A single CTA button that links to `/go` (Shopping Assistant tab). Copy: *"The same tools power the in-app shopping assistant — try it on the Go section."* This is the equivalent of the "Try the Demo →" CTAs on the other AI sections, but instead of a new demo it points to the existing one.
+
+### 1e. Connect your own client
+
+A new subsection with three copy-pasteable configuration snippets, each in a `<pre>` block with a code copy button (use whatever pattern already exists in the repo for code blocks; if none exists, plain `<pre>` is fine — no scope creep on copy-button infrastructure).
+
+The public MCP endpoint is `https://api.kylebradshaw.dev/go-ai/mcp` (verify the exact ingress path during implementation — check `k8s/go-ecommerce/` ingress rules for ai-service before publishing the snippet).
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "kyle-portfolio": {
+      "transport": "http",
+      "url": "https://api.kylebradshaw.dev/go-ai/mcp"
+    }
+  }
+}
+```
+
+**Codex CLI** — config block matching the format Codex expects for HTTP MCP servers (verify against current Codex docs at implementation time; if the format has shifted, update the snippet rather than ship something stale).
+
+**MCP Inspector** — single command:
+
+```bash
+npx @modelcontextprotocol/inspector https://api.kylebradshaw.dev/go-ai/mcp
+```
+
+A short note below the snippets: *"Public tools (catalog search, RAG search, `list_collections`) work without auth. Scoped tools (cart, orders, returns) require a Bearer JWT — register and log in at /go/register, then copy the token from the auth header in DevTools."*
+
+### 1f. GitHub link
+
+A small footer link to `go/ai-service/internal/mcp/` on GitHub, the way other portfolio sections do.
+
+## Component changes
+
+| File | Change |
+|---|---|
+| `frontend/src/app/ai/page.tsx` | Add Section 1 (MCP Server), reorder existing sections, update bio paragraph |
+| `frontend/src/components/ai/MCPToolCatalog.tsx` | NEW — extracted shared component for the 12-tool diagram |
+| `frontend/src/components/go/tabs/AiAssistantTab.tsx` | Replace inline tool-catalog chart string with `<MCPToolCatalog />` import |
+| (no backend changes) | — |
+
+## Issue cleanup as part of this scope
+
+- **Close #79** (Phase 4a: RAG evaluation harness) with a comment linking to `services/eval/` and `/ai/eval`.
+- **Close #83** (Eval Service UI) with a comment linking to `frontend/src/app/ai/eval/page.tsx`.
+- Leave #80, #81 (RAG retrieval quality) and #84, #85 (eval comparison/dashboard) open. They belong to the RAG and Eval sections respectively — out of scope for this MCP highlight.
+
+## Out of scope (explicit non-goals worth re-stating)
+
+- No interactive MCP-tool runner UI on `/ai`.
+- No work on hybrid search, re-ranking, eval comparison endpoints, or eval dashboard.
+- No changes to the MCP server's auth model, transport, or tool registry.
+- No reframing of `/ai/rag`, `/ai/debug`, or `/ai/eval` pages.
+
+## Verification
+
+- `make preflight-frontend` (tsc + Next build + lint) passes.
+- `/ai` renders all four sections in the new order, with the new MCP section at the top.
+- The shared `<MCPToolCatalog />` component renders identically on both `/ai` and `/go` (Shopping Assistant tab).
+- The Claude Desktop and Inspector snippets are syntactically valid (paste-test against a local Claude Desktop and a fresh Inspector run before merging).
+- Manually verify the public ingress path resolves: `curl -s https://api.kylebradshaw.dev/go-ai/mcp` returns a non-error response (the MCP handshake will reject a plain GET, but the server should respond — a 404 or transport error means the ingress path is wrong).
+- Issues #79 and #83 are closed with reference comments.
+
+## Open questions
+
+- **Exact public path for the MCP endpoint.** I've assumed `https://api.kylebradshaw.dev/go-ai/mcp` based on the documented ingress routing pattern (`/go-api/*`, `/go-auth/*`, `/go-products/*`). The actual ai-service ingress path needs to be confirmed before the connection snippets ship — the wrong path in a portfolio JSON config block is a credibility hit.
+- **Should the connection-instructions section include a "minimal JWT for testing" path?** Right now visitors would need to register and copy a token from DevTools to exercise scoped tools. A more polished story would be a "guest token" link that mints a read-only JWT scoped to the demo user. Out of scope for this round; flagged for future iteration.

--- a/docs/superpowers/specs/2026-04-27-ai-mcp-highlight-design.md
+++ b/docs/superpowers/specs/2026-04-27-ai-mcp-highlight-design.md
@@ -99,7 +99,7 @@ A single CTA button that links to `/go` (Shopping Assistant tab). Copy: *"The sa
 
 A new subsection with three copy-pasteable configuration snippets, each in a `<pre>` block with a code copy button (use whatever pattern already exists in the repo for code blocks; if none exists, plain `<pre>` is fine — no scope creep on copy-button infrastructure).
 
-The public MCP endpoint is `https://api.kylebradshaw.dev/go-ai/mcp` (verify the exact ingress path during implementation — check `k8s/go-ecommerce/` ingress rules for ai-service before publishing the snippet).
+The public MCP endpoint is `https://api.kylebradshaw.dev/ai-api/mcp`. Verified against `go/k8s/ingress.yml` — the `/ai-api(/|$)(.*)` rule routes to `go-ai-service:8093` with rewrite-target `/$2`, so `/ai-api/mcp` reaches the `/mcp` handler registered in `go/ai-service/cmd/server/routes.go:75`. The frontend smoke tests already use this path — see `frontend/e2e/smoke-prod/smoke-health.spec.ts:26-30`.
 
 **Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -108,7 +108,7 @@ The public MCP endpoint is `https://api.kylebradshaw.dev/go-ai/mcp` (verify the 
   "mcpServers": {
     "kyle-portfolio": {
       "transport": "http",
-      "url": "https://api.kylebradshaw.dev/go-ai/mcp"
+      "url": "https://api.kylebradshaw.dev/ai-api/mcp"
     }
   }
 }
@@ -119,7 +119,7 @@ The public MCP endpoint is `https://api.kylebradshaw.dev/go-ai/mcp` (verify the 
 **MCP Inspector** — single command:
 
 ```bash
-npx @modelcontextprotocol/inspector https://api.kylebradshaw.dev/go-ai/mcp
+npx @modelcontextprotocol/inspector https://api.kylebradshaw.dev/ai-api/mcp
 ```
 
 A short note below the snippets: *"Public tools (catalog search, RAG search, `list_collections`) work without auth. Scoped tools (cart, orders, returns) require a Bearer JWT — register and log in at /go/register, then copy the token from the auth header in DevTools."*
@@ -156,10 +156,9 @@ A small footer link to `go/ai-service/internal/mcp/` on GitHub, the way other po
 - `/ai` renders all four sections in the new order, with the new MCP section at the top.
 - The shared `<MCPToolCatalog />` component renders identically on both `/ai` and `/go` (Shopping Assistant tab).
 - The Claude Desktop and Inspector snippets are syntactically valid (paste-test against a local Claude Desktop and a fresh Inspector run before merging).
-- Manually verify the public ingress path resolves: `curl -s https://api.kylebradshaw.dev/go-ai/mcp` returns a non-error response (the MCP handshake will reject a plain GET, but the server should respond — a 404 or transport error means the ingress path is wrong).
+- Manually verify the public ingress path resolves: `curl -s https://api.kylebradshaw.dev/ai-api/mcp` returns a non-error response (the MCP handshake will reject a plain GET, but the server should respond — a 404 or transport error means the ingress path is wrong).
 - Issues #79 and #83 are closed with reference comments.
 
 ## Open questions
 
-- **Exact public path for the MCP endpoint.** I've assumed `https://api.kylebradshaw.dev/go-ai/mcp` based on the documented ingress routing pattern (`/go-api/*`, `/go-auth/*`, `/go-products/*`). The actual ai-service ingress path needs to be confirmed before the connection snippets ship — the wrong path in a portfolio JSON config block is a credibility hit.
 - **Should the connection-instructions section include a "minimal JWT for testing" path?** Right now visitors would need to register and copy a token from DevTools to exercise scoped tools. A more polished story would be a "guest token" link that mints a read-only JWT scoped to the demo user. Out of scope for this round; flagged for future iteration.

--- a/frontend/e2e/mocked/ai-mcp-section.spec.ts
+++ b/frontend/e2e/mocked/ai-mcp-section.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from "./fixtures";
+
+test.describe("/ai MCP Server section", () => {
+  test("MCP Server is the first section heading on /ai", async ({ page }) => {
+    await page.goto("/ai");
+    const sectionHeadings = page.locator("section h2");
+    await expect(sectionHeadings.first()).toHaveText("MCP Server");
+  });
+
+  test("RAG Evaluation appears as the second section on /ai", async ({ page }) => {
+    await page.goto("/ai");
+    const sectionHeadings = page.locator("section h2");
+    await expect(sectionHeadings.nth(1)).toHaveText("RAG Evaluation");
+  });
+
+  test("MCP section shows the verified public endpoint", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByText("https://api.kylebradshaw.dev/ai-api/mcp", { exact: false }).first(),
+    ).toBeVisible();
+  });
+
+  test("MCP section renders the Claude Desktop config snippet", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByRole("heading", { name: "Claude Desktop", exact: false }),
+    ).toBeVisible();
+    await expect(page.getByText('"mcpServers"', { exact: false })).toBeVisible();
+  });
+
+  test("MCP section renders the Codex CLI config snippet", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByRole("heading", { name: "Codex CLI", exact: false }),
+    ).toBeVisible();
+  });
+
+  test("MCP section renders the MCP Inspector command", async ({ page }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByText("npx @modelcontextprotocol/inspector", { exact: false }),
+    ).toBeVisible();
+  });
+
+  test("MCP section CTA links to the /go shopping assistant tab", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+    const cta = page.getByRole("link", { name: /Try it on the Go section/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/go");
+  });
+
+  test("MCP section links to the GitHub source for the MCP server", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+    const githubLink = page.getByRole("link", { name: /View source on GitHub/i });
+    await expect(githubLink).toBeVisible();
+    await expect(githubLink).toHaveAttribute(
+      "href",
+      /github\.com\/.*\/go\/ai-service\/internal\/mcp/,
+    );
+  });
+
+  test("Tool catalog renders on /ai (shared component, identifying caption)", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+    await expect(
+      page.getByText(/twelve tools/i).first(),
+    ).toBeVisible();
+  });
+
+  test("Tool catalog renders on /go AI Assistant tab", async ({ page }) => {
+    await page.goto("/go");
+    await page.getByRole("button", { name: "AI Assistant" }).click();
+    await expect(page.getByText(/twelve tools/i)).toBeVisible();
+  });
+});

--- a/frontend/src/app/ai/page.tsx
+++ b/frontend/src/app/ai/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { MermaidDiagram } from "@/components/MermaidDiagram";
+import { MCPSection } from "@/components/ai/MCPSection";
 
 const architectureDiagram = `flowchart LR
   subgraph Ingestion["Document Ingestion"]
@@ -48,10 +49,12 @@ export default function AISection() {
         {/* Bio */}
         <section className="mt-8">
           <p className="text-muted-foreground leading-relaxed">
-            Building intelligent systems with retrieval-augmented generation and
-            agentic architectures. This section demonstrates RAG pipelines,
-            vector search, LLM orchestration, and tool-using agents — built with
-            FastAPI, Qdrant, and Ollama, deployed on Kubernetes.
+            Building intelligent systems with retrieval-augmented generation,
+            agentic architectures, and Model Context Protocol (MCP) servers
+            that any AI client can call. This section demonstrates an MCP
+            server fronting twelve tools, RAG pipelines with evaluation,
+            vector search, and tool-using agents — built with FastAPI,
+            Qdrant, Ollama, and Go, deployed on Kubernetes.
           </p>
           <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
             Prometheus scrapes every AI service and streams metrics to a live{" "}
@@ -67,8 +70,41 @@ export default function AISection() {
           </p>
         </section>
 
-        {/* Project Explanation */}
+        {/* MCP Server (top section) */}
+        <MCPSection />
+
+        {/* RAG Evaluation */}
+        <section className="mt-16">
+          <h2 className="text-2xl font-semibold">RAG Evaluation</h2>
+          <p className="mt-4 text-muted-foreground leading-relaxed">
+            A measurement tool for systematically tracking RAG pipeline quality.
+            Create golden datasets with expected answers, run RAGAS evaluations
+            against the live pipeline, and view scorecards with per-query
+            breakdowns — faithfulness, answer relevancy, context precision, and
+            context recall.
+          </p>
+
+          <h3 className="mt-6 text-lg font-medium">What It Demonstrates</h3>
+          <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
+            <li>RAGAS evaluation framework for RAG quality measurement</li>
+            <li>Cross-service JWT authentication (Go auth → Python eval)</li>
+            <li>Async evaluation with polling for long-running LLM judge calls</li>
+            <li>Golden dataset management for repeatable quality tracking</li>
+          </ul>
+        </section>
+
+        {/* Eval Demo Link */}
         <section className="mt-12">
+          <Link
+            href="/ai/eval"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Try RAG Evaluation &rarr;
+          </Link>
+        </section>
+
+        {/* Document Q&A Assistant */}
+        <section className="mt-16">
           <h2 className="text-2xl font-semibold">Document Q&A Assistant</h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
             A full-stack Retrieval-Augmented Generation (RAG) application that
@@ -107,7 +143,7 @@ export default function AISection() {
           </Link>
         </section>
 
-        {/* Debug Assistant Section */}
+        {/* Debug Assistant */}
         <section className="mt-16">
           <h2 className="text-2xl font-semibold">Debug Assistant</h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
@@ -151,36 +187,6 @@ export default function AISection() {
             className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
           >
             Try the Debug Demo &rarr;
-          </Link>
-        </section>
-
-        {/* RAG Evaluation Section */}
-        <section className="mt-16">
-          <h2 className="text-2xl font-semibold">RAG Evaluation</h2>
-          <p className="mt-4 text-muted-foreground leading-relaxed">
-            A measurement tool for systematically tracking RAG pipeline quality.
-            Create golden datasets with expected answers, run RAGAS evaluations
-            against the live pipeline, and view scorecards with per-query
-            breakdowns — faithfulness, answer relevancy, context precision, and
-            context recall.
-          </p>
-
-          <h3 className="mt-6 text-lg font-medium">What It Demonstrates</h3>
-          <ul className="mt-2 list-disc pl-6 text-muted-foreground space-y-1">
-            <li>RAGAS evaluation framework for RAG quality measurement</li>
-            <li>Cross-service JWT authentication (Go auth → Python eval)</li>
-            <li>Async evaluation with polling for long-running LLM judge calls</li>
-            <li>Golden dataset management for repeatable quality tracking</li>
-          </ul>
-        </section>
-
-        {/* Eval Demo Link */}
-        <section className="mt-12">
-          <Link
-            href="/ai/eval"
-            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-          >
-            Try RAG Evaluation &rarr;
           </Link>
         </section>
       </div>

--- a/frontend/src/components/ai/MCPArchitectureDiagram.tsx
+++ b/frontend/src/components/ai/MCPArchitectureDiagram.tsx
@@ -1,0 +1,36 @@
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const mcpArchitectureChart = `flowchart LR
+  subgraph Clients ["External MCP clients"]
+    direction TB
+    CD[Claude Desktop]
+    CX[Codex CLI]
+    INS[MCP Inspector]
+  end
+  subgraph Server ["ai-service /mcp endpoint (Go)"]
+    direction TB
+    HTTP[HTTPS Streamable<br/>transport]
+    AUTH{Bearer JWT?}
+    REG[Tool registry<br/>12 tools]
+    HTTP --> AUTH
+    AUTH -->|valid token| REG
+    AUTH -->|absent| REG
+  end
+  subgraph Backends ["Backends (in-cluster)"]
+    direction TB
+    EC[Ecommerce<br/>REST + gRPC]
+    RAG[Python RAG bridge<br/>circuit breaker, OTel]
+    QD[(Qdrant)]
+    OLL[(Ollama)]
+    RAG --> QD
+    RAG --> OLL
+  end
+  CD -->|"public + auth-scoped<br/>tools"| HTTP
+  CX --> HTTP
+  INS -->|"discovery + invoke"| HTTP
+  REG --> EC
+  REG --> RAG`;
+
+export function MCPArchitectureDiagram() {
+  return <MermaidDiagram chart={mcpArchitectureChart} />;
+}

--- a/frontend/src/components/ai/MCPSection.tsx
+++ b/frontend/src/components/ai/MCPSection.tsx
@@ -1,0 +1,134 @@
+import Link from "next/link";
+import { MCPArchitectureDiagram } from "./MCPArchitectureDiagram";
+import { MCPToolCatalog } from "./MCPToolCatalog";
+
+const claudeDesktopConfig = `{
+  "mcpServers": {
+    "kyle-portfolio": {
+      "transport": "http",
+      "url": "https://api.kylebradshaw.dev/ai-api/mcp"
+    }
+  }
+}`;
+
+const codexConfig = `[mcp_servers.kyle-portfolio]
+transport = "http"
+url = "https://api.kylebradshaw.dev/ai-api/mcp"`;
+
+const inspectorCommand = `npx @modelcontextprotocol/inspector https://api.kylebradshaw.dev/ai-api/mcp`;
+
+const githubMcpUrl =
+  "https://github.com/kabradshaw1/portfolio/tree/main/go/ai-service/internal/mcp";
+
+export function MCPSection() {
+  return (
+    <section className="mt-12">
+      <h2 className="text-2xl font-semibold">MCP Server</h2>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The Go ai-service exposes twelve tools to any{" "}
+        <a
+          href="https://modelcontextprotocol.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-foreground transition-colors"
+        >
+          Model Context Protocol
+        </a>{" "}
+        client over HTTPS. Built on the official{" "}
+        <code>modelcontextprotocol/go-sdk</code>, it fronts both the ecommerce
+        backend (REST + gRPC) and a Python RAG pipeline (HTTP, circuit breaker,
+        OTel trace propagation). Authentication is optional: catalog and
+        knowledge-base tools work anonymously; cart, order, and return tools
+        require a Bearer JWT.
+      </p>
+
+      <h3 className="mt-10 text-xl font-semibold">Architecture</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        External MCP clients connect over the HTTPS Streamable transport. The
+        Go server enforces optional JWT auth, then routes tool calls to either
+        the ecommerce backend or the Python RAG bridge. The bridge uses a
+        circuit breaker with a 30-second timeout and propagates OTel trace
+        context across the language boundary.
+      </p>
+      <div className="mt-6 rounded-xl border border-foreground/10 bg-card p-6">
+        <MCPArchitectureDiagram />
+      </div>
+
+      <MCPToolCatalog />
+
+      <h3 className="mt-10 text-xl font-semibold">Try it interactively</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The same tool registry powers an in-browser agent loop on the Go
+        section. The agent runs Qwen 2.5 14B locally and streams tool calls
+        and results live.
+      </p>
+      <div className="mt-6">
+        <Link
+          href="/go"
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Try it on the Go section &rarr;
+        </Link>
+      </div>
+
+      <h3 className="mt-10 text-xl font-semibold">Connect your own client</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The MCP server is publicly reachable at{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-sm">
+          https://api.kylebradshaw.dev/ai-api/mcp
+        </code>
+        . Public tools (catalog search, RAG search,{" "}
+        <code>list_collections</code>) work without auth. Auth-scoped tools
+        require a Bearer JWT &mdash; register at{" "}
+        <Link href="/go/register" className="underline hover:text-foreground">
+          /go/register
+        </Link>
+        , log in, and copy the access token from the{" "}
+        <code>Authorization</code> header in DevTools.
+      </p>
+
+      <h4 className="mt-6 text-lg font-medium">Claude Desktop</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Add to{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+          ~/Library/Application Support/Claude/claude_desktop_config.json
+        </code>
+        :
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg border border-foreground/10 bg-card p-4 text-xs">
+        <code>{claudeDesktopConfig}</code>
+      </pre>
+
+      <h4 className="mt-6 text-lg font-medium">Codex CLI</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Add to{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+          ~/.codex/config.toml
+        </code>
+        :
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg border border-foreground/10 bg-card p-4 text-xs">
+        <code>{codexConfig}</code>
+      </pre>
+
+      <h4 className="mt-6 text-lg font-medium">MCP Inspector</h4>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Browse and invoke tools directly:
+      </p>
+      <pre className="mt-3 overflow-x-auto rounded-lg border border-foreground/10 bg-card p-4 text-xs">
+        <code>{inspectorCommand}</code>
+      </pre>
+
+      <p className="mt-8 text-sm">
+        <a
+          href={githubMcpUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-foreground transition-colors"
+        >
+          View source on GitHub &rarr;
+        </a>
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/components/ai/MCPToolCatalog.tsx
+++ b/frontend/src/components/ai/MCPToolCatalog.tsx
@@ -1,0 +1,50 @@
+import { MermaidDiagram } from "@/components/MermaidDiagram";
+
+const toolCatalogChart = `flowchart LR
+  AGENT((MCP client<br/>or in-app agent))
+  subgraph Catalog ["Catalog (public)"]
+    T1[search_products<br/>query + max_price]
+    T2[get_product<br/>full details by ID]
+    T3[check_inventory<br/>stock count]
+  end
+  subgraph Orders ["Orders (auth-scoped)"]
+    T4[list_orders<br/>last 20 orders]
+    T5[get_order<br/>single order detail]
+    T6[summarize_orders<br/>LLM-generated summary]
+  end
+  subgraph CartReturns ["Cart & Returns (auth-scoped)"]
+    T7[view_cart<br/>items + total]
+    T8[add_to_cart<br/>product + quantity]
+    T9[initiate_return<br/>order item + reason]
+  end
+  subgraph Knowledge ["Knowledge Base (public, RAG)"]
+    T10[search_documents<br/>semantic search + sources]
+    T11[ask_document<br/>natural-language Q&A]
+    T12[list_collections<br/>vector store inventory]
+  end
+  AGENT --> Catalog
+  AGENT --> Orders
+  AGENT --> CartReturns
+  AGENT --> Knowledge
+  X[place_order<br/>deliberately excluded]:::disabled
+  AGENT -.-x X
+  classDef disabled stroke-dasharray: 5 5,opacity:0.5`;
+
+export function MCPToolCatalog() {
+  return (
+    <div>
+      <h3 className="mt-10 text-xl font-semibold">Tool Catalog</h3>
+      <p className="mt-4 text-muted-foreground leading-relaxed">
+        The MCP server exposes twelve tools across four domains. Catalog and
+        knowledge-base tools are public; order, cart, and return tools require a
+        Bearer JWT. Knowledge-base tools call the Python RAG pipeline through a
+        circuit-breaker HTTP bridge with a 30-second timeout. Checkout
+        (<code>place_order</code>) is deliberately excluded &mdash; the agent
+        can advise but not transact.
+      </p>
+      <div className="mt-6">
+        <MermaidDiagram chart={toolCatalogChart} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/go/tabs/AiAssistantTab.tsx
+++ b/frontend/src/components/go/tabs/AiAssistantTab.tsx
@@ -1,4 +1,5 @@
 import { MermaidDiagram } from "@/components/MermaidDiagram";
+import { MCPToolCatalog } from "@/components/ai/MCPToolCatalog";
 
 export function AiAssistantTab() {
   return (
@@ -14,48 +15,7 @@ export function AiAssistantTab() {
         across the stack boundary.
       </p>
 
-      <h3 className="mt-10 text-xl font-semibold">Tool Catalog</h3>
-      <p className="mt-4 text-muted-foreground leading-relaxed">
-        The agent has access to twelve tools organized into four domains.
-        Catalog tools are public; order, cart, and return tools require JWT
-        authentication; knowledge base tools are public and hit the Python
-        RAG pipeline via a circuit-breaker HTTP bridge with 30-second
-        timeout. Checkout is deliberately excluded &mdash; the agent can
-        advise but not transact.
-      </p>
-      <div className="mt-6">
-        <MermaidDiagram
-          chart={`flowchart LR
-  AGENT((Agent<br/>Qwen 2.5 14B))
-  subgraph Catalog ["Catalog (public)"]
-    T1[search_products<br/>query + max_price]
-    T2[get_product<br/>full details by ID]
-    T3[check_inventory<br/>stock count]
-  end
-  subgraph Orders ["Orders (auth-scoped)"]
-    T4[list_orders<br/>last 20 orders]
-    T5[get_order<br/>single order detail]
-    T6[summarize_orders<br/>LLM-generated summary]
-  end
-  subgraph CartReturns ["Cart & Returns (auth-scoped)"]
-    T7[view_cart<br/>items + total]
-    T8[add_to_cart<br/>product + quantity]
-    T9[initiate_return<br/>order item + reason]
-  end
-  subgraph Knowledge ["Knowledge Base (public, RAG)"]
-    T10[search_documents<br/>semantic search + sources]
-    T11[ask_document<br/>natural-language Q&A]
-    T12[list_collections<br/>vector store inventory]
-  end
-  AGENT --> Catalog
-  AGENT --> Orders
-  AGENT --> CartReturns
-  AGENT --> Knowledge
-  X[place_order<br/>deliberately excluded]:::disabled
-  AGENT -.-x X
-  classDef disabled stroke-dasharray: 5 5,opacity:0.5`}
-        />
-      </div>
+      <MCPToolCatalog />
 
       <h3 className="mt-10 text-xl font-semibold">Agent Loop</h3>
       <p className="mt-4 text-muted-foreground leading-relaxed">


### PR DESCRIPTION
## Summary
- Lead the /ai portfolio page with a new MCP Server section explaining the official-SDK MCP server, its architecture, and the 12-tool catalog.
- Extract the tool catalog into a shared `<MCPToolCatalog />` component reused on both /ai and /go (Shopping Assistant tab).
- Add connect-your-own-client snippets for Claude Desktop, Codex CLI, and MCP Inspector pointing at the verified public endpoint `https://api.kylebradshaw.dev/ai-api/mcp`.
- Reorder /ai sections so RAG Evaluation sits immediately below the new MCP section.

Closes #79 — RAG eval harness shipped under `services/eval/`.
Closes #83 — Eval Service UI shipped at `/ai/eval`.

## Test plan
- [x] `make preflight-frontend` passes (tsc + next build + eslint, 0 errors)
- [x] `make preflight-e2e` passes — 31/31 mocked e2e tests pass, including new `frontend/e2e/mocked/ai-mcp-section.spec.ts` (10 tests)
- [ ] Visual check on QA: MCP Server is first \`<h2>\`, RAG Evaluation second; tool catalog renders on both /ai and /go
- [ ] Public endpoint resolves: \`curl -s -o /dev/null -w "%{http_code}\n" https://qa-api.kylebradshaw.dev/ai-api/mcp\` returns a non-5xx response

🤖 Generated with [Claude Code](https://claude.com/claude-code)