### PR TITLE
feat(pitr): WAL archiving + point-in-time recovery

### DIFF
--- a/docs/adr/database/wal-archiving-pitr.md
+++ b/docs/adr/database/wal-archiving-pitr.md
@@ -1,0 +1,96 @@
+# ADR: WAL Archiving + Point-in-Time Recovery (2026-04-27)
+
+## Status
+Accepted
+
+## Context
+
+The existing data-integrity work (`docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md`) gave the shared Postgres 17 instance daily `pg_dump` snapshots with 7-day retention. RPO under that posture is up to 24 hours: a disaster at 23:59 loses an entire day's writes.
+
+Phase 2 of that ADR explicitly listed WAL-based continuous archiving as the next step. This ADR documents what landed.
+
+## Decisions
+
+### Native `archive_command` rather than pgBackRest or Wal-G
+
+Postgres ships `archive_command` and `pg_basebackup` in the core image. A POSIX-`sh` wrapper script that does `cp + sync + atomic rename` is ~15 lines and has no operational dependencies beyond the base image. pgBackRest is a more capable tool — incremental backups, encryption, parallel archive, S3 first-class — but it adds a binary, a config file, a separate daemon, and a different mental model from the surrounding pg_dump pipeline.
+
+For the portfolio, the native primitives are the right choice: they teach the underlying mechanism, the failure modes are the ones a textbook covers, and the interview narrative ("I wrote the archive_command myself") is more interesting than "I configured pgBackRest." When we outgrow the script — multi-region, off-host storage, incremental — pgBackRest is the natural next step.
+
+### Two retained base backups, not one
+
+The basebackup script keeps the four most recent weekly base backups, and prunes WAL only down to the *second-most-recent* base backup's `START WAL LOCATION`. This is defence in depth: if the most recent base backup is corrupt or unreadable, the previous backup plus retained WAL still gives a recoverable point.
+
+Cost: roughly an extra week of WAL on disk (~50–200 MB compressed). Trivial against the 10 GB PV.
+
+### `archive_timeout = 300`
+
+Without `archive_timeout`, an idle Postgres might never fill a WAL segment, leaving the most recent commits unarchived for arbitrary durations. `archive_timeout = 300` (5 minutes) forces a WAL switch every five minutes during idle periods, capping the gap between commit and archive at ~5 minutes plus the few seconds the wrapper needs.
+
+The cost is one mostly-empty WAL segment file every 5 idle minutes. At 16 MB per WAL segment, that's ~4.6 GB/day of zero-padded archive in the worst case — pruning catches up at the next weekly base backup, so steady-state WAL on disk is bounded by the inter-basebackup interval, not the timeout.
+
+### `--wal-method=fetch` (WAL bundled into the base backup)
+
+`pg_basebackup` defaults to `stream` WAL mode, which uses a second connection to stream WAL while the base backup runs and writes a small `pg_wal/` directory referencing the live archive. With `fetch`, the WAL needed to make the base backup self-consistent is bundled into the tarball.
+
+The downside (slightly larger tarball) is acceptable. The upside is significant: a `fetch` tarball is restorable on its own — even if the WAL archive directory is later wiped or corrupted, the base backup can still bootstrap a cluster up to its checkpoint. This matters for the no-paid-services constraint where archive and base-backup live on the same physical disk.
+
+### `replicator` role, not reusing `taskuser`
+
+`pg_basebackup` only needs the `REPLICATION` attribute. The application's `taskuser` already has full DDL/DML on every database; granting it `REPLICATION` would be a principle-of-least-privilege violation. A dedicated `replicator` role with only `REPLICATION LOGIN` keeps the base-backup credential's blast radius tiny — even if leaked, it cannot read application data.
+
+### Three new alerts use existing Prometheus metrics, not a custom exporter
+
+`pg_stat_archiver_archived_count`, `pg_stat_archiver_failed_count`, `pg_stat_archiver_last_archived_time` are scraped by the existing `postgres_exporter` sidecar from the built-in `pg_stat_archiver` view. `kube_cronjob_status_last_successful_time` is exposed by the existing `kube-state-metrics` deployment. No new exporter, scrape config, or textfile collector is introduced.
+
+### Three panels appended to the existing PostgreSQL dashboard
+
+The query-observability work already has its own dashboard (`pg-query-performance`). Archive health is operational, not query-performance, so these panels belong on the existing `postgresql` dashboard alongside connection utilization, cache hit ratio, and pg_dump backup freshness. The on-call engineer sees archive health on the same screen as everything else they care about.
+
+### Same physical disk as data — accepted constraint
+
+The `wal-archive` and `basebackup` PVs are hostPath PVs on the same Debian node where the data PVC lives. A whole-disk failure loses both data and backups simultaneously. This is an explicit constraint of the no-paid-services posture and is acknowledged in the data-integrity ADR's trade-offs section. The mitigation (off-host archive on S3) is a separate roadmap item awaiting relaxation of that constraint.
+
+## Consequences
+
+**Positive:**
+- RPO drops from ≤ 24 hours to ≤ 5 minutes (one `archive_timeout` window plus pending in-flight WAL).
+- An operator can recover to any timestamp within the WAL retention window using the runbook's Scenario 4 — the most powerful Postgres recovery primitive.
+- Archive failures and base-backup staleness are alerted, not silent. A broken `archive_command` would otherwise stall WAL recycling and silently fill the data PVC.
+- The `replicator` role pattern generalizes: streaming replication (roadmap item #161) reuses the same role.
+
+**Trade-offs:**
+- `archive_mode = on` requires a Postgres restart. Acceptable given the existing `Recreate` deployment strategy.
+- Disk usage grows by ~10 GB (two new hostPath PVs) on the Minikube node.
+- The wrapper script's loud-fail behaviour on existing-archive-file means an operator running disaster-recovery exercises may see legitimate alert noise; bypass requires consciously deleting the offending archive file.
+- WAL archive lives on the same physical disk as the data PVC. Disk failure remains unmitigated.
+
+**Phase 3 (future, separate roadmap items):**
+- Streaming replication / hot standby (#161) — same WAL stream, different consumer.
+- Off-host archive (S3-compatible) once the no-paid-services constraint relaxes.
+- Automated weekly PITR drill (#158) — periodic restore-and-verify using the artifacts produced here.
+
+## Operator action required when applying
+
+The live `java-secrets` Secret in the cluster needs a new `replicator-password` key. Generate a new password, base64-encode, and patch the existing Secret:
+
+```bash
+NEW_PW=$(openssl rand -hex 24)
+ssh debian "kubectl get secret java-secrets -n java-tasks -o json | \
+  jq --arg pw \"\$(echo -n $NEW_PW | base64)\" \
+  '.data[\"replicator-password\"] = \$pw' | kubectl apply -f -"
+```
+
+Then kick the bootstrap Job:
+
+```bash
+ssh debian "kubectl delete job postgres-replicator-bootstrap -n java-tasks --ignore-not-found"
+cat java/k8s/jobs/postgres-replicator-bootstrap.yml | ssh debian "kubectl apply -f -"
+```
+
+The first base backup runs naturally on the next Sunday 03:00 UTC. To validate sooner, run it manually:
+
+```bash
+ssh debian "kubectl create job --from=cronjob/postgres-basebackup postgres-basebackup-manual -n java-tasks"
+ssh debian "kubectl logs job/postgres-basebackup-manual -n java-tasks -f"
+```

--- a/docs/runbooks/postgres-recovery.md
+++ b/docs/runbooks/postgres-recovery.md
@@ -2,15 +2,21 @@
 
 ## Overview
 
-The shared PostgreSQL instance (`postgres` deployment in `java-tasks` namespace) hosts all Go and Java service databases. This runbook covers three recovery scenarios ordered by severity.
+The shared PostgreSQL instance (`postgres` deployment in `java-tasks` namespace) hosts all Go and Java service databases. This runbook covers four recovery scenarios ordered by severity.
 
 **Related alerts:**
-- `Postgres Backup Stale` — no successful backup in 26h
+- `Postgres Backup Stale` — no successful pg_dump in 26h → Scenario 2
 - `Postgres Connection Utilization High` — connections > 80%
 - `Postgres Cache Hit Ratio Low` — cache ratio < 95%
 - `Postgres Deadlocks Detected` — deadlocks in 5m window
+- `Postgres Archive Command Failing` — `archive_command` exiting non-zero → Scenario 4 (preventive — not a recovery trigger by itself)
+- `Postgres WAL Archive Stale` — no new WAL archived in 10+ min → Scenario 4 (preventive)
+- `Postgres Base Backup Stale` — no successful weekly base backup in 8d → Scenario 4 (preventive)
 
-**Backup location:** `/backups/postgres/` on the Debian host (outside Minikube PVC)
+**Backup locations on the Debian host:**
+- `/backups/postgres/` — daily `pg_dump` per database (Scenario 2)
+- `/backups/wal-archive/` — continuous WAL archive (Scenario 4)
+- `/backups/basebackup/` — weekly `pg_basebackup` tarballs (Scenario 4)
 
 ---
 
@@ -212,3 +218,137 @@ Restoring from backup preserves data created after the last seed run.
    ```
 
 5. **Verify** the service is healthy via its health endpoint.
+
+---
+
+## Scenario 4: Point-in-Time Recovery (PITR) to a Specific Timestamp
+
+### Symptoms
+
+- A specific destructive event has been identified — bad migration, accidental
+  `DELETE`/`UPDATE` without `WHERE`, malicious write — and rolling the cluster
+  back to a point *just before* the event will recover the data.
+- A pg_dump restore (Scenario 2) would lose too much: the most recent dump is
+  hours older than the event's timestamp, and the daily snapshot granularity
+  is unacceptable for the affected data.
+- Postgres itself is healthy — this scenario is for *logical* recovery, not
+  physical-corruption recovery.
+
+### Prerequisites
+
+- The event's timestamp is known (Grafana, application logs, audit trail).
+- That timestamp falls within the WAL archive retention window: at minimum,
+  later than the `START WAL LOCATION` of the second-most-recent base backup.
+  (The basebackup script retains WAL only that far back.)
+- A base backup taken *before* the target timestamp exists in
+  `/backups/basebackup/` on the Debian host.
+- The `replicator-password` key in the live `java-secrets` Secret is set.
+  (Check: `kubectl get secret java-secrets -n java-tasks -o jsonpath='{.data.replicator-password}' | base64 -d`
+  should print a non-empty value.)
+
+**Estimated time:** 15-30 minutes (dominated by base-backup unpack + WAL replay).
+
+### Steps
+
+1. **Find a usable base backup taken *before* the target timestamp:**
+   ```bash
+   ssh debian "ls -1 /backups/basebackup/"
+   ```
+   Pick the most recent directory whose timestamp (`YYYYMMDDTHHMMSSZ` format)
+   is earlier than the target timestamp. Set:
+   ```bash
+   BACKUP_STAMP=20260426T030000Z   # adjust
+   TARGET_TIME='2026-04-27 14:23:00 UTC'   # adjust
+   ```
+
+2. **Stop Postgres so the data PVC is unmounted:**
+   ```bash
+   ssh debian "kubectl scale deployment postgres -n java-tasks --replicas=0"
+   ssh debian "kubectl wait --for=delete pod -l app=postgres -n java-tasks --timeout=120s"
+   ```
+
+3. **Wipe the data PVC (it will be re-seeded from the base backup):**
+   ```bash
+   ssh debian "kubectl delete pvc postgres-data -n java-tasks"
+   ssh debian "kubectl get pv | awk '/postgres-data/ {print \$1}' | xargs -r kubectl delete pv"
+   cat java/k8s/volumes/postgres-pvc.yml | ssh debian "kubectl apply -f -"
+   ```
+
+4. **Unpack the base backup tarball into the new data PVC.** Run a one-shot
+   pod with both PVCs mounted:
+   ```bash
+   ssh debian "kubectl run pitr-restore -n java-tasks --restart=Never \
+     --image=postgres:17-alpine \
+     --overrides='{\"spec\":{\"containers\":[{\"name\":\"pitr-restore\",\"image\":\"postgres:17-alpine\",\"command\":[\"sh\",\"-c\",\"sleep 3600\"],\"volumeMounts\":[{\"name\":\"data\",\"mountPath\":\"/var/lib/postgresql/data\"},{\"name\":\"basebackup\",\"mountPath\":\"/backups/basebackup\",\"readOnly\":true}]}],\"volumes\":[{\"name\":\"data\",\"persistentVolumeClaim\":{\"claimName\":\"postgres-data\"}},{\"name\":\"basebackup\",\"persistentVolumeClaim\":{\"claimName\":\"postgres-basebackup\"}}]}}' \
+     --command -- sh -c 'sleep 3600'"
+
+   ssh debian "kubectl wait --for=condition=ready pod/pitr-restore -n java-tasks --timeout=60s"
+   ssh debian "kubectl exec -n java-tasks pitr-restore -- sh -c '
+     mkdir -p /var/lib/postgresql/data/pgdata &&
+     cd /var/lib/postgresql/data/pgdata &&
+     tar -xzf /backups/basebackup/${BACKUP_STAMP}/base.tar.gz &&
+     tar -xzf /backups/basebackup/${BACKUP_STAMP}/pg_wal.tar.gz -C pg_wal/ &&
+     chown -R postgres:postgres /var/lib/postgresql/data
+   '"
+   ```
+
+5. **Configure recovery target.** Append to `postgresql.auto.conf` and drop a
+   `recovery.signal` file:
+   ```bash
+   ssh debian "kubectl exec -n java-tasks pitr-restore -- sh -c \"
+     cat >> /var/lib/postgresql/data/pgdata/postgresql.auto.conf <<EOF
+   restore_command = 'cp /var/lib/postgresql/wal-archive/%f %p'
+   recovery_target_time = '${TARGET_TIME}'
+   recovery_target_action = 'promote'
+   EOF
+     touch /var/lib/postgresql/data/pgdata/recovery.signal
+     chown postgres:postgres /var/lib/postgresql/data/pgdata/postgresql.auto.conf
+     chown postgres:postgres /var/lib/postgresql/data/pgdata/recovery.signal
+   \""
+
+   ssh debian "kubectl delete pod pitr-restore -n java-tasks"
+   ```
+
+   Note: `restore_command` reads from `/var/lib/postgresql/wal-archive/`,
+   which is mounted into the postgres pod from the `postgres-wal-archive`
+   PVC. Postgres replays WAL from there in order until `recovery_target_time`
+   is reached, then promotes (becomes a normal read-write database).
+
+6. **Scale Postgres back up:**
+   ```bash
+   ssh debian "kubectl scale deployment postgres -n java-tasks --replicas=1"
+   ssh debian "kubectl wait --for=condition=ready pod -l app=postgres -n java-tasks --timeout=300s"
+   ```
+
+   Watch logs to see WAL replay progress:
+   ```bash
+   ssh debian "kubectl logs -n java-tasks deployment/postgres --tail=200 -f"
+   ```
+   Look for `redo done at <LSN>` and `recovery target time reached at <ts>` —
+   these confirm the recovery target was honored. The line
+   `archive recovery complete` indicates promotion.
+
+7. **Verify:** query for the absence of the corruption-causing row, or the
+   presence of the row that was deleted:
+   ```bash
+   ssh debian "kubectl exec deployment/postgres -n java-tasks -- \
+     psql -U taskuser -d <affected-db> -c \"<verification query>\""
+   ```
+
+8. **Restart all services to drop stale connections:**
+   ```bash
+   ssh debian "kubectl rollout restart deployment -n go-ecommerce"
+   ssh debian "kubectl rollout restart deployment -n go-ecommerce-qa"
+   ssh debian "kubectl rollout restart deployment task-service -n java-tasks"
+   ```
+
+### After-action
+
+- File a follow-up to take a fresh `pg_dump` ASAP (the daily backup at 02:00 UTC
+  may not run before the next incident) — the cluster is now on a new timeline
+  but the backup pipeline is not aware of that until the next dump.
+- The next weekly `postgres-basebackup` (Sunday 03:00 UTC) will pick up the
+  new timeline automatically — no manual intervention required.
+- If the target timestamp turned out to be wrong, you can re-run this entire
+  procedure from the same base backup tarball; the WAL archive is unchanged
+  by the restore.

--- a/docs/superpowers/plans/2026-04-27-pitr.md
+++ b/docs/superpowers/plans/2026-04-27-pitr.md
@@ -1,0 +1,1541 @@
+# WAL Archiving + Point-in-Time Recovery — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Continuously archive WAL segments and take weekly base backups of the shared Postgres 17 instance so any operator can restore the cluster to any timestamp within the retention window. Add Prometheus alerts and Grafana panels so archive failures and backup staleness are visible, not silent.
+
+**Architecture:** Two new hostPath PVs (`postgres-wal-archive`, `postgres-basebackup`) follow the existing `postgres-backup` pattern. A new ConfigMap (`postgres-wal-scripts`) ships two POSIX `sh` scripts: an atomic `archive_command` wrapper, and a weekly `pg_basebackup` + WAL-prune script run by a new `postgres-basebackup` CronJob. The Postgres deployment gains four new `args` flags (`archive_mode`, `archive_command`, `archive_timeout`, `wal_level`), the wrapper script mount, and the wal-archive volume mount. A new `replicator` role with `REPLICATION` privilege is created by a one-shot Job (mirrors the existing `postgres-grafana-reader` Job). Three panels are appended to the existing PostgreSQL dashboard, three alert rules are appended to the existing PostgreSQL alert group. The PITR procedure is appended to the existing recovery runbook as Scenario 4.
+
+**Tech Stack:** PostgreSQL 17 (`archive_mode`, `archive_command`, `pg_basebackup`, `pg_archivecleanup`), Kubernetes (CronJob, ConfigMap, hostPath PV, kustomize overlay patches), Prometheus + `pg_stat_archiver`, kube-state-metrics (`kube_cronjob_status_last_successful_time`), Grafana (dashboards + unified alerting), `golang-migrate`-style one-shot Job for SQL bootstrap, Go testcontainers (integration test).
+
+---
+
+## File Structure
+
+**New files:**
+
+| Path | Purpose |
+|---|---|
+| `java/k8s/configmaps/postgres-wal-scripts.yml` | `pg-archive-wal.sh` + `pg-basebackup-and-prune.sh`, mounted 0755 |
+| `java/k8s/volumes/postgres-wal-archive-pv.yml` | hostPath PV + PVC, 10Gi, ReadWriteOnce, `/backups/wal-archive` |
+| `java/k8s/volumes/postgres-basebackup-pv.yml` | hostPath PV + PVC, 10Gi, ReadWriteOnce, `/backups/basebackup` |
+| `java/k8s/jobs/postgres-replicator-bootstrap.yml` | One-shot Job that creates / re-passwords `replicator` role |
+| `java/k8s/cronjobs/postgres-basebackup.yml` | Weekly base backup CronJob (Sundays 03:00 UTC) |
+| `go/pkg/db/wal_archive_integration_test.go` | testcontainers test: archive script runs, files appear, idempotent |
+| `docs/adr/database/wal-archiving-pitr.md` | Companion ADR (creates `database/` dir) |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `java/k8s/secrets/java-secrets.yml.template` | Add `replicator-password` key (template only, real secret is set out of band) |
+| `java/k8s/deployments/postgres.yml` | Append 4 args, mount wal-archive PVC, mount wal-scripts CM into `/usr/local/bin/` |
+| `java/k8s/kustomization.yaml` | Add the four new manifests + create `cronjobs/` directory entry |
+| `k8s/overlays/qa-java/kustomization.yaml` | Add `$patch: delete` for the new CronJob and the new replicator-bootstrap Job (QA shares prod Postgres; this avoids duplicate base backups + redundant role-creation runs) |
+| `k8s/monitoring/configmaps/grafana-dashboards.yml` | Append 3 panels to `postgresql.json`, increment `version` and `id` numbering |
+| `k8s/monitoring/configmaps/grafana-alerting.yml` | Append 3 rules to the existing `PostgreSQL` group |
+| `docs/runbooks/postgres-recovery.md` | Append Scenario 4 (PITR), add cross-link from header |
+
+**Why the new `cronjobs/` directory in `java/k8s/`?** The existing `postgres-backup` CronJob lives in `java/k8s/jobs/` for historical reasons. Plotting two CronJobs into a directory called `jobs/` becomes confusing when half are one-shot Jobs (`postgres-grafana-reader`, `postgres-extensions-bootstrap`) and half are CronJobs. Move forward by creating `java/k8s/cronjobs/` for the new file. The existing `postgres-backup.yml` is left where it is — relocating it is out of scope.
+
+**Why is the QA overlay involved?** The QA Java overlay deletes the postgres `Deployment` + `PVC` and replaces the `Service` with `ExternalName` pointing at the prod Postgres (see `k8s/overlays/qa-java/kustomization.yaml:65-101`). Without a delete patch, the new `postgres-basebackup` CronJob would also be applied into `java-tasks-qa` and run weekly base backups against the prod Postgres from a second namespace — duplicate heavy work. Same argument applies to the `replicator` role bootstrap Job.
+
+---
+
+## Conventions used in this plan
+
+- Indentation in YAML manifests is **2 spaces** (matches the rest of the repo).
+- Bash heredocs in K8s manifests use `<<'EOF'` (single-quoted) so `$VAR` in script bodies is not expanded by the shell wrapping the heredoc.
+- Resource requests/limits follow the small-Job pattern from `postgres-grafana-reader.yml`: `requests {cpu:10m, memory:32Mi}`, `limits {cpu:100m, memory:64Mi}` for psql Jobs; `requests {cpu:100m, memory:128Mi}`, `limits {cpu:500m, memory:512Mi}` for the basebackup CronJob (heavier).
+- All commits go on `agent/feat-pitr` (already created in worktree). Run `make preflight-go` before any commit that touches Go code.
+
+---
+
+## Task 1: Add the WAL archive + basebackup PVs and PVCs
+
+**Files:**
+- Create: `java/k8s/volumes/postgres-wal-archive-pv.yml`
+- Create: `java/k8s/volumes/postgres-basebackup-pv.yml`
+
+- [ ] **Step 1: Create `postgres-wal-archive-pv.yml`**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-wal-archive-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /backups/wal-archive
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-wal-archive
+  namespace: java-tasks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+- [ ] **Step 2: Create `postgres-basebackup-pv.yml`**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-basebackup-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /backups/basebackup
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-basebackup
+  namespace: java-tasks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+- [ ] **Step 3: Validate YAML structure**
+
+Run: `kubectl --dry-run=client apply -f java/k8s/volumes/postgres-wal-archive-pv.yml -f java/k8s/volumes/postgres-basebackup-pv.yml`
+Expected: each resource prints `<name> created (dry run)`. No error.
+
+(If kubectl is not on PATH locally, skip — CI's `policy-check` job runs it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add java/k8s/volumes/postgres-wal-archive-pv.yml java/k8s/volumes/postgres-basebackup-pv.yml
+git commit -m "feat(pitr): add wal-archive and basebackup hostPath PVs"
+```
+
+---
+
+## Task 2: Author the WAL archive + basebackup wrapper scripts ConfigMap
+
+**Files:**
+- Create: `java/k8s/configmaps/postgres-wal-scripts.yml`
+
+The ConfigMap holds two POSIX `sh` scripts. Both are mounted at `/usr/local/bin/` with `defaultMode: 0755`.
+
+- [ ] **Step 1: Create the ConfigMap**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-wal-scripts
+  namespace: java-tasks
+data:
+  pg-archive-wal.sh: |
+    #!/bin/sh
+    # Postgres archive_command target.
+    #   $1 = %p — absolute path to the WAL segment (under pg_wal/)
+    #   $2 = %f — segment filename
+    # Contract: exit 0 on success. Anything non-zero causes Postgres to
+    # retry forever, which stalls WAL recycling — so we want loud-fail
+    # on real corruption (overwrite attempt) and durable success on the
+    # happy path.
+    set -eu
+
+    SRC="$1"
+    FN="$2"
+    DST_DIR="/var/lib/postgresql/wal-archive"
+    DST="$DST_DIR/$FN"
+    TMP="$DST.tmp"
+
+    if [ -e "$DST" ]; then
+      echo "pg-archive-wal: $FN already archived; refusing overwrite" >&2
+      exit 1
+    fi
+
+    cp "$SRC" "$TMP"
+    sync "$TMP"
+    mv "$TMP" "$DST"
+  pg-basebackup-and-prune.sh: |
+    #!/bin/sh
+    # Weekly: take a base backup as a gzip tarball, prune old base
+    # backups, and prune WAL older than the second-newest surviving
+    # base backup.
+    set -eu
+
+    STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+    BACKUP_DIR="/backups/basebackup/$STAMP"
+    ARCHIVE_DIR="/backups/wal-archive"
+    RETAIN=4   # keep 4 most-recent weekly base backups
+
+    mkdir -p "$BACKUP_DIR"
+
+    echo "Base backup -> $BACKUP_DIR"
+    pg_basebackup \
+      --host=postgres.java-tasks.svc.cluster.local \
+      --username=replicator \
+      --pgdata="$BACKUP_DIR" \
+      --format=tar \
+      --gzip --compress=6 \
+      --wal-method=fetch \
+      --label="weekly-$STAMP" \
+      --checkpoint=fast \
+      --progress
+
+    echo "Pruning base backups older than $RETAIN newest..."
+    # shellcheck disable=SC2012  # ls -1d is fine for our naming convention
+    ls -1d /backups/basebackup/*/ 2>/dev/null \
+      | sort \
+      | head -n -"$RETAIN" \
+      | xargs -r rm -rf
+
+    echo "Pruning WAL older than the second-newest base backup..."
+    SECOND_NEWEST=$(ls -1d /backups/basebackup/*/ 2>/dev/null | sort | tail -n 2 | head -n 1)
+    if [ -n "$SECOND_NEWEST" ] && [ -f "$SECOND_NEWEST/backup_label.gz" ]; then
+      START_WAL=$(zcat "$SECOND_NEWEST/backup_label.gz" \
+                  | awk '/^START WAL LOCATION:/ {print $6; exit}' \
+                  | tr -d '()')
+      if [ -n "$START_WAL" ]; then
+        pg_archivecleanup "$ARCHIVE_DIR" "$START_WAL"
+      fi
+    fi
+
+    echo "Base backup + prune complete."
+    ls -1d /backups/basebackup/*/ | sort
+```
+
+Notes for the implementer:
+- These scripts are POSIX `sh`, not bash. Don't use `[[`, `local`, `<<<`, or arrays.
+- The archive script's `mv` after `sync` is the atomicity contract: even if Postgres crashes mid-archive, an incomplete `.tmp` file is left behind but the `archive_command` from Postgres's perspective failed (exit non-zero) and will be retried. A real archived file is always complete.
+- `pg_basebackup` and `pg_archivecleanup` come pre-installed in the `postgres:17-alpine` image used by the CronJob; no extra package install needed.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add java/k8s/configmaps/postgres-wal-scripts.yml
+git commit -m "feat(pitr): postgres-wal-scripts configmap (archive_command + basebackup wrappers)"
+```
+
+---
+
+## Task 3: Add the replicator-password key to the secret template
+
+**Files:**
+- Modify: `java/k8s/secrets/java-secrets.yml.template`
+
+The secret template documents the keys an operator must populate when applying the real secret. The actual base64 password is set in the runtime cluster outside source control — the template provides the placeholder.
+
+- [ ] **Step 1: Append the new key**
+
+Open `java/k8s/secrets/java-secrets.yml.template` and add `replicator-password` after `grafana-reader-password`:
+
+```yaml
+# Template — replace base64 values before applying
+apiVersion: v1
+kind: Secret
+metadata:
+  name: java-secrets
+  namespace: java-tasks
+type: Opaque
+data:
+  # grafana_reader role created by jobs/postgres-grafana-reader.yml using this key
+  # echo -n 'value' | base64
+  postgres-password: dGFza3Bhc3M=       # taskpass
+  jwt-secret: ZGV2LXNlY3JldC1rZXktYXQtbGVhc3QtMzItY2hhcmFjdGVycy1sb25n
+  google-client-id: ""
+  google-client-secret: ""
+  grafana-reader-password: Z3JhZmFuYS1yZWFkZXItc2VjcmV0   # grafana-reader-secret
+  # replicator role created by jobs/postgres-replicator-bootstrap.yml using this key
+  replicator-password: cmVwbGljYXRvci1zZWNyZXQ=           # replicator-secret
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add java/k8s/secrets/java-secrets.yml.template
+git commit -m "feat(pitr): document replicator-password key in secret template"
+```
+
+**Operator action (NOT part of this PR):** the live `java-secrets` Secret in the cluster needs the new key set. Document this in the rollout section of the ADR (Task 12) and in the PITR runbook (Task 11) prerequisite checklist. The implementer doesn't need to update the live secret — Kyle handles that out of band.
+
+---
+
+## Task 4: Add the replicator-role bootstrap Job
+
+**Files:**
+- Create: `java/k8s/jobs/postgres-replicator-bootstrap.yml`
+
+This is a one-shot Job analogous to `postgres-grafana-reader.yml`. It creates (or rotates the password on) the `replicator` role with the minimum privileges `pg_basebackup` requires.
+
+- [ ] **Step 1: Create the Job**
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgres-replicator-bootstrap
+  namespace: java-tasks
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: psql
+          image: postgres:17-alpine
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: postgres-password
+            - name: REPLICATOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: replicator-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              psql -h postgres.java-tasks.svc.cluster.local -U taskuser -d postgres \
+                -v ON_ERROR_STOP=1 \
+                -v repl_pw="$REPLICATOR_PASSWORD" <<'SQL'
+              DO $$
+              BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'replicator') THEN
+                  EXECUTE format('CREATE ROLE replicator WITH REPLICATION LOGIN PASSWORD %L', :'repl_pw');
+                ELSE
+                  EXECUTE format('ALTER ROLE replicator WITH REPLICATION LOGIN PASSWORD %L', :'repl_pw');
+                END IF;
+              END
+              $$;
+              SQL
+              echo "replicator role ready"
+          resources:
+            requests: { cpu: "10m", memory: "32Mi" }
+            limits:   { cpu: "100m", memory: "64Mi" }
+```
+
+Notes:
+- The `REPLICATION` attribute is the only privilege `pg_basebackup` needs — no GRANT statements required.
+- The `DO $$ ... END $$` block is idempotent: re-runs rotate the password instead of failing.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add java/k8s/jobs/postgres-replicator-bootstrap.yml
+git commit -m "feat(pitr): postgres-replicator-bootstrap job (creates replicator role)"
+```
+
+---
+
+## Task 5: Update the Postgres deployment with archiving args + volume mounts
+
+**Files:**
+- Modify: `java/k8s/deployments/postgres.yml`
+
+The deployment changes are additive: four new `args` flags, two new `volumeMounts` on the `postgres` container, and two new `volumes` entries on the pod spec.
+
+- [ ] **Step 1: Append four new `args` flags**
+
+In `java/k8s/deployments/postgres.yml`, find the existing `args:` list under the `postgres` container (currently ending at line 48 with `auto_explain.sample_rate=1.0`). Append:
+
+```yaml
+            - "-c"
+            - "archive_mode=on"
+            - "-c"
+            - "archive_command=/usr/local/bin/pg-archive-wal.sh %p %f"
+            - "-c"
+            - "archive_timeout=300"
+            - "-c"
+            - "wal_level=replica"
+```
+
+- [ ] **Step 2: Mount the wal-scripts ConfigMap and the wal-archive PVC**
+
+Find the `volumeMounts:` block under the `postgres` container (currently ends with `subPath: pgdata` for `postgres-data`). Append:
+
+```yaml
+            - name: wal-scripts
+              mountPath: /usr/local/bin/pg-archive-wal.sh
+              subPath: pg-archive-wal.sh
+              readOnly: true
+            - name: wal-archive
+              mountPath: /var/lib/postgresql/wal-archive
+```
+
+`subPath` mount of just the archive script keeps `/usr/local/bin/` writeable for the rest of the image — an unkeyed mount of the whole ConfigMap would shadow the directory.
+
+- [ ] **Step 3: Add the matching `volumes:` entries**
+
+Find the pod-level `volumes:` block (currently ends with the `exporter-queries` ConfigMap). Append:
+
+```yaml
+        - name: wal-scripts
+          configMap:
+            name: postgres-wal-scripts
+            defaultMode: 0755
+        - name: wal-archive
+          persistentVolumeClaim:
+            claimName: postgres-wal-archive
+```
+
+- [ ] **Step 4: Verify the manifest is still well-formed**
+
+Run: `python3 -c 'import yaml,sys; list(yaml.safe_load_all(open("java/k8s/deployments/postgres.yml"))); print("ok")'`
+Expected: `ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add java/k8s/deployments/postgres.yml
+git commit -m "feat(pitr): enable archive_mode + mount wal-archive PV in postgres deployment"
+```
+
+---
+
+## Task 6: Add the weekly basebackup CronJob
+
+**Files:**
+- Create: `java/k8s/cronjobs/postgres-basebackup.yml`
+
+- [ ] **Step 1: Create the CronJob**
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-basebackup
+  namespace: java-tasks
+spec:
+  schedule: "0 3 * * 0"   # Sundays 03:00 UTC, one hour after the daily pg_dump
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600   # base backup of multi-DB cluster on portfolio data should finish well under an hour
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: basebackup
+              image: postgres:17-alpine
+              command: ["/usr/local/bin/pg-basebackup-and-prune.sh"]
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: java-secrets
+                      key: replicator-password
+              volumeMounts:
+                - name: scripts
+                  mountPath: /usr/local/bin/pg-basebackup-and-prune.sh
+                  subPath: pg-basebackup-and-prune.sh
+                  readOnly: true
+                - name: basebackup
+                  mountPath: /backups/basebackup
+                - name: wal-archive
+                  mountPath: /backups/wal-archive
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+          volumes:
+            - name: scripts
+              configMap:
+                name: postgres-wal-scripts
+                defaultMode: 0755
+            - name: basebackup
+              persistentVolumeClaim:
+                claimName: postgres-basebackup
+            - name: wal-archive
+              persistentVolumeClaim:
+                claimName: postgres-wal-archive
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add java/k8s/cronjobs/postgres-basebackup.yml
+git commit -m "feat(pitr): weekly postgres-basebackup CronJob"
+```
+
+---
+
+## Task 7: Wire new manifests into the kustomization
+
+**Files:**
+- Modify: `java/k8s/kustomization.yaml`
+
+- [ ] **Step 1: Append the four new resource paths**
+
+Open `java/k8s/kustomization.yaml`. Insert the new entries in alphabetical order within their existing groups:
+
+```yaml
+  - configmaps/postgres-exporter-queries.yml
+  - configmaps/postgres-initdb.yml
+  - configmaps/postgres-wal-scripts.yml          # NEW
+```
+
+```yaml
+  - volumes/postgres-pvc.yml
+  - volumes/postgres-backup-pv.yml
+  - volumes/postgres-basebackup-pv.yml           # NEW
+  - volumes/postgres-wal-archive-pv.yml          # NEW
+```
+
+```yaml
+  - jobs/postgres-backup.yml
+  - jobs/postgres-extensions-bootstrap.yml
+  - jobs/postgres-grafana-reader.yml
+  - jobs/postgres-replicator-bootstrap.yml       # NEW
+  - cronjobs/postgres-basebackup.yml             # NEW (introduces cronjobs/ dir)
+```
+
+The final file should look like (full listing):
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yml
+  - configmaps/activity-service-config.yml
+  - configmaps/gateway-service-config.yml
+  - configmaps/notification-service-config.yml
+  - configmaps/postgres-exporter-queries.yml
+  - configmaps/postgres-initdb.yml
+  - configmaps/postgres-wal-scripts.yml
+  - configmaps/rabbitmq-definitions.yml
+  - configmaps/task-service-config.yml
+  - deployments/activity-service.yml
+  - deployments/gateway-service.yml
+  - deployments/mongodb.yml
+  - deployments/notification-service.yml
+  - deployments/postgres.yml
+  - deployments/rabbitmq.yml
+  - deployments/redis.yml
+  - deployments/task-service.yml
+  - services/activity-service.yml
+  - services/gateway-service.yml
+  - services/mongodb.yml
+  - services/notification-service.yml
+  - services/postgres.yml
+  - services/rabbitmq.yml
+  - services/redis.yml
+  - services/task-service.yml
+  - volumes/postgres-pvc.yml
+  - volumes/postgres-backup-pv.yml
+  - volumes/postgres-basebackup-pv.yml
+  - volumes/postgres-wal-archive-pv.yml
+  - jobs/postgres-backup.yml
+  - jobs/postgres-extensions-bootstrap.yml
+  - jobs/postgres-grafana-reader.yml
+  - jobs/postgres-replicator-bootstrap.yml
+  - cronjobs/postgres-basebackup.yml
+  - pdb/postgres-pdb.yml
+  - ingress.yml
+  - ingress-rabbitmq.yml
+  - network-policy.yml
+```
+
+- [ ] **Step 2: Verify kustomize renders without errors**
+
+Run: `kubectl kustomize java/k8s/ > /tmp/java-k8s.yaml && wc -l /tmp/java-k8s.yaml`
+Expected: prints a positive line count, no error.
+
+(If kubectl is unavailable locally, skip — CI's policy-check will catch it.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add java/k8s/kustomization.yaml
+git commit -m "feat(pitr): wire new wal-archive manifests into java kustomization"
+```
+
+---
+
+## Task 8: Patch the QA Java overlay to drop the new CronJob and bootstrap Job
+
+**Files:**
+- Modify: `k8s/overlays/qa-java/kustomization.yaml`
+
+Background: the QA Java overlay deletes the `postgres` Deployment + PVC and replaces the `postgres` Service with an `ExternalName` pointing at the prod Postgres. We don't want a second base-backup CronJob running in the QA namespace against the same prod Postgres, and the `replicator` role only needs to be created once. Add `$patch: delete` directives for both.
+
+- [ ] **Step 1: Append delete patches**
+
+Open `k8s/overlays/qa-java/kustomization.yaml`. Find the existing block of `# --- Remove infrastructure deployments (shared with prod) ---` patches around line 65. After the existing `Remove rabbitmq ingress` patch (currently the last patch in the file, ending around line 172), append:
+
+```yaml
+  # --- Remove WAL-archive workloads (shared prod handles them) ---
+  - target:
+      kind: CronJob
+      name: postgres-basebackup
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: postgres-basebackup
+  - target:
+      kind: Job
+      name: postgres-replicator-bootstrap
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: postgres-replicator-bootstrap
+```
+
+- [ ] **Step 2: Verify the QA overlay renders without errors**
+
+Run: `kubectl kustomize k8s/overlays/qa-java/ > /tmp/qa-java.yaml && grep -c 'kind: CronJob' /tmp/qa-java.yaml`
+Expected: `0` for `postgres-basebackup` (existing `postgres-backup` CronJob is unchanged — it's already in the qa overlay's input). Run a more targeted check:
+```
+grep -A1 'name: postgres-basebackup' /tmp/qa-java.yaml || echo 'absent (good)'
+grep -A1 'name: postgres-replicator-bootstrap' /tmp/qa-java.yaml || echo 'absent (good)'
+```
+Expected: both print `absent (good)`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k8s/overlays/qa-java/kustomization.yaml
+git commit -m "feat(pitr): drop basebackup cronjob + replicator job in qa overlay"
+```
+
+---
+
+## Task 9: Append the three new alerts to the PostgreSQL alert group
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-alerting.yml`
+
+The existing `PostgreSQL` group ends after the `pg-backup-stale` rule near line 1579. Append three new rules immediately after, before the next group begins.
+
+- [ ] **Step 1: Find the insertion point**
+
+Search `k8s/monitoring/configmaps/grafana-alerting.yml` for the `PostgreSQL` group:
+```
+grep -n '^      - orgId: 1$\|name: PostgreSQL' k8s/monitoring/configmaps/grafana-alerting.yml
+```
+The `PostgreSQL` group begins at the line `name: PostgreSQL` (currently line 1391). The next group starts at the next `- orgId: 1` line after 1579.
+
+- [ ] **Step 2: Append the three rules at the end of the PostgreSQL group**
+
+Insert after the existing `pg-backup-stale` rule (at the end of the group's `rules:` list, before the next `- orgId: 1` group begins):
+
+```yaml
+          - uid: pg-archive-command-failing
+            title: Postgres Archive Command Failing
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: rate(pg_stat_archiver_failed_count[10m])
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 0
+                  refId: C
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "pg_stat_archiver is reporting failures — archive_command is broken; WAL recycling will stall and PITR will silently break"
+
+          - uid: pg-wal-archive-stale
+            title: Postgres WAL Archive Stale
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: time() - pg_stat_archiver_last_archived_time
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 600
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 600
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "No WAL archived in 10+ minutes — archive_timeout is 5m so this should never happen under normal load"
+
+          - uid: pg-basebackup-stale
+            title: Postgres Base Backup Stale
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 86400
+                  to: 0
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    time() - max(kube_cronjob_status_last_successful_time{
+                      cronjob="postgres-basebackup",
+                      namespace="java-tasks"
+                    })
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange:
+                  from: 86400
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange:
+                  from: 86400
+                  to: 0
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params:
+                          - 691200
+                  refId: C
+            for: 0s
+            labels:
+              severity: critical
+            annotations:
+              summary: "No successful postgres-basebackup CronJob in 8+ days — PITR baseline may have aged out"
+```
+
+Indentation note: each rule starts with `          - uid:` (10-space prefix) matching the existing `pg-backup-stale` rule.
+
+- [ ] **Step 3: Verify the YAML still parses**
+
+Run: `python3 -c 'import yaml; list(yaml.safe_load_all(open("k8s/monitoring/configmaps/grafana-alerting.yml"))); print("ok")'`
+Expected: `ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-alerting.yml
+git commit -m "feat(pitr): alert rules — archive failures, WAL staleness, basebackup staleness"
+```
+
+---
+
+## Task 10: Append three panels to the existing PostgreSQL dashboard
+
+**Files:**
+- Modify: `k8s/monitoring/configmaps/grafana-dashboards.yml`
+
+The existing `postgresql.json` dashboard (uid `postgresql`) lives at the top-level key `postgresql.json:` (around line 3281). Its panels currently use `id` 1–7. Append three panels (`id` 8–10) at row `y: 24` (below the current bottom row at `y: 16`) and bump the dashboard's `version` from `1` to `2`.
+
+- [ ] **Step 1: Find the closing `]` of the `panels` array**
+
+Search for the closing of the `Connections by Service` panel — currently at the end of the `panels` array, near line 3501:
+```
+],
+"schemaVersion": 39,
+"tags": ["postgresql", "database"],
+```
+
+Insert the three new panels before the closing `]` (i.e., after the `Connections by Service` panel's closing brace, separating with a comma).
+
+- [ ] **Step 2: Insert the three new panels**
+
+Append (replacing the existing `]` after the `Connections by Service` panel with `,` followed by the three panels and then the `]`):
+
+```json
+        ,
+        {
+          "title": "Time Since Last WAL Archive",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 24 },
+          "id": 8,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "time() - pg_stat_archiver_last_archived_time",
+              "legendFormat": "age",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 300 },
+                  { "color": "red", "value": 600 }
+                ]
+              }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "WAL Archive Failures (5m rate)",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 8, "x": 8, "y": 24 },
+          "id": 9,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "rate(pg_stat_archiver_failed_count[5m])",
+              "legendFormat": "failures/sec",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 0.0001 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi" },
+            "legend": { "displayMode": "list", "placement": "bottom" }
+          }
+        },
+        {
+          "title": "Time Since Last Base Backup",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 8, "x": 16, "y": 24 },
+          "id": 10,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "time() - max(kube_cronjob_status_last_successful_time{cronjob=\"postgres-basebackup\", namespace=\"java-tasks\"})",
+              "legendFormat": "age",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 604800 },
+                  { "color": "red", "value": 691200 }
+                ]
+              }
+            },
+            "overrides": []
+          }
+        }
+      ],
+```
+
+(Notice the leading `,` before the first new panel — this comma replaces what was previously the panels-array trailing close.)
+
+- [ ] **Step 3: Bump the dashboard `version` from 1 to 2**
+
+In the same `postgresql.json` block, find:
+
+```json
+      "title": "PostgreSQL",
+      "uid": "postgresql",
+      "version": 1
+```
+
+Change to:
+
+```json
+      "title": "PostgreSQL",
+      "uid": "postgresql",
+      "version": 2
+```
+
+- [ ] **Step 4: Verify the embedded JSON still parses**
+
+Run:
+```bash
+python3 - <<'PY'
+import yaml, json, sys
+with open("k8s/monitoring/configmaps/grafana-dashboards.yml") as f:
+    cm = yaml.safe_load(f)
+data = cm["data"]["postgresql.json"]
+parsed = json.loads(data)
+panel_ids = [p["id"] for p in parsed["panels"]]
+print("panel_ids:", panel_ids)
+print("version:", parsed["version"])
+PY
+```
+Expected: `panel_ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`, `version: 2`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/grafana-dashboards.yml
+git commit -m "feat(pitr): three new wal-archive panels on postgresql dashboard"
+```
+
+---
+
+## Task 11: Append Scenario 4 (PITR) to the recovery runbook
+
+**Files:**
+- Modify: `docs/runbooks/postgres-recovery.md`
+
+Append a new scenario at the end of the file, peer with Scenarios 1–3. Also add the related-alerts entries near the top of the file so the on-call sees the new alerts mapped to this scenario.
+
+- [ ] **Step 1: Update the alert list at the top**
+
+In `docs/runbooks/postgres-recovery.md`, find the `**Related alerts:**` block (around line 7) and append three lines:
+
+```
+**Related alerts:**
+- `Postgres Backup Stale` — no successful pg_dump in 26h → Scenario 2
+- `Postgres Connection Utilization High` — connections > 80%
+- `Postgres Cache Hit Ratio Low` — cache ratio < 95%
+- `Postgres Deadlocks Detected` — deadlocks in 5m window
+- `Postgres Archive Command Failing` — `archive_command` exiting non-zero → Scenario 4 (preventive — not a recovery trigger by itself)
+- `Postgres WAL Archive Stale` — no new WAL archived in 10+ min → Scenario 4 (preventive)
+- `Postgres Base Backup Stale` — no successful weekly base backup in 8d → Scenario 4 (preventive)
+```
+
+- [ ] **Step 2: Append the new scenario at the end of the file**
+
+Append after the existing Scenario 3 (which currently ends at the bottom of the file):
+
+```markdown
+---
+
+## Scenario 4: Point-in-Time Recovery (PITR) to a Specific Timestamp
+
+### Symptoms
+
+- A specific destructive event has been identified — bad migration, accidental
+  `DELETE`/`UPDATE` without `WHERE`, malicious write — and rolling the cluster
+  back to a point *just before* the event will recover the data.
+- A pg_dump restore (Scenario 2) would lose too much: the most recent dump is
+  hours older than the event's timestamp, and the daily snapshot granularity
+  is unacceptable for the affected data.
+- Postgres itself is healthy — this scenario is for *logical* recovery, not
+  physical-corruption recovery.
+
+### Prerequisites
+
+- The event's timestamp is known (Grafana, application logs, audit trail).
+- That timestamp falls within the WAL archive retention window: at minimum,
+  later than the `START WAL LOCATION` of the second-most-recent base backup.
+  (The basebackup script retains WAL only that far back.)
+- A base backup taken *before* the target timestamp exists in
+  `/backups/basebackup/` on the Debian host.
+- The `replicator-password` key in the live `java-secrets` Secret is set.
+  (Check: `kubectl get secret java-secrets -n java-tasks -o jsonpath='{.data.replicator-password}' | base64 -d`
+  should print a non-empty value.)
+
+**Estimated time:** 15-30 minutes (dominated by base-backup unpack + WAL replay).
+
+### Steps
+
+1. **Find a usable base backup taken *before* the target timestamp:**
+   ```bash
+   ssh debian "ls -1 /backups/basebackup/"
+   ```
+   Pick the most recent directory whose timestamp (`YYYYMMDDTHHMMSSZ` format)
+   is earlier than the target timestamp. Set:
+   ```bash
+   BACKUP_STAMP=20260426T030000Z   # adjust
+   TARGET_TIME='2026-04-27 14:23:00 UTC'   # adjust
+   ```
+
+2. **Stop Postgres so the data PVC is unmounted:**
+   ```bash
+   ssh debian "kubectl scale deployment postgres -n java-tasks --replicas=0"
+   ssh debian "kubectl wait --for=delete pod -l app=postgres -n java-tasks --timeout=120s"
+   ```
+
+3. **Wipe the data PVC (it will be re-seeded from the base backup):**
+   ```bash
+   ssh debian "kubectl delete pvc postgres-data -n java-tasks"
+   ssh debian "kubectl get pv | awk '/postgres-data/ {print \$1}' | xargs -r kubectl delete pv"
+   cat java/k8s/volumes/postgres-pvc.yml | ssh debian "kubectl apply -f -"
+   ```
+
+4. **Unpack the base backup tarball into the new data PVC.** Run a one-shot
+   pod with both PVCs mounted:
+   ```bash
+   ssh debian "kubectl run pitr-restore -n java-tasks --rm -i --restart=Never \
+     --image=postgres:17-alpine \
+     --overrides='{\"spec\":{\"containers\":[{\"name\":\"pitr-restore\",\"image\":\"postgres:17-alpine\",\"command\":[\"sh\",\"-c\",\"sleep 3600\"],\"volumeMounts\":[{\"name\":\"data\",\"mountPath\":\"/var/lib/postgresql/data\"},{\"name\":\"basebackup\",\"mountPath\":\"/backups/basebackup\",\"readOnly\":true}]}],\"volumes\":[{\"name\":\"data\",\"persistentVolumeClaim\":{\"claimName\":\"postgres-data\"}},{\"name\":\"basebackup\",\"persistentVolumeClaim\":{\"claimName\":\"postgres-basebackup\"}}]}}' \
+     --command -- sh -c 'sleep 3600' &"
+
+   # Wait for the pod to be ready, then exec the unpack:
+   ssh debian "kubectl wait --for=condition=ready pod/pitr-restore -n java-tasks --timeout=60s"
+   ssh debian "kubectl exec -n java-tasks pitr-restore -- sh -c '
+     mkdir -p /var/lib/postgresql/data/pgdata &&
+     cd /var/lib/postgresql/data/pgdata &&
+     tar -xzf /backups/basebackup/${BACKUP_STAMP}/base.tar.gz &&
+     tar -xzf /backups/basebackup/${BACKUP_STAMP}/pg_wal.tar.gz -C pg_wal/ &&
+     chown -R postgres:postgres /var/lib/postgresql/data
+   '"
+   ```
+
+5. **Configure recovery target.** Append to `postgresql.auto.conf` and drop a
+   `recovery.signal` file:
+   ```bash
+   ssh debian "kubectl exec -n java-tasks pitr-restore -- sh -c \"
+     cat >> /var/lib/postgresql/data/pgdata/postgresql.auto.conf <<EOF
+   restore_command = 'cp /var/lib/postgresql/wal-archive/%f %p'
+   recovery_target_time = '${TARGET_TIME}'
+   recovery_target_action = 'promote'
+   EOF
+     touch /var/lib/postgresql/data/pgdata/recovery.signal
+     chown postgres:postgres /var/lib/postgresql/data/pgdata/postgresql.auto.conf
+     chown postgres:postgres /var/lib/postgresql/data/pgdata/recovery.signal
+   \""
+
+   ssh debian "kubectl delete pod pitr-restore -n java-tasks"
+   ```
+
+   Note: `restore_command` reads from `/var/lib/postgresql/wal-archive/`,
+   which is mounted into the postgres pod (Task 5). Postgres replays WAL
+   from there in order until `recovery_target_time` is reached, then
+   promotes (becomes a normal read-write database).
+
+6. **Scale Postgres back up:**
+   ```bash
+   ssh debian "kubectl scale deployment postgres -n java-tasks --replicas=1"
+   ssh debian "kubectl wait --for=condition=ready pod -l app=postgres -n java-tasks --timeout=300s"
+   ```
+
+   Watch logs to see WAL replay progress:
+   ```bash
+   ssh debian "kubectl logs -n java-tasks deployment/postgres --tail=200 -f"
+   ```
+   Look for `redo done at <LSN>` and `recovery target time reached at <ts>` —
+   these confirm the recovery target was honored. The line
+   `archive recovery complete` indicates promotion.
+
+7. **Verify:** query for the absence of the corruption-causing row, or the
+   presence of the row that was deleted:
+   ```bash
+   ssh debian "kubectl exec deployment/postgres -n java-tasks -- \
+     psql -U taskuser -d <affected-db> -c \"<verification query>\""
+   ```
+
+8. **Restart all services to drop stale connections:**
+   ```bash
+   ssh debian "kubectl rollout restart deployment -n go-ecommerce"
+   ssh debian "kubectl rollout restart deployment -n go-ecommerce-qa"
+   ssh debian "kubectl rollout restart deployment task-service -n java-tasks"
+   ```
+
+### After-action
+
+- File a follow-up to take a fresh `pg_dump` ASAP (the daily backup at 02:00 UTC
+  may not run before the next incident) — the cluster is now on a new timeline
+  but the backup pipeline is not aware of that until the next dump.
+- The next weekly `postgres-basebackup` (Sunday 03:00 UTC) will pick up the
+  new timeline automatically — no manual intervention required.
+- If the target timestamp turned out to be wrong, you can re-run this entire
+  procedure from the same base backup tarball; the WAL archive is unchanged
+  by the restore.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/runbooks/postgres-recovery.md
+git commit -m "docs(runbook): scenario 4 — point-in-time recovery"
+```
+
+---
+
+## Task 12: Write the companion ADR
+
+**Files:**
+- Create: `docs/adr/database/wal-archiving-pitr.md`
+
+The `docs/adr/database/` directory may not exist yet — create it as part of writing the file.
+
+- [ ] **Step 1: Create the ADR**
+
+```markdown
+# ADR: WAL Archiving + Point-in-Time Recovery (2026-04-27)
+
+## Status
+Accepted
+
+## Context
+
+The existing data-integrity work (`docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md`) gave the shared Postgres 17 instance daily `pg_dump` snapshots with 7-day retention. RPO under that posture is up to 24 hours: a disaster at 23:59 loses an entire day's writes.
+
+Phase 2 of that ADR explicitly listed WAL-based continuous archiving as the next step. This ADR documents what landed.
+
+## Decisions
+
+### Native `archive_command` rather than pgBackRest or Wal-G
+
+Postgres ships `archive_command` and `pg_basebackup` in the core image. A POSIX-`sh` wrapper script that does `cp + sync + atomic rename` is ~15 lines and has no operational dependencies beyond the base image. pgBackRest is a more capable tool — incremental backups, encryption, parallel archive, S3 first-class — but it adds a binary, a config file, a separate daemon, and a different mental model from the surrounding pg_dump pipeline.
+
+For the portfolio, the native primitives are the right choice: they teach the underlying mechanism, the failure modes are the ones a textbook covers, and the interview narrative ("I wrote the archive_command myself") is more interesting than "I configured pgBackRest." When we outgrow the script — multi-region, off-host storage, incremental — pgBackRest is the natural next step.
+
+### Two retained base backups, not one
+
+The basebackup script keeps the four most recent weekly base backups, and prunes WAL only down to the *second-most-recent* base backup's `START WAL LOCATION`. This is defence in depth: if the most recent base backup is corrupt or unreadable, the previous backup plus retained WAL still gives a recoverable point.
+
+Cost: roughly an extra week of WAL on disk (~50–200 MB compressed). Trivial against the 10 GB PV.
+
+### `archive_timeout = 300`
+
+Without `archive_timeout`, an idle Postgres might never fill a WAL segment, leaving the most recent commits unarchived for arbitrary durations. `archive_timeout = 300` (5 minutes) forces a WAL switch every five minutes during idle periods, capping the gap between commit and archive at ~5 minutes plus the few seconds the wrapper needs.
+
+The cost is one mostly-empty WAL segment file every 5 idle minutes. At 16 MB per WAL segment, that's ~4.6 GB/day of zero-padded archive in the worst case — pruning catches up at the next weekly base backup, so steady-state WAL on disk is bounded by the inter-basebackup interval, not the timeout.
+
+### `--wal-method=fetch` (WAL bundled into the base backup)
+
+`pg_basebackup` defaults to `stream` WAL mode, which uses a second connection to stream WAL while the base backup runs and writes a small `pg_wal/` directory referencing the live archive. With `fetch`, the WAL needed to make the base backup self-consistent is bundled into the tarball.
+
+The downside (slightly larger tarball) is acceptable. The upside is significant: a `fetch` tarball is restorable on its own — even if the WAL archive directory is later wiped or corrupted, the base backup can still bootstrap a cluster up to its checkpoint. This matters for the no-paid-services constraint where archive and base-backup live on the same physical disk.
+
+### `replicator` role, not reusing `taskuser`
+
+`pg_basebackup` only needs the `REPLICATION` attribute. The application's `taskuser` already has full DDL/DML on every database; granting it `REPLICATION` would be principle-of-least-privilege violation. A dedicated `replicator` role with only `REPLICATION LOGIN` keeps the base-backup credential's blast radius tiny — even if leaked, it cannot read application data.
+
+### Three new alerts use existing Prometheus metrics, not a custom exporter
+
+`pg_stat_archiver_archived_count`, `pg_stat_archiver_failed_count`, `pg_stat_archiver_last_archived_time` are scraped by the existing `postgres_exporter` sidecar from the built-in `pg_stat_archiver` view. `kube_cronjob_status_last_successful_time` is exposed by the existing `kube-state-metrics` deployment. No new exporter, scrape config, or textfile collector is introduced.
+
+### Three panels appended to the existing PostgreSQL dashboard
+
+The query-observability work already has its own dashboard (`pg-query-performance`). Archive health is operational, not query-performance, so these panels belong on the existing `postgresql` dashboard alongside connection utilization, cache hit ratio, and pg_dump backup freshness. The on-call engineer sees archive health on the same screen as everything else they care about.
+
+### Same physical disk as data — accepted constraint
+
+The `wal-archive` and `basebackup` PVs are hostPath PVs on the same Debian node where the data PVC lives. A whole-disk failure loses both data and backups simultaneously. This is an explicit constraint of the no-paid-services posture and is acknowledged in the data-integrity ADR's trade-offs section. The mitigation (off-host archive on S3) is a separate roadmap item awaiting relaxation of that constraint.
+
+## Consequences
+
+**Positive:**
+- RPO drops from ≤ 24 hours to ≤ 5 minutes (one `archive_timeout` window plus pending in-flight WAL).
+- An operator can recover to any timestamp within the WAL retention window using the runbook's Scenario 4 — the most powerful Postgres recovery primitive.
+- Archive failures and base-backup staleness are alerted, not silent. A broken `archive_command` would otherwise stall WAL recycling and silently fill the data PVC.
+- The `replicator` role pattern generalizes: streaming replication (roadmap item #161) reuses the same role.
+
+**Trade-offs:**
+- `archive_mode = on` requires a Postgres restart. Acceptable given the existing `Recreate` deployment strategy.
+- Disk usage grows by ~10 GB (two new hostPath PVs) on the Minikube node.
+- The wrapper script's loud-fail behaviour on existing-archive-file means an operator running disaster-recovery exercises may see legitimate alert noise; bypass requires consciously deleting the offending archive file.
+- WAL archive lives on the same physical disk as the data PVC. Disk failure remains unmitigated.
+
+**Phase 3 (future, separate roadmap items):**
+- Streaming replication / hot standby (#161) — same WAL stream, different consumer.
+- Off-host archive (S3-compatible) once the no-paid-services constraint relaxes.
+- Automated weekly PITR drill (#158) — periodic restore-and-verify using the artifacts produced here.
+
+## Operator action required when applying
+
+The live `java-secrets` Secret in the cluster needs a new `replicator-password` key. Generate a new password, base64-encode, and patch the existing Secret:
+
+```
+NEW_PW=$(openssl rand -hex 24)
+ssh debian "kubectl get secret java-secrets -n java-tasks -o json | \
+  jq --arg pw \"\$(echo -n $NEW_PW | base64)\" \
+  '.data[\"replicator-password\"] = \$pw' | kubectl apply -f -"
+```
+
+Then kick the bootstrap Job:
+
+```
+ssh debian "kubectl delete job postgres-replicator-bootstrap -n java-tasks --ignore-not-found"
+ssh debian "kubectl apply -f - < java/k8s/jobs/postgres-replicator-bootstrap.yml"
+```
+
+The first base backup runs naturally on the next Sunday 03:00 UTC. To validate sooner, run it manually:
+
+```
+ssh debian "kubectl create job --from=cronjob/postgres-basebackup postgres-basebackup-manual -n java-tasks"
+ssh debian "kubectl logs job/postgres-basebackup-manual -n java-tasks -f"
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adr/database/wal-archiving-pitr.md
+git commit -m "docs(adr): wal archiving + point-in-time recovery"
+```
+
+---
+
+## Task 13: Write the Go integration test
+
+**Files:**
+- Create: `go/pkg/db/wal_archive_integration_test.go`
+
+This test validates two contracts of the archive-script design:
+
+1. With `archive_mode=on` and `archive_timeout=2`, a forced WAL switch results in a file appearing in the archive directory (i.e., `archive_command` is being invoked and our atomic-rename pattern works).
+2. The script refuses to overwrite an existing archived segment (the no-corruption invariant).
+
+Pattern follows `go/pkg/db/extensions_integration_test.go` — testcontainers-postgres, build-tagged `//go:build integration`.
+
+- [ ] **Step 1: Write the test file**
+
+```go
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// archiveScript is the production wrapper from
+// java/k8s/configmaps/postgres-wal-scripts.yml; we keep it inline here so
+// the test exercises the exact same logic.
+const archiveScript = `#!/bin/sh
+set -eu
+SRC="$1"
+FN="$2"
+DST_DIR="/var/lib/postgresql/wal-archive"
+DST="$DST_DIR/$FN"
+TMP="$DST.tmp"
+if [ -e "$DST" ]; then
+  echo "pg-archive-wal: $FN already archived; refusing overwrite" >&2
+  exit 1
+fi
+cp "$SRC" "$TMP"
+sync "$TMP"
+mv "$TMP" "$DST"
+`
+
+func TestWalArchiveAndIdempotency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+	ctx := context.Background()
+
+	hostArchive := t.TempDir()
+	if err := os.Chmod(hostArchive, 0o777); err != nil {
+		t.Fatalf("chmod tmpdir: %v", err)
+	}
+
+	hostScript := filepath.Join(t.TempDir(), "pg-archive-wal.sh")
+	if err := os.WriteFile(hostScript, []byte(archiveScript), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:17-alpine",
+		postgres.WithDatabase("appdb"),
+		postgres.WithUsername("appuser"),
+		postgres.WithPassword("apppass"),
+		testcontainers.WithCmdArgs(
+			"-c", "wal_level=replica",
+			"-c", "archive_mode=on",
+			"-c", "archive_command=/usr/local/bin/pg-archive-wal.sh %p %f",
+			"-c", "archive_timeout=2",
+		),
+		testcontainers.CustomizeRequest(testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				Mounts: testcontainers.ContainerMounts{
+					{Source: testcontainers.GenericBindMountSource{HostPath: hostArchive}, Target: "/var/lib/postgresql/wal-archive"},
+					{Source: testcontainers.GenericBindMountSource{HostPath: hostScript}, Target: "/usr/local/bin/pg-archive-wal.sh"},
+				},
+			},
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = pgContainer.Terminate(ctx) })
+
+	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("dsn: %v", err)
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	// Generate WAL: a writable table, an insert, then force a segment switch.
+	if _, err := db.ExecContext(ctx, `CREATE TABLE marker (n int)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO marker VALUES (1)`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `SELECT pg_switch_wal()`); err != nil {
+		t.Fatalf("switch wal: %v", err)
+	}
+
+	// Wait for at least one archived segment to appear. Postgres's archive
+	// loop runs every few seconds; allow up to 30 seconds for a 2-second
+	// archive_timeout in case of CI flakiness.
+	deadline := time.Now().Add(30 * time.Second)
+	var archived []os.DirEntry
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(hostArchive)
+		if err != nil {
+			t.Fatalf("read archive: %v", err)
+		}
+		archived = nil
+		for _, e := range entries {
+			// pg WAL segment names are 24 hex chars; skip .tmp partials.
+			if !e.IsDir() && len(e.Name()) == 24 {
+				archived = append(archived, e)
+			}
+		}
+		if len(archived) > 0 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if len(archived) == 0 {
+		t.Fatalf("no WAL segments archived within 30s")
+	}
+
+	// Idempotency contract: re-running the script with an existing archive
+	// target must exit non-zero (no overwrite).
+	srcSegment := filepath.Join(hostArchive, archived[0].Name())
+	cmd := exec.CommandContext(ctx, "/bin/sh", hostScript, srcSegment, archived[0].Name())
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Errorf("expected re-archive to fail with non-zero exit; got success: %s", string(out))
+	}
+}
+```
+
+- [ ] **Step 2: Run preflight before committing**
+
+Run: `make preflight-go`
+Expected: `golangci-lint` passes; `go test -race -short ./...` runs unit tests across all services. The new test is `//go:build integration`-tagged so it does NOT run under `-short` — preflight passing means the new file compiles and lints, which is what we want.
+
+If `golangci-lint` flags anything in the new file, fix and re-run.
+
+- [ ] **Step 3: Sanity-check the integration build tag**
+
+Run: `cd go/pkg && go build -tags integration ./db/...`
+Expected: builds with no error. (The `testcontainers-go` and `pgx/v5/stdlib` deps are already in `go/pkg/go.mod` from the existing extensions_integration_test.go.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/pkg/db/wal_archive_integration_test.go
+git commit -m "test(pitr): integration test — archive script + idempotency contract"
+```
+
+---
+
+## Task 14: Final sweep, push, open PR
+
+- [ ] **Step 1: Verify the worktree is clean and on the right branch**
+
+```bash
+git status
+git branch --show-current
+```
+Expected: `nothing to commit, working tree clean`; branch `agent/feat-pitr`.
+
+- [ ] **Step 2: Run a broader preflight covering all touched languages**
+
+Run: `make preflight-go`
+Expected: pass.
+
+This PR has no Python/Java/frontend code changes — `make preflight-go` is the only preflight that exercises modified code. K8s manifests are validated by CI's policy-check job; the local kustomize dry-run done in earlier tasks is sufficient.
+
+- [ ] **Step 3: Push the feature branch**
+
+```bash
+git push -u origin agent/feat-pitr
+```
+
+- [ ] **Step 4: Open the PR against `qa`**
+
+```bash
+gh pr create --base qa --title "feat(pitr): WAL archiving + point-in-time recovery" --body "$(cat <<'EOF'
+## Summary
+- Continuous WAL archiving via a new `archive_command` wrapper script and a 10Gi `postgres-wal-archive` hostPath PV
+- Weekly `pg_basebackup` CronJob (Sundays 03:00 UTC) writing to a 10Gi `postgres-basebackup` hostPath PV; retains 4 weekly tarballs + WAL back to the second-newest backup
+- New `replicator` role created by a one-shot Job analogous to `postgres-grafana-reader`
+- Three new Grafana alerts and three new panels on the existing PostgreSQL dashboard, sourced from `pg_stat_archiver` and `kube_cronjob_status_last_successful_time` (no new exporter)
+- PITR procedure appended to `docs/runbooks/postgres-recovery.md` as Scenario 4
+- Companion ADR at `docs/adr/database/wal-archiving-pitr.md`
+- Integration test (testcontainers, build-tagged) validates the archive script's happy path and idempotency contract
+
+Implements item 3 of the db-roadmap (issue #157). Spec at `docs/superpowers/specs/2026-04-27-pitr-design.md`. Plan at `docs/superpowers/plans/2026-04-27-pitr.md`.
+
+## Operator action required after merge
+The live `java-secrets` Secret needs a `replicator-password` key — see "Operator action required when applying" in the ADR. The bootstrap Job will fail until this is set.
+
+## Test plan
+- [ ] CI green on `qa`
+- [ ] Apply to QA cluster; manually trigger basebackup CronJob and verify a tarball lands in `/backups/basebackup/` on the Debian node
+- [ ] In a postgres pod exec, `SELECT * FROM pg_stat_archiver` shows `archived_count > 0` and a recent `last_archived_time`
+- [ ] Trigger the `PgWalArchiveStale` alert by `kubectl exec`-ing into postgres and renaming the archive script for ~12 minutes, confirm Telegram fires, restore the script
+- [ ] Walk through Scenario 4 in QA on a parallel temporary deployment, restore to a 5-minutes-ago timestamp, query a known marker
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Notify Kyle**
+
+In the chat, paste the PR URL and stop. Per project rules, Claude does NOT watch CI; Kyle will report failures and ask for fixes if needed.
+
+---
+
+## Self-Review Checklist
+
+Mapping each spec section to a task:
+
+| Spec section | Task |
+|---|---|
+| Architecture (PVs, ConfigMap, CronJob, exporter, dashboard) | Tasks 1, 2, 6, 9, 10 |
+| PostgreSQL configuration (4 args) | Task 5 |
+| Archive script body | Task 2 |
+| Base backup + WAL retention script | Task 2 |
+| `replicator` role | Tasks 3, 4 |
+| CronJob manifest | Task 6 |
+| Storage layout (two new PVs/PVCs) | Task 1 |
+| Observability — `pg_stat_archiver` metrics | Existing exporter; no code change |
+| Dashboard panels | Task 10 |
+| Alerts | Task 9 |
+| PITR runbook | Task 11 |
+| Integration test | Task 13 |
+| QA smoke (manual) | PR test plan |
+| Rollout (independently mergeable) | Tasks land in commit order matching spec rollout order |
+| Companion ADR | Task 12 |
+
+Spec sections without corresponding tasks: none.
+
+Type/identifier consistency:
+- ConfigMap name `postgres-wal-scripts` used consistently in deployment mount, CronJob mount, and script-file references (`/usr/local/bin/pg-archive-wal.sh`).
+- PVC names `postgres-wal-archive` and `postgres-basebackup` are consistent across the PVC manifest, the deployment, and the CronJob.
+- The archive directory is `/var/lib/postgresql/wal-archive` from inside the postgres container (matches the script's `DST_DIR`) and `/backups/wal-archive` from inside the CronJob container (matches the script's `ARCHIVE_DIR`).
+- Alert UIDs (`pg-archive-command-failing`, `pg-wal-archive-stale`, `pg-basebackup-stale`) match the alert titles and the runbook cross-link.
+- `replicator-password` Secret key consistent across template, bootstrap Job, CronJob, and ADR operator-action snippet.
+- `kube_cronjob_status_last_successful_time` is the kube-state-metrics metric name (not `kube_cronjob_last_successful_time`) — checked against existing usage in `pg-backup-stale` alert (which uses `kube_job_status_completion_time` for daily backup; for weekly we use the cronjob-level metric).
+
+Placeholders / TODOs in the plan: none. All commands, code blocks, and YAML manifests are concrete.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-27-pitr.md`.
+
+This plan is being executed inline in the same session (Auto mode is on; the user expects continuous execution). Use **superpowers:executing-plans** to walk through tasks 1 → 14.

--- a/docs/superpowers/specs/2026-04-27-pitr-design.md
+++ b/docs/superpowers/specs/2026-04-27-pitr-design.md
@@ -1,0 +1,353 @@
+# Design: WAL Archiving + Point-in-Time Recovery
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Roadmap position:** Item 3 of 10 in the `db-roadmap` GitHub label
+- **GitHub issue:** [#157 — WAL archiving + Point-in-Time Recovery](https://github.com/kabradshaw1/portfolio/issues/157)
+- **Builds on:**
+  - `docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md` — daily `pg_dump`, recovery runbook (this is the explicit Phase 2 follow-up)
+  - `docs/runbooks/postgres-recovery.md` — existing recovery scenarios (extended here)
+  - `docs/superpowers/specs/2026-04-27-pg-query-observability-design.md` — postgres_exporter, dashboard, alert patterns
+
+## Context
+
+The shared PostgreSQL 17 instance currently has daily `pg_dump` snapshots with 7-day retention. RPO is up to 24 hours — a disaster at 23:59 loses the entire day's data. The existing data-integrity ADR explicitly lists WAL-based continuous archiving + PITR as Phase 2 — that is what this spec delivers.
+
+A production system would treat 24h RPO as unacceptable for any data the business cares about. WAL archiving narrows RPO to seconds (every committed transaction is in a WAL segment that gets archived as soon as the segment is full or `archive_timeout` elapses), and base backups + the WAL archive together let an operator recover to any specific timestamp.
+
+This is also baseline interview vocabulary: RPO, RTO, and "how do you do PITR in Postgres?" are standard backend questions.
+
+## Goals
+
+- Continuously archive WAL segments to durable storage as they fill.
+- Take a weekly `pg_basebackup` so any restore has a base to apply WAL on top of.
+- Enable point-in-time recovery: given a target timestamp, an operator can restore the cluster to its state at that moment.
+- Detect archiving failures fast (silent archive failure stalls WAL recycling and eventually fills the data PVC).
+- Document the PITR procedure in the existing recovery runbook so an on-call engineer can execute it under pressure.
+
+## Non-goals
+
+- Streaming replication / read replica (separate roadmap item #161).
+- Off-host backup storage (S3/GCS) — bound by the no-paid-services constraint.
+- Automated weekly PITR drills (separate roadmap item #158, "automated backup verification").
+- WAL-based logical replication (`wal_level = logical`) — separate roadmap item #163.
+- Multi-region / DR-to-another-site posture.
+
+## Architecture
+
+```
+Postgres pod (java-tasks namespace, single replica, Recreate strategy)
+│
+├── volume: postgres-data           PVC, existing                /var/lib/postgresql/data
+├── volume: postgres-backup         hostPath PV, existing        /backups/postgres        (pg_dump output)
+├── volume: postgres-wal-archive    hostPath PV, NEW             /backups/wal-archive
+└── volume: postgres-basebackup     hostPath PV, NEW             /backups/basebackup
+                                     │
+   args (extends existing -c flags from query-observability spec):
+     -c archive_mode=on
+     -c archive_command='/usr/local/bin/pg-archive-wal.sh %p %f'
+     -c archive_timeout=300         (force WAL switch every 5 min when idle)
+     -c wal_level=replica           (default; explicit for clarity)
+
+   ConfigMap: postgres-wal-scripts (mounted at /usr/local/bin)
+     - pg-archive-wal.sh            atomic, idempotent archiver
+     - pg-basebackup-and-prune.sh   weekly base backup + WAL retention
+
+CronJobs (java-tasks namespace):
+   - postgres-basebackup            Sundays 03:00 UTC, runs pg-basebackup-and-prune.sh
+                                     in a postgres-client image with both backup PVs
+                                     and the WAL archive PV mounted
+
+postgres_exporter sidecar           existing — gains scrape of pg_stat_archiver
+                                     view (built-in, no custom query needed)
+
+Grafana                             extends existing PostgreSQL dashboard with
+                                     three new panels; appends three new alerts to
+                                     the PostgreSQL alert group
+```
+
+Three independent data flows: (1) WAL archive — every committed transaction lands in a WAL segment that the wrapper script copies to the archive PV; (2) base backups — weekly tarball lands in the basebackup PV; (3) observability — `pg_stat_archiver` view is scraped, dashboard and alerts derive from it.
+
+## PostgreSQL configuration
+
+Adds three new `args` flags to the postgres container (extending the args from the query-observability spec):
+
+```yaml
+args:
+  # ...existing flags from pg-query-observability spec...
+  - "-c"
+  - "archive_mode=on"
+  - "-c"
+  - "archive_command=/usr/local/bin/pg-archive-wal.sh %p %f"
+  - "-c"
+  - "archive_timeout=300"
+  - "-c"
+  - "wal_level=replica"
+```
+
+`wal_level=replica` is the default in PG 17, but setting it explicitly documents intent and protects against future config drift.
+
+`archive_timeout=300` forces a WAL switch every 5 minutes during idle periods. Without it, an idle database might never fill a WAL segment, leaving recent commits unarchived for arbitrary durations.
+
+## The archive script
+
+`pg-archive-wal.sh` (mounted from `postgres-wal-scripts` ConfigMap into `/usr/local/bin/` in the postgres container):
+
+```bash
+#!/bin/sh
+# Postgres archive_command target.
+#   $1 = %p — absolute path to the WAL segment in pg_wal/
+#   $2 = %f — segment filename
+# Contract: exit 0 on success. Anything non-zero retries forever.
+set -eu
+
+SRC="$1"
+FN="$2"
+DST_DIR="/var/lib/postgresql/wal-archive"
+DST="$DST_DIR/$FN"
+TMP="$DST.tmp"
+
+# Refuse to overwrite — would corrupt the archive timeline.
+if [ -e "$DST" ]; then
+  echo "pg-archive-wal: $FN already archived; refusing overwrite" >&2
+  exit 1
+fi
+
+cp "$SRC" "$TMP"
+sync "$TMP"
+mv "$TMP" "$DST"
+```
+
+Notes:
+- Atomic via temp + rename (mv on the same filesystem is atomic).
+- `sync` after `cp` ensures the segment is durable before Postgres considers it archived and recycles the source.
+- Refuses to overwrite. An overwrite would silently break the timeline; failing loud is correct.
+- Runs as the `postgres` user (the image entrypoint already drops privileges before running `archive_command`).
+
+## Base backup + WAL retention
+
+A weekly CronJob runs `pg-basebackup-and-prune.sh` in a postgres-client container. The script does two things atomically:
+
+```bash
+#!/bin/sh
+set -eu
+
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+BACKUP_DIR="/backups/basebackup/$STAMP"
+ARCHIVE_DIR="/backups/wal-archive"
+RETAIN=4   # keep 4 most recent weekly base backups
+
+mkdir -p "$BACKUP_DIR"
+
+# 1) Take the base backup as a tarball, with WAL inline so this backup is
+#    self-restorable even if the archive is lost.
+pg_basebackup \
+  --host=postgres.java-tasks.svc.cluster.local \
+  --username=replicator \
+  --pgdata="$BACKUP_DIR" \
+  --format=tar \
+  --gzip --compress=6 \
+  --wal-method=fetch \
+  --label="weekly-$STAMP" \
+  --checkpoint=fast \
+  --progress
+
+# 2) Prune base backups older than the retention window.
+ls -1d /backups/basebackup/*/ 2>/dev/null \
+  | sort | head -n -"$RETAIN" | xargs -r rm -rf
+
+# 3) Find the SECOND-most-recent surviving base backup. Retain WAL >= the
+#    earliest WAL needed by that backup, so we always have recovery from
+#    at least the previous-but-one weekly point. Use pg_archivecleanup.
+SECOND_NEWEST=$(ls -1d /backups/basebackup/*/ | sort | tail -n 2 | head -n 1)
+if [ -n "$SECOND_NEWEST" ] && [ -f "$SECOND_NEWEST/backup_label.gz" ]; then
+  START_WAL=$(zcat "$SECOND_NEWEST/backup_label.gz" \
+              | awk '/^START WAL LOCATION:/ {print $6; exit}' | tr -d '()')
+  if [ -n "$START_WAL" ]; then
+    pg_archivecleanup "$ARCHIVE_DIR" "$START_WAL"
+  fi
+fi
+```
+
+Why `--wal-method=fetch`? It pulls the WAL into the base backup tarball directly, so a single backup tarball is restorable on its own — even if the WAL archive is lost. The downside (a slightly larger tarball) is acceptable.
+
+Why retain WAL from the *second*-most-recent base backup? Defence in depth: if the most recent base backup is corrupt, the previous backup + WAL gives a fallback path.
+
+A new database role `replicator` with `REPLICATION` privilege is created (separate from `taskuser`) so the base-backup process has only the privileges it needs. Created by a one-shot Job analogous to the `grafana_reader` Job in the query-observability spec.
+
+## CronJob manifest
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-basebackup
+  namespace: java-tasks
+spec:
+  schedule: "0 3 * * 0"   # Sundays 03:00 UTC, one hour after the daily pg_dump
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: basebackup
+              image: postgres:17-alpine
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: java-secrets
+                      key: replicator-password
+              command: ["/usr/local/bin/pg-basebackup-and-prune.sh"]
+              volumeMounts:
+                - name: scripts
+                  mountPath: /usr/local/bin/pg-basebackup-and-prune.sh
+                  subPath: pg-basebackup-and-prune.sh
+                - name: basebackup
+                  mountPath: /backups/basebackup
+                - name: wal-archive
+                  mountPath: /backups/wal-archive
+          volumes:
+            - name: scripts
+              configMap:
+                name: postgres-wal-scripts
+                defaultMode: 0755
+            - name: basebackup
+              persistentVolumeClaim:
+                claimName: postgres-basebackup
+            - name: wal-archive
+              persistentVolumeClaim:
+                claimName: postgres-wal-archive
+```
+
+## Storage layout
+
+Two new hostPath PVs and PVCs follow the existing `postgres-backup-pv.yml` shape:
+
+| PV / PVC | Size | hostPath on Minikube node | Mount in postgres pod | Mount in CronJob |
+|---|---|---|---|---|
+| postgres-data (existing) | 5Gi | `/data/postgres` | `/var/lib/postgresql/data` | — |
+| postgres-backup (existing) | 5Gi | `/backups/postgres` | — | — |
+| postgres-wal-archive (NEW) | 10Gi | `/backups/wal-archive` | `/var/lib/postgresql/wal-archive` | `/backups/wal-archive` |
+| postgres-basebackup (NEW) | 10Gi | `/backups/basebackup` | — | `/backups/basebackup` |
+
+Sizing: at portfolio traffic, daily WAL volume is ~50–200 MB compressed. 10 Gi covers months of archive even if pruning failed. Base backup tarballs are ~200–500 MB compressed each; 4 retained × 500 MB = 2 GB worst case, with margin.
+
+## Observability
+
+`pg_stat_archiver` is a Postgres-built-in view exposing archiver health. `postgres_exporter` v0.16.0 already scrapes it; no custom query needed. Three metrics matter:
+
+- `pg_stat_archiver_archived_count` — total successful archives (counter)
+- `pg_stat_archiver_failed_count` — total failures (counter)
+- `pg_stat_archiver_last_archived_time` — timestamp of last success
+
+### Dashboard panels
+
+Append three panels to the existing PostgreSQL health dashboard (the one shipped in the data-integrity ADR), not the new query-performance dashboard:
+
+| Panel | Type | Source | Purpose |
+|---|---|---|---|
+| Time since last WAL archive | Stat | Prometheus | At-a-glance freshness — should be < `archive_timeout` (5 min) under normal load |
+| Archive failures (5m rate) | Time series | Prometheus | Detects archive_command flapping |
+| Time since last base backup | Stat | Prometheus (kube-state-metrics) | Should be < 8 days |
+
+The "time since last base backup" panel sources from `kube_cronjob_status_last_successful_time{cronjob="postgres-basebackup"}`, exposed by the existing kube-state-metrics deployment. No new exporter or textfile collector is needed.
+
+### Alerts
+
+Append three rules to the existing `PostgreSQL` group in `grafana-alerting.yml`. All use `noDataState: OK` per project convention.
+
+| Alert | Threshold | Why |
+|---|---|---|
+| `PgArchiveCommandFailing` | `rate(pg_stat_archiver_failed_count[10m]) > 0` for 5m | Archive failures stall WAL recycling and silently break PITR |
+| `PgWalArchiveStale` | `time() - pg_stat_archiver_last_archived_time > 600` for 5m | No archive in 10 min when `archive_timeout=300` indicates archive_command is broken |
+| `PgBasebackupStale` | `time() - kube_cronjob_status_last_successful_time{cronjob="postgres-basebackup"} > 691200` (8 days) | One-day buffer past the 7-day schedule for transient failures |
+
+## PITR runbook
+
+A new section is appended to the existing `docs/runbooks/postgres-recovery.md`. Structure mirrors the existing three scenarios (symptoms, prerequisites, step-by-step, verification):
+
+> **Scenario 4: Point-in-time recovery to a specific timestamp**
+>
+> *Symptoms:* an operator-induced data corruption (bad migration, accidental DELETE, malicious write) that needs to be undone without taking the database back further than necessary.
+>
+> *Prerequisites:* the target timestamp falls within the WAL archive retention window; at least one base backup exists from before the target timestamp.
+>
+> *Steps:*
+> 1. Stop Postgres (`kubectl scale deployment postgres -n java-tasks --replicas=0`).
+> 2. Choose the most recent base backup taken *before* the target timestamp. List candidates with `kubectl exec` into a debug pod with the basebackup PV mounted.
+> 3. Restore that base backup tarball to a fresh data dir (the `postgres-data` PVC is wiped or replaced).
+> 4. Drop a `recovery.signal` file in the data dir.
+> 5. Add `restore_command='cp /var/lib/postgresql/wal-archive/%f %p'` and `recovery_target_time='YYYY-MM-DD HH:MM:SS UTC'` and `recovery_target_action='promote'` to `postgresql.auto.conf`.
+> 6. Scale Postgres back up. It enters recovery, replays WAL until the target time is reached, and promotes.
+> 7. Verify by querying for the corruption-causing row's absence (or the missing row's presence, depending on direction).
+>
+> Each step has the exact `kubectl` / `psql` commands inline in the runbook.
+
+The cross-link from the existing recovery scenarios is updated so on-call sees PITR as a peer of the existing options.
+
+## Testing
+
+**Integration test** (Go, testcontainers, build-tagged) at `go/pkg/db/wal_archive_integration_test.go`:
+
+1. Start Postgres in a container with `archive_mode=on`, `archive_timeout=2`, and `archive_command` pointing at a directory mounted from a host tmpdir.
+2. Insert a row, force a WAL switch (`SELECT pg_switch_wal()`), wait briefly.
+3. Assert at least one file appears in the archive directory.
+4. Verify the archive script's idempotency: re-run with the same target should fail loudly (exit non-zero), confirming the no-overwrite contract.
+
+**QA smoke test** (manual, in QA cluster):
+
+1. After deploy, exec into the postgres pod and run `SELECT * FROM pg_stat_archiver;` — verify `archived_count > 0` and `last_archived_time` is recent.
+2. Verify a WAL file is visible on the host: `ls /backups/wal-archive/` on the Minikube node.
+3. Trigger a manual base backup: `kubectl create job --from=cronjob/postgres-basebackup postgres-basebackup-manual -n java-tasks-qa`. Verify a new tarball appears.
+4. Run a PITR drill in QA per the runbook — restore to a 5-minutes-ago timestamp on a parallel temporary deployment, query a known marker.
+
+The continuous PITR-restore verification is delegated to the next roadmap item (#158, "automated backup verification") so this spec stays focused.
+
+## Rollout
+
+Each step is independently mergeable.
+
+1. Land the wrapper scripts ConfigMap.
+2. Add the two new PVs/PVCs.
+3. Create the `replicator` role via a one-shot Job (analogous to the `grafana_reader` Job).
+4. Update the postgres deployment with the new `args` and the wal-archive volume mount. Deploy → `Recreate` restart picks it up.
+5. Add the basebackup CronJob.
+6. Run the basebackup manually once to seed the basebackup PV.
+7. Add dashboard panels.
+8. Add alerts.
+9. Run the manual QA PITR drill and append findings to the runbook.
+
+## ADR
+
+Companion ADR at `docs/adr/database/wal-archiving-pitr.md` (the `database/` directory is created by either this work or the migration-lint work, whichever lands first). The ADR documents:
+
+- Why native `archive_command` over pgBackRest (interview narrative + matches existing pg_dump pattern)
+- Why two retained base backups (defence-in-depth against backup corruption)
+- Why hostPath PVs over off-host storage (no-paid-services constraint, with the explicit acknowledgement that disk failure is unmitigated)
+- The `archive_timeout = 300` choice and what it costs in WAL volume
+- The decision to bundle WAL into the base backup tarball (`--wal-method=fetch`)
+
+## Consequences
+
+**Positive:**
+- RPO drops from ≤ 24h to seconds (one `archive_timeout` window plus pending in-flight WAL).
+- An operator can recover to any timestamp within the archive retention window — the most powerful Postgres recovery primitive.
+- Archive failures and base-backup staleness are alerted, not silent.
+- The runbook turns "we have backups" into "we know how to restore to a specific second."
+
+**Trade-offs:**
+- `archive_mode=on` requires a Postgres restart. Acceptable given the existing `Recreate` strategy.
+- Disk usage grows by ~10 GB (two hostPath PVs).
+- WAL archiving is on the same physical disk as the data PVC. Disk failure remains unmitigated — that's a Phase 3 problem (off-host or replica).
+- The wrapper script's failure mode (refuses to overwrite) is loud-fail; an operator might see legitimate alert noise during disaster-recovery exercises and need to consciously bypass.
+
+**Phase 2 (future, separate roadmap items):**
+- Automated weekly PITR drill (#158 — backup verification)
+- Read replica via streaming replication (#161) — the same WAL stream that feeds the archive can feed a hot standby
+- Off-host archive (S3-compatible) once the no-paid-services constraint relaxes

--- a/go/pkg/db/wal_archive_integration_test.go
+++ b/go/pkg/db/wal_archive_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/moby/moby/api/types/container"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// archiveScript is the production wrapper from
+// java/k8s/configmaps/postgres-wal-scripts.yml; we keep it inline here so
+// the test exercises the exact same logic.
+const archiveScript = `#!/bin/sh
+set -eu
+SRC="$1"
+FN="$2"
+DST_DIR="/var/lib/postgresql/wal-archive"
+DST="$DST_DIR/$FN"
+TMP="$DST.tmp"
+if [ -e "$DST" ]; then
+  echo "pg-archive-wal: $FN already archived; refusing overwrite" >&2
+  exit 1
+fi
+cp "$SRC" "$TMP"
+sync "$TMP"
+mv "$TMP" "$DST"
+`
+
+func TestWalArchiveAndIdempotency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+	ctx := context.Background()
+
+	hostArchive := t.TempDir()
+	if err := os.Chmod(hostArchive, 0o777); err != nil {
+		t.Fatalf("chmod tmpdir: %v", err)
+	}
+
+	hostScript := filepath.Join(t.TempDir(), "pg-archive-wal.sh")
+	if err := os.WriteFile(hostScript, []byte(archiveScript), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:17-alpine",
+		postgres.WithDatabase("appdb"),
+		postgres.WithUsername("appuser"),
+		postgres.WithPassword("apppass"),
+		testcontainers.WithCmdArgs(
+			"-c", "wal_level=replica",
+			"-c", "archive_mode=on",
+			"-c", "archive_command=/usr/local/bin/pg-archive-wal.sh %p %f",
+			"-c", "archive_timeout=2",
+		),
+		testcontainers.WithHostConfigModifier(func(hc *container.HostConfig) {
+			hc.Binds = append(hc.Binds,
+				hostArchive+":/var/lib/postgresql/wal-archive",
+				hostScript+":/usr/local/bin/pg-archive-wal.sh:ro",
+			)
+		}),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = pgContainer.Terminate(ctx) })
+
+	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("dsn: %v", err)
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE marker (n int)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO marker VALUES (1)`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `SELECT pg_switch_wal()`); err != nil {
+		t.Fatalf("switch wal: %v", err)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	var archived []os.DirEntry
+	for time.Now().Before(deadline) {
+		entries, err := os.ReadDir(hostArchive)
+		if err != nil {
+			t.Fatalf("read archive: %v", err)
+		}
+		archived = nil
+		for _, e := range entries {
+			if !e.IsDir() && len(e.Name()) == 24 {
+				archived = append(archived, e)
+			}
+		}
+		if len(archived) > 0 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if len(archived) == 0 {
+		t.Fatalf("no WAL segments archived within 30s")
+	}
+
+	srcSegment := filepath.Join(hostArchive, archived[0].Name())
+	cmd := exec.CommandContext(ctx, "/bin/sh", hostScript, srcSegment, archived[0].Name())
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Errorf("expected re-archive to fail with non-zero exit; got success: %s", string(out))
+	}
+}

--- a/go/pkg/go.mod
+++ b/go/pkg/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/moby/moby/api v1.54.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/kafka-go v0.4.50
 	github.com/sony/gobreaker/v2 v2.4.0
@@ -65,7 +66,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.54.1 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/java/k8s/configmaps/postgres-wal-scripts.yml
+++ b/java/k8s/configmaps/postgres-wal-scripts.yml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-wal-scripts
+  namespace: java-tasks
+data:
+  pg-archive-wal.sh: |
+    #!/bin/sh
+    # Postgres archive_command target.
+    #   $1 = %p — absolute path to the WAL segment (under pg_wal/)
+    #   $2 = %f — segment filename
+    # Contract: exit 0 on success. Anything non-zero causes Postgres to
+    # retry forever, which stalls WAL recycling — so we want loud-fail
+    # on real corruption (overwrite attempt) and durable success on the
+    # happy path.
+    set -eu
+
+    SRC="$1"
+    FN="$2"
+    DST_DIR="/var/lib/postgresql/wal-archive"
+    DST="$DST_DIR/$FN"
+    TMP="$DST.tmp"
+
+    if [ -e "$DST" ]; then
+      echo "pg-archive-wal: $FN already archived; refusing overwrite" >&2
+      exit 1
+    fi
+
+    cp "$SRC" "$TMP"
+    sync "$TMP"
+    mv "$TMP" "$DST"
+  pg-basebackup-and-prune.sh: |
+    #!/bin/sh
+    # Weekly: take a base backup as a gzip tarball, prune old base
+    # backups, and prune WAL older than the second-newest surviving
+    # base backup.
+    set -eu
+
+    STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+    BACKUP_DIR="/backups/basebackup/$STAMP"
+    ARCHIVE_DIR="/backups/wal-archive"
+    RETAIN=4   # keep 4 most-recent weekly base backups
+
+    mkdir -p "$BACKUP_DIR"
+
+    echo "Base backup -> $BACKUP_DIR"
+    pg_basebackup \
+      --host=postgres.java-tasks.svc.cluster.local \
+      --username=replicator \
+      --pgdata="$BACKUP_DIR" \
+      --format=tar \
+      --gzip --compress=6 \
+      --wal-method=fetch \
+      --label="weekly-$STAMP" \
+      --checkpoint=fast \
+      --progress
+
+    echo "Pruning base backups older than $RETAIN newest..."
+    # shellcheck disable=SC2012  # ls -1d is fine for our naming convention
+    ls -1d /backups/basebackup/*/ 2>/dev/null \
+      | sort \
+      | head -n -"$RETAIN" \
+      | xargs -r rm -rf
+
+    echo "Pruning WAL older than the second-newest base backup..."
+    SECOND_NEWEST=$(ls -1d /backups/basebackup/*/ 2>/dev/null | sort | tail -n 2 | head -n 1)
+    if [ -n "$SECOND_NEWEST" ] && [ -f "$SECOND_NEWEST/backup_label.gz" ]; then
+      START_WAL=$(zcat "$SECOND_NEWEST/backup_label.gz" \
+                  | awk '/^START WAL LOCATION:/ {print $6; exit}' \
+                  | tr -d '()')
+      if [ -n "$START_WAL" ]; then
+        pg_archivecleanup "$ARCHIVE_DIR" "$START_WAL"
+      fi
+    fi
+
+    echo "Base backup + prune complete."
+    ls -1d /backups/basebackup/*/ | sort

--- a/java/k8s/cronjobs/postgres-basebackup.yml
+++ b/java/k8s/cronjobs/postgres-basebackup.yml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-basebackup
+  namespace: java-tasks
+spec:
+  schedule: "0 3 * * 0"   # Sundays 03:00 UTC, one hour after the daily pg_dump
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: basebackup
+              image: postgres:17-alpine
+              command: ["/usr/local/bin/pg-basebackup-and-prune.sh"]
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: java-secrets
+                      key: replicator-password
+              volumeMounts:
+                - name: scripts
+                  mountPath: /usr/local/bin/pg-basebackup-and-prune.sh
+                  subPath: pg-basebackup-and-prune.sh
+                  readOnly: true
+                - name: basebackup
+                  mountPath: /backups/basebackup
+                - name: wal-archive
+                  mountPath: /backups/wal-archive
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+          volumes:
+            - name: scripts
+              configMap:
+                name: postgres-wal-scripts
+                defaultMode: 0755
+            - name: basebackup
+              persistentVolumeClaim:
+                claimName: postgres-basebackup
+            - name: wal-archive
+              persistentVolumeClaim:
+                claimName: postgres-wal-archive

--- a/java/k8s/deployments/postgres.yml
+++ b/java/k8s/deployments/postgres.yml
@@ -46,6 +46,14 @@ spec:
             - "auto_explain.log_format=json"
             - "-c"
             - "auto_explain.sample_rate=1.0"
+            - "-c"
+            - "archive_mode=on"
+            - "-c"
+            - "archive_command=/usr/local/bin/pg-archive-wal.sh %p %f"
+            - "-c"
+            - "archive_timeout=300"
+            - "-c"
+            - "wal_level=replica"
           lifecycle:
             preStop:
               exec:
@@ -80,6 +88,12 @@ spec:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
               subPath: pgdata
+            - name: wal-scripts
+              mountPath: /usr/local/bin/pg-archive-wal.sh
+              subPath: pg-archive-wal.sh
+              readOnly: true
+            - name: wal-archive
+              mountPath: /var/lib/postgresql/wal-archive
           resources:
             requests:
               memory: "128Mi"
@@ -125,3 +139,10 @@ spec:
         - name: exporter-queries
           configMap:
             name: postgres-exporter-queries
+        - name: wal-scripts
+          configMap:
+            name: postgres-wal-scripts
+            defaultMode: 0755
+        - name: wal-archive
+          persistentVolumeClaim:
+            claimName: postgres-wal-archive

--- a/java/k8s/jobs/postgres-replicator-bootstrap.yml
+++ b/java/k8s/jobs/postgres-replicator-bootstrap.yml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgres-replicator-bootstrap
+  namespace: java-tasks
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: psql
+          image: postgres:17-alpine
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: postgres-password
+            - name: REPLICATOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: replicator-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              psql -h postgres.java-tasks.svc.cluster.local -U taskuser -d postgres \
+                -v ON_ERROR_STOP=1 \
+                -v repl_pw="$REPLICATOR_PASSWORD" <<'SQL'
+              DO $$
+              BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'replicator') THEN
+                  EXECUTE format('CREATE ROLE replicator WITH REPLICATION LOGIN PASSWORD %L', :'repl_pw');
+                ELSE
+                  EXECUTE format('ALTER ROLE replicator WITH REPLICATION LOGIN PASSWORD %L', :'repl_pw');
+                END IF;
+              END
+              $$;
+              SQL
+              echo "replicator role ready"
+          resources:
+            requests: { cpu: "10m", memory: "32Mi" }
+            limits:   { cpu: "100m", memory: "64Mi" }

--- a/java/k8s/kustomization.yaml
+++ b/java/k8s/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - configmaps/notification-service-config.yml
   - configmaps/postgres-exporter-queries.yml
   - configmaps/postgres-initdb.yml
+  - configmaps/postgres-wal-scripts.yml
   - configmaps/rabbitmq-definitions.yml
   - configmaps/task-service-config.yml
   - deployments/activity-service.yml
@@ -28,9 +29,13 @@ resources:
   - services/task-service.yml
   - volumes/postgres-pvc.yml
   - volumes/postgres-backup-pv.yml
+  - volumes/postgres-basebackup-pv.yml
+  - volumes/postgres-wal-archive-pv.yml
   - jobs/postgres-backup.yml
   - jobs/postgres-extensions-bootstrap.yml
   - jobs/postgres-grafana-reader.yml
+  - jobs/postgres-replicator-bootstrap.yml
+  - cronjobs/postgres-basebackup.yml
   - pdb/postgres-pdb.yml
   - ingress.yml
   - ingress-rabbitmq.yml

--- a/java/k8s/secrets/java-secrets.yml.template
+++ b/java/k8s/secrets/java-secrets.yml.template
@@ -13,3 +13,5 @@ data:
   google-client-id: ""
   google-client-secret: ""
   grafana-reader-password: Z3JhZmFuYS1yZWFkZXItc2VjcmV0   # grafana-reader-secret
+  # replicator role created by jobs/postgres-replicator-bootstrap.yml using this key
+  replicator-password: cmVwbGljYXRvci1zZWNyZXQ=           # replicator-secret

--- a/java/k8s/volumes/postgres-basebackup-pv.yml
+++ b/java/k8s/volumes/postgres-basebackup-pv.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-basebackup-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /backups/basebackup
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-basebackup
+  namespace: java-tasks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 10Gi

--- a/java/k8s/volumes/postgres-wal-archive-pv.yml
+++ b/java/k8s/volumes/postgres-wal-archive-pv.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-wal-archive-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /backups/wal-archive
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-wal-archive
+  namespace: java-tasks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -1724,3 +1724,112 @@ data:
               severity: warning
             annotations:
               summary: "No auto_explain log lines in 24h — query observability is silently broken"
+
+          - uid: pg-archive-command-failing
+            title: Postgres Archive Command Failing
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: rate(pg_stat_archiver_failed_count[10m])
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0] }
+                  refId: C
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              summary: "pg_stat_archiver is reporting failures — archive_command is broken; WAL recycling will stall and PITR will silently break"
+
+          - uid: pg-wal-archive-stale
+            title: Postgres WAL Archive Stale
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: time() - pg_stat_archiver_last_archived_time
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [600] }
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "No WAL archived in 10+ minutes — archive_timeout is 5m so this should never happen under normal load"
+
+          - uid: pg-basebackup-stale
+            title: Postgres Base Backup Stale
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 86400, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    time() - max(kube_cronjob_status_last_successful_time{
+                      cronjob="postgres-basebackup",
+                      namespace="java-tasks"
+                    })
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 86400, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 86400, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [691200] }
+                  refId: C
+            for: 0s
+            labels:
+              severity: critical
+            annotations:
+              summary: "No successful postgres-basebackup CronJob in 8+ days — PITR baseline may have aged out"

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -3497,6 +3497,96 @@ data:
             "orientation": "horizontal",
             "displayMode": "gradient"
           }
+        },
+        {
+          "title": "Time Since Last WAL Archive",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 8, "x": 0, "y": 24 },
+          "id": 8,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "time() - pg_stat_archiver_last_archived_time",
+              "legendFormat": "age",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 300 },
+                  { "color": "red", "value": 600 }
+                ]
+              }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "WAL Archive Failures (5m rate)",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 8, "x": 8, "y": 24 },
+          "id": 9,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "rate(pg_stat_archiver_failed_count[5m])",
+              "legendFormat": "failures/sec",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "red", "value": 0.0001 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi" },
+            "legend": { "displayMode": "list", "placement": "bottom" }
+          }
+        },
+        {
+          "title": "Time Since Last Base Backup",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 8, "x": 16, "y": 24 },
+          "id": 10,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "time() - max(kube_cronjob_status_last_successful_time{cronjob=\"postgres-basebackup\", namespace=\"java-tasks\"})",
+              "legendFormat": "age",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 604800 },
+                  { "color": "red", "value": 691200 }
+                ]
+              }
+            },
+            "overrides": []
+          }
         }
       ],
       "schemaVersion": 39,
@@ -3507,7 +3597,7 @@ data:
       "timezone": "",
       "title": "PostgreSQL",
       "uid": "postgresql",
-      "version": 1
+      "version": 2
     }
   pg-query-performance.json: |
     {

--- a/k8s/overlays/qa-java/kustomization.yaml
+++ b/k8s/overlays/qa-java/kustomization.yaml
@@ -170,3 +170,22 @@ patches:
       kind: Ingress
       metadata:
         name: rabbitmq-ingress
+  # --- Remove WAL-archive workloads (shared prod handles them) ---
+  - target:
+      kind: CronJob
+      name: postgres-basebackup
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: postgres-basebackup
+  - target:
+      kind: Job
+      name: postgres-replicator-bootstrap
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: postgres-replicator-bootstrap


### PR DESCRIPTION
## Summary
- Continuous WAL archiving via a new `archive_command` wrapper script and a 10Gi `postgres-wal-archive` hostPath PV
- Weekly `pg_basebackup` CronJob (Sundays 03:00 UTC) writing to a 10Gi `postgres-basebackup` hostPath PV; retains 4 weekly tarballs + WAL back to the second-newest backup
- New `replicator` role created by a one-shot Job analogous to `postgres-grafana-reader`
- Three new Grafana alerts (`PgArchiveCommandFailing`, `PgWalArchiveStale`, `PgBasebackupStale`) and three new panels on the existing PostgreSQL dashboard, sourced from `pg_stat_archiver` and `kube_cronjob_status_last_successful_time` (no new exporter)
- PITR procedure appended to `docs/runbooks/postgres-recovery.md` as Scenario 4
- Companion ADR at `docs/adr/database/wal-archiving-pitr.md`
- Integration test (testcontainers, build-tagged) validates the archive script's happy path and idempotency contract

Implements item 3 of the db-roadmap (issue #157). Spec at `docs/superpowers/specs/2026-04-27-pitr-design.md`. Plan at `docs/superpowers/plans/2026-04-27-pitr.md`.

## Operator action required after merge
The live `java-secrets` Secret needs a `replicator-password` key — see "Operator action required when applying" in the ADR. The bootstrap Job will fail until this is set.

## Test plan
- [ ] CI green on `qa`
- [ ] Apply to QA cluster; manually trigger basebackup CronJob and verify a tarball lands in `/backups/basebackup/` on the Debian node
- [ ] In a postgres pod exec, `SELECT * FROM pg_stat_archiver` shows `archived_count > 0` and a recent `last_archived_time`
- [ ] Trigger the `PgWalArchiveStale` alert by `kubectl exec`-ing into postgres and renaming the archive script for ~12 minutes, confirm Telegram fires, restore the script
- [ ] Walk through Scenario 4 in QA on a parallel temporary deployment, restore to a 5-minutes-ago timestamp, query a known marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)