### PR TITLE
feat: /database portfolio page (PostgreSQL focus, NoSQL/Vector stubs)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-database-portfolio-page.md
+++ b/docs/superpowers/plans/2026-04-27-database-portfolio-page.md
@@ -1,0 +1,1005 @@
+# `/database` Portfolio Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a recruiter-facing `/database` portfolio page that surfaces the existing PostgreSQL work (query optimization, schema design, migration safety, reliability) under a single discoverable URL, with stub tabs reserving IA for NoSQL and Vector content later.
+
+**Architecture:** Next.js App Router page at `frontend/src/app/database/page.tsx` with a three-tab state machine that exactly mirrors `/go` page tab pattern. The PostgreSQL tab is a two-column layout (pillar sections + sticky table-of-contents) using a reusable `PillarSection` component and an `IntersectionObserver`-driven `StickyToc`. NoSQL and Vector tabs are short stub components that point users at `/java` and `/ai` respectively. The homepage gets a new card slotted between `/cicd` and `/security`.
+
+**Tech Stack:**
+- Next.js (App Router) + React + TypeScript — match the existing repo conventions
+- Tailwind CSS — match existing classnames (`text-muted-foreground`, `border-foreground/10`, etc.)
+- shadcn/ui primitives already in repo: `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent` (`frontend/src/components/ui/card.tsx`)
+- Playwright (`frontend/e2e/mocked/` directory, `npm run e2e`) — only test framework wired up for the frontend
+- Native browser `IntersectionObserver` for the scroll-spy TOC; no extra deps
+
+---
+
+## Pre-flight notes for the executing engineer
+
+- **Read `frontend/AGENTS.md`.** The repo says "This is NOT the Next.js you know — APIs, conventions, and file structure may all differ from your training data." Use the existing `/go` page (`frontend/src/app/go/page.tsx`) as the canonical reference for component shape and tab state, and read `node_modules/next/dist/docs/` if you need any Next API beyond what `/go` already uses.
+- **No new deps.** Everything in this plan uses existing components, Tailwind classes, and the standard browser API (`IntersectionObserver`).
+- **Test strategy.** Frontend tests are Playwright-only (`frontend/e2e/mocked/*.spec.ts`). There is no Vitest / Jest. Component-level "tests" are Playwright assertions on rendered DOM. Run with `npm run e2e -- <spec.ts>` from `frontend/`.
+- **Dev server.** `cd frontend && npm run dev` serves on `http://localhost:3000`. Playwright auto-starts it via `webServer` config when not already running.
+- **Preflight.** Frontend changes require `make preflight-frontend` and `make preflight-e2e` per `CLAUDE.md`. Run them before pushing.
+- **Vercel-bake gotcha.** This page does NOT add any `NEXT_PUBLIC_*` env vars, so the Vercel localhost-fallback rule from `CLAUDE.md` doesn't apply. If you find yourself wanting one, stop and reconsider — none of the content on this page is dynamic.
+
+---
+
+## File Structure
+
+**New files:**
+
+```
+frontend/src/app/database/
+├── page.tsx                            # Three-tab page, mirrors /go pattern
+└── error.tsx                           # Standard error boundary
+
+frontend/src/components/database/
+├── tabs.ts                             # Tab union type + tab labels
+├── PillarSection.tsx                   # Reusable: header + narrative + bullets + ADR links
+├── StickyToc.tsx                       # IntersectionObserver active-section tracker
+├── PostgresTab.tsx                     # Two-column layout w/ four pillars + sticky TOC
+├── NoSqlTab.tsx                        # Stub component → /java
+└── VectorTab.tsx                       # Stub component → /ai
+
+frontend/e2e/mocked/
+└── database-page.spec.ts               # Playwright e2e for the new page
+```
+
+**Modified files:**
+
+```
+frontend/src/app/page.tsx               # Add Database Engineering card between /cicd and /security
+```
+
+**Decomposition rationale:**
+
+- `PillarSection` and `StickyToc` are isolated components with narrow inputs (props arrays). They're easy to reason about independently and trivial to reuse if a future pillar lands on a different page.
+- `tabs.ts` holds the single source of truth for tab keys and labels — same shape `/go` uses inline today, but extracted because three different files need to reference the labels (page.tsx, e2e tests, future stubs).
+- `PostgresTab` owns the four-pillar narrative and the wiring of `PillarSection` + `StickyToc`. Splitting each pillar into its own file would be over-engineering: each pillar is mostly a data array, not behavior.
+- Stubs are full files (not inline JSX in `page.tsx`) so swapping them for real content later is a single-file change.
+
+---
+
+## Task 1: `/database` route skeleton with three tabs
+
+**Files:**
+- Create: `frontend/src/app/database/page.tsx`
+- Create: `frontend/src/app/database/error.tsx`
+- Create: `frontend/src/components/database/tabs.ts`
+- Create: `frontend/src/components/database/PostgresTab.tsx` (placeholder)
+- Create: `frontend/src/components/database/NoSqlTab.tsx` (placeholder)
+- Create: `frontend/src/components/database/VectorTab.tsx` (placeholder)
+- Create: `frontend/e2e/mocked/database-page.spec.ts`
+
+This task ships the page skeleton and a passing-and-failing test pair: the page loads, all three tabs are present, switching tabs swaps the visible content. Pillar content lands in later tasks.
+
+- [ ] **Step 1: Create the tabs data module**
+
+`frontend/src/components/database/tabs.ts`:
+
+```ts
+export type DatabaseTab = "postgres" | "nosql" | "vector";
+
+export const databaseTabs: { key: DatabaseTab; label: string }[] = [
+  { key: "postgres", label: "PostgreSQL" },
+  { key: "nosql", label: "NoSQL" },
+  { key: "vector", label: "Vector" },
+];
+```
+
+- [ ] **Step 2: Create placeholder tab components**
+
+`frontend/src/components/database/PostgresTab.tsx`:
+
+```tsx
+export function PostgresTab() {
+  return (
+    <div data-testid="postgres-tab">
+      <p className="text-muted-foreground">PostgreSQL content — coming in Task 5.</p>
+    </div>
+  );
+}
+```
+
+`frontend/src/components/database/NoSqlTab.tsx`:
+
+```tsx
+export function NoSqlTab() {
+  return (
+    <div data-testid="nosql-tab">
+      <p className="text-muted-foreground">NoSQL content — coming in Task 6.</p>
+    </div>
+  );
+}
+```
+
+`frontend/src/components/database/VectorTab.tsx`:
+
+```tsx
+export function VectorTab() {
+  return (
+    <div data-testid="vector-tab">
+      <p className="text-muted-foreground">Vector content — coming in Task 6.</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create the page (mirrors `/go` page tab pattern exactly)**
+
+`frontend/src/app/database/page.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { databaseTabs, type DatabaseTab } from "@/components/database/tabs";
+import { PostgresTab } from "@/components/database/PostgresTab";
+import { NoSqlTab } from "@/components/database/NoSqlTab";
+import { VectorTab } from "@/components/database/VectorTab";
+
+export default function DatabasePage() {
+  const [activeTab, setActiveTab] = useState<DatabaseTab>("postgres");
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="mt-8 text-3xl font-bold">Database Engineering</h1>
+
+      {/* Bio Section */}
+      <section className="mt-8">
+        <p className="text-muted-foreground leading-relaxed">
+          Production-grade PostgreSQL is one of the load-bearing skills behind
+          this portfolio: real-database benchmarks, range partitioning with
+          materialized views, a custom AST-based migration linter, and an
+          operational track with backups and recovery runbooks. MongoDB and
+          Qdrant are also in use elsewhere in the portfolio — dedicated tabs
+          for each are coming.
+        </p>
+      </section>
+
+      {/* Project Section with Tabs */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Database Tracks</h2>
+
+        {/* Tab Bar */}
+        <div className="mt-4 flex gap-0 border-b border-foreground/10">
+          {databaseTabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                activeTab === tab.key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab Content */}
+        <div className="mt-8">
+          {activeTab === "postgres" && <PostgresTab />}
+          {activeTab === "nosql" && <NoSqlTab />}
+          {activeTab === "vector" && <VectorTab />}
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create the standard error boundary**
+
+`frontend/src/app/database/error.tsx`:
+
+```tsx
+"use client";
+
+export default function DatabaseError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="text-2xl font-bold">Something went wrong on /database</h1>
+      <p className="mt-4 text-muted-foreground">{error.message}</p>
+      <button
+        onClick={reset}
+        className="mt-6 rounded-lg border px-4 py-2 text-sm hover:bg-accent transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Write the failing Playwright test**
+
+`frontend/e2e/mocked/database-page.spec.ts`:
+
+```ts
+import { test, expect } from "./fixtures";
+
+test.describe("/database page", () => {
+  test("renders the page heading", async ({ page }) => {
+    await page.goto("/database");
+    await expect(page.getByRole("heading", { name: "Database Engineering", level: 1 })).toBeVisible();
+  });
+
+  test("renders all three tab labels", async ({ page }) => {
+    await page.goto("/database");
+    await expect(page.getByRole("button", { name: "PostgreSQL", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "NoSQL", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Vector", exact: true })).toBeVisible();
+  });
+
+  test("PostgreSQL tab is active by default", async ({ page }) => {
+    await page.goto("/database");
+    await expect(page.getByTestId("postgres-tab")).toBeVisible();
+    await expect(page.getByTestId("nosql-tab")).not.toBeVisible();
+    await expect(page.getByTestId("vector-tab")).not.toBeVisible();
+  });
+
+  test("clicking NoSQL switches to the NoSQL tab", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "NoSQL", exact: true }).click();
+    await expect(page.getByTestId("nosql-tab")).toBeVisible();
+    await expect(page.getByTestId("postgres-tab")).not.toBeVisible();
+  });
+
+  test("clicking Vector switches to the Vector tab", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Vector", exact: true }).click();
+    await expect(page.getByTestId("vector-tab")).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 6: Run the e2e test, verify it passes**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run e2e -- database-page.spec.ts
+```
+
+Expected: 5 tests pass. (If the dev server isn't running, Playwright starts it automatically per `playwright.config.ts`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page
+git add frontend/src/app/database frontend/src/components/database frontend/e2e/mocked/database-page.spec.ts
+git commit -m "feat(database): scaffold /database page with three-tab skeleton"
+```
+
+---
+
+## Task 2: NoSQL and Vector stub content
+
+**Files:**
+- Modify: `frontend/src/components/database/NoSqlTab.tsx`
+- Modify: `frontend/src/components/database/VectorTab.tsx`
+- Modify: `frontend/e2e/mocked/database-page.spec.ts`
+
+The stubs do real work: they tell recruiters that NoSQL and Vector experience exists in the portfolio and point at where the running code lives.
+
+- [ ] **Step 1: Replace `NoSqlTab` placeholder with stub content**
+
+`frontend/src/components/database/NoSqlTab.tsx`:
+
+```tsx
+import Link from "next/link";
+
+export function NoSqlTab() {
+  return (
+    <div data-testid="nosql-tab" className="space-y-6">
+      <p className="text-muted-foreground leading-relaxed">
+        MongoDB powers the activity feed and analytics aggregations in the
+        Java task-management portfolio — document-shaped activity events,
+        time-bucketed aggregations, and a Redis read-cache layered on top.
+        A dedicated NoSQL section is on the way; for now, the running code
+        and its supporting docs live on the Java page.
+      </p>
+      <div>
+        <Link
+          href="/java"
+          className="inline-flex items-center gap-2 rounded-lg border px-6 py-3 text-sm font-medium hover:bg-accent transition-colors"
+        >
+          View MongoDB usage in /java &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Replace `VectorTab` placeholder with stub content**
+
+`frontend/src/components/database/VectorTab.tsx`:
+
+```tsx
+import Link from "next/link";
+
+export function VectorTab() {
+  return (
+    <div data-testid="vector-tab" className="space-y-6">
+      <p className="text-muted-foreground leading-relaxed">
+        Qdrant backs the retrieval layer behind the Document Q&amp;A
+        assistant and the code-aware Debug Assistant — chunked PDF
+        embeddings, code-aware splitting, and approximate-nearest-neighbor
+        search feeding RAG prompts. A dedicated vector-database section is
+        on the way; for now, the running code and its supporting docs live
+        on the AI page.
+      </p>
+      <div>
+        <Link
+          href="/ai"
+          className="inline-flex items-center gap-2 rounded-lg border px-6 py-3 text-sm font-medium hover:bg-accent transition-colors"
+        >
+          View vector DB usage in /ai &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add stub-content assertions to the existing spec**
+
+Append to `frontend/e2e/mocked/database-page.spec.ts` inside the same `test.describe` block:
+
+```ts
+  test("NoSQL stub points to /java", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "NoSQL", exact: true }).click();
+    await expect(page.getByText("MongoDB powers the activity feed", { exact: false })).toBeVisible();
+    const link = page.getByRole("link", { name: /View MongoDB usage in \/java/ });
+    await expect(link).toHaveAttribute("href", "/java");
+  });
+
+  test("Vector stub points to /ai", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Vector", exact: true }).click();
+    await expect(page.getByText("Qdrant backs the retrieval layer", { exact: false })).toBeVisible();
+    const link = page.getByRole("link", { name: /View vector DB usage in \/ai/ });
+    await expect(link).toHaveAttribute("href", "/ai");
+  });
+```
+
+- [ ] **Step 4: Run the spec and verify all 7 tests pass**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run e2e -- database-page.spec.ts
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/database/NoSqlTab.tsx frontend/src/components/database/VectorTab.tsx frontend/e2e/mocked/database-page.spec.ts
+git commit -m "feat(database): NoSQL and Vector stub content with cross-links"
+```
+
+---
+
+## Task 3: `PillarSection` reusable component
+
+**Files:**
+- Create: `frontend/src/components/database/PillarSection.tsx`
+
+`PillarSection` is the unit the PostgreSQL tab repeats four times. Defining it before the tab keeps each pillar's data declarative.
+
+- [ ] **Step 1: Create `PillarSection.tsx`**
+
+```tsx
+import type { ReactNode } from "react";
+
+export type PillarLink = {
+  label: string;
+  href: string;
+};
+
+export type PillarSectionProps = {
+  /** Anchor id, used by the sticky TOC and as the `<h2>`'s id. */
+  id: string;
+  /** Section heading, e.g. "Query Optimization & Benchmarking". */
+  title: string;
+  /** Two- to four-sentence narrative paragraph(s). */
+  narrative: ReactNode;
+  /** 4–6 concrete-claim bullets. Strings or ReactNodes. */
+  bullets: ReactNode[];
+  /** ADR / runbook links rendered as a muted button row. */
+  links: PillarLink[];
+};
+
+export function PillarSection({ id, title, narrative, bullets, links }: PillarSectionProps) {
+  return (
+    <section id={id} className="scroll-mt-24" data-testid={`pillar-${id}`}>
+      <h2 className="text-2xl font-semibold">{title}</h2>
+      <div className="mt-4 text-muted-foreground leading-relaxed space-y-3">{narrative}</div>
+      <ul className="mt-4 space-y-2 list-disc pl-5 text-sm text-muted-foreground">
+        {bullets.map((bullet, i) => (
+          <li key={i} className="leading-relaxed">{bullet}</li>
+        ))}
+      </ul>
+      {links.length > 0 && (
+        <div className="mt-5 flex flex-wrap gap-3">
+          {links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium hover:bg-accent transition-colors"
+              target={link.href.startsWith("http") ? "_blank" : undefined}
+              rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+            >
+              {link.label} &rarr;
+            </a>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check the component by running the existing build**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run build 2>&1 | tail -20
+```
+
+Expected: build succeeds. (`PillarSection` isn't imported anywhere yet, so it just has to compile cleanly.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/database/PillarSection.tsx
+git commit -m "feat(database): add PillarSection reusable component"
+```
+
+---
+
+## Task 4: `StickyToc` with IntersectionObserver
+
+**Files:**
+- Create: `frontend/src/components/database/StickyToc.tsx`
+
+The sticky TOC tracks which pillar is currently in view and highlights the corresponding entry. On mobile (< md), it collapses to a horizontal chip row pinned at the top of the tab content. On desktop, it sits as a sticky right-column.
+
+- [ ] **Step 1: Create `StickyToc.tsx`**
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type StickyTocItem = {
+  id: string;
+  label: string;
+};
+
+export type StickyTocProps = {
+  items: StickyTocItem[];
+};
+
+export function StickyToc({ items }: StickyTocProps) {
+  const [activeId, setActiveId] = useState<string>(items[0]?.id ?? "");
+
+  useEffect(() => {
+    if (typeof window === "undefined" || items.length === 0) return;
+
+    const sections = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (sections.length === 0) return;
+
+    // Pick the section closest to the top of the viewport that is still
+    // intersecting. The 0.25 threshold avoids flicker when sections are
+    // long enough that two are partially in view.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      {
+        // Trigger when a section's top crosses ~25% of the viewport.
+        rootMargin: "-25% 0px -65% 0px",
+        threshold: 0,
+      },
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, [items]);
+
+  return (
+    <>
+      {/* Mobile: horizontal chip row */}
+      <nav
+        aria-label="Section navigation"
+        className="md:hidden -mx-6 mb-6 overflow-x-auto px-6"
+        data-testid="sticky-toc-mobile"
+      >
+        <ul className="flex gap-2 whitespace-nowrap">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  activeId === item.id
+                    ? "border-primary text-foreground bg-accent"
+                    : "border-foreground/10 text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Desktop: sticky right-column TOC */}
+      <nav
+        aria-label="Section navigation"
+        className="hidden md:block sticky top-24 self-start"
+        data-testid="sticky-toc-desktop"
+      >
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-3">On this page</p>
+        <ul className="space-y-2 border-l border-foreground/10">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={`block border-l-2 pl-3 -ml-px text-sm transition-colors ${
+                  activeId === item.id
+                    ? "border-primary text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check the component**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run build 2>&1 | tail -10
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/database/StickyToc.tsx
+git commit -m "feat(database): add StickyToc with IntersectionObserver scroll-spy"
+```
+
+---
+
+## Task 5: PostgreSQL tab — four pillars + sticky TOC
+
+**Files:**
+- Modify: `frontend/src/components/database/PostgresTab.tsx`
+- Modify: `frontend/e2e/mocked/database-page.spec.ts`
+
+Replace the placeholder `PostgresTab` with the real two-column layout: pillar sections in the main column, `StickyToc` in the right column on desktop.
+
+- [ ] **Step 1: Replace `PostgresTab.tsx`**
+
+```tsx
+import { PillarSection } from "@/components/database/PillarSection";
+import { StickyToc, type StickyTocItem } from "@/components/database/StickyToc";
+
+const tocItems: StickyTocItem[] = [
+  { id: "optimization", label: "Query Optimization" },
+  { id: "schema", label: "Schema Design" },
+  { id: "migrations", label: "Migration Safety" },
+  { id: "reliability", label: "Reliability & Recovery" },
+];
+
+export function PostgresTab() {
+  return (
+    <div data-testid="postgres-tab" className="md:grid md:grid-cols-[1fr_220px] md:gap-10">
+      <div className="space-y-16 min-w-0">
+        <PillarSection
+          id="optimization"
+          title="Query Optimization & Benchmarking"
+          narrative={
+            <>
+              <p>
+                Functional ORM-style code is a starting point, not the finish line.
+                The Go services were re-benchmarked against a real PostgreSQL 16
+                container and rewritten where the data showed it.
+              </p>
+              <p>
+                <code>testcontainers-go</code> made the benchmarks runnable on any
+                Docker-equipped machine; results were captured to{" "}
+                <code>go/benchdata/</code> for interview-ready evidence.
+              </p>
+            </>
+          }
+          bullets={[
+            <>Real-DB benchmarks via <code>testcontainers-go</code> against PostgreSQL 16; results in <code>go/benchdata/baseline-results.txt</code> and <code>optimized-results.txt</code></>,
+            <><strong>Batch INSERT for order items: 3.5× speedup on 20-item orders</strong> (4.5ms → 1.3ms), single round trip instead of N</>,
+            <><code>COUNT(*) OVER()</code> window function replaces COUNT-then-data double query</>,
+            <>CTE-based atomic conflict resolution in cart updates (<code>WITH updated AS (UPDATE … RETURNING) SELECT EXISTS(...)</code>)</>,
+            <>pgx prepared-statement cache enabled (<code>QueryExecModeCacheDescribe</code>)</>,
+            <>Targeted indexes: <code>idx_orders_saga_step</code>, partial <code>idx_products_low_stock WHERE stock &lt; 10</code>, composite <code>idx_cart_items_user_reserved</code></>,
+            <>Typed pgx error checks: <code>errors.Is(err, pgx.ErrNoRows)</code>, <code>errors.As(err, &amp;pgconn.PgError)</code> for code <code>23505</code></>,
+          ]}
+          links={[
+            { label: "Read the ADR", href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/ecommerce/go-database-optimization.md" },
+          ]}
+        />
+
+        <PillarSection
+          id="schema"
+          title="Schema Design — Partitioning & Materialized Views"
+          narrative={
+            <>
+              <p>
+                Reporting workloads on a monotonically growing <code>orders</code>{" "}
+                table forced a schema-design pass. Range partitioning by{" "}
+                <code>created_at</code> prunes scan scope; three materialized views
+                give constant-time reads for dashboard queries; CTE + window
+                functions express the rolling-average business logic without
+                application-side aggregation.
+              </p>
+            </>
+          }
+          bullets={[
+            <>Range partitioning on <code>orders.created_at</code> (monthly), 18 months pre-provisioned with a default catch-all partition</>,
+            <>Background goroutine creates partitions 3 months ahead daily; idempotent <code>CREATE TABLE IF NOT EXISTS</code></>,
+            <>Three materialized views (<code>mv_daily_revenue</code>, <code>mv_product_performance</code>, <code>mv_customer_summary</code>) refreshed <code>CONCURRENTLY</code> on a 15-min cadence</>,
+            <>Unique indexes per MV to support <code>REFRESH CONCURRENTLY</code></>,
+            <>CTE-driven reporting with <code>SUM(...) OVER (ORDER BY day ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)</code> for rolling 7/30-day averages</>,
+            <><code>DENSE_RANK()</code> for tie-aware top-N (turnover, top customers)</>,
+            <>Composite primary key trade-off documented (<code>(id, created_at)</code> removes single-column FK target — referential integrity moves to the saga)</>,
+          ]}
+          links={[
+            { label: "Read the ADR", href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/ecommerce/go-sql-optimization-reporting.md" },
+          ]}
+        />
+
+        <PillarSection
+          id="migrations"
+          title="Migration Safety — migration-lint"
+          narrative={
+            <>
+              <p>
+                <code>golang-migrate</code> catches syntactic errors when the
+                migration runs against Docker; it doesn&apos;t catch operationally
+                unsafe DDL that&apos;s syntactically valid. A custom Go linter
+                (<code>migration-lint</code>) walks each <code>.up.sql</code> AST
+                via <code>libpg_query</code> and flags eight common foot-guns at
+                lint time, before any container starts.
+              </p>
+              <p>
+                Each rule pairs with a recipe in a checked-in safe-migration
+                runbook.
+              </p>
+            </>
+          }
+          bullets={[
+            <>Custom Go CLI built on <code>pganalyze/pg_query_go</code> (CGO wrapper around <code>libpg_query</code>, the upstream PG parser)</>,
+            <>Eight rules: CREATE INDEX without CONCURRENTLY (MIG001), NOT NULL ADD COLUMN with volatile default (MIG002), table-rewrite ALTER COLUMN TYPE (MIG003), CHECK without NOT VALID (MIG004), DROP COLUMN (MIG005), RENAME COLUMN (MIG006), CONCURRENTLY mixed with other DDL (MIG007), LOCK TABLE (MIG008)</>,
+            <>Per-statement opt-out: <code>{`-- migration-lint: ignore=MIGNNN reason="..."`}</code> with mandatory <code>reason=&quot;…&quot;</code></>,
+            <>Wired into <code>make preflight-go-migrations</code> and the CI matrix as a hard prerequisite to the runtime migration pipeline</>,
+            <>Companion 8-recipe runbook</>,
+            <>Worked example: <code>CREATE INDEX CONCURRENTLY</code> in its own migration file (<code>go/product-service/migrations/005_add_product_search_index.up.sql</code>)</>,
+          ]}
+          links={[
+            { label: "Read the ADR", href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/database/migration-lint.md" },
+            { label: "Read the runbook", href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/runbooks/postgres-migrations.md" },
+          ]}
+        />
+
+        <PillarSection
+          id="reliability"
+          title="Reliability & Recovery"
+          narrative={
+            <>
+              <p>
+                Production-grade SQL isn&apos;t only about queries. Postgres needs
+                scheduled backups, monitored health, and a written runbook for
+                the day someone has to restore from one. The portfolio&apos;s
+                Postgres deployment ships with all three.
+              </p>
+            </>
+          }
+          bullets={[
+            <>Automated <code>pg_dump</code> CronJob writing to a persistent volume on the Minikube node; retention policy in the manifest</>,
+            <>Pod Disruption Budget on the StatefulSet (<code>maxUnavailable: 1</code>) so node drains don&apos;t block on a single-replica DB</>,
+            <><code>postgres_exporter</code> sidecar feeding Prometheus; Grafana dashboard surfaces connection counts, replication lag, table sizes, and slow queries</>,
+            <>Alert rules: backup-job failure, replication-lag-too-high, disk-full, long-running-transaction</>,
+            <>Written recovery runbook: step-by-step from <code>pg_dump</code> artifact to a restored database</>,
+          ]}
+          links={[
+            { label: "Read the runbook", href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/runbooks/postgres-recovery.md" },
+          ]}
+        />
+      </div>
+
+      {/* TOC column */}
+      <aside className="hidden md:block">
+        <StickyToc items={tocItems} />
+      </aside>
+
+      {/* Mobile TOC (above content) — rendered inside StickyToc with md:hidden,
+          but it lives at the top of the tab DOM so it appears first on mobile. */}
+      <div className="md:hidden order-first">
+        <StickyToc items={tocItems} />
+      </div>
+    </div>
+  );
+}
+```
+
+> Note on the mobile TOC: the `StickyToc` component renders both the mobile chip row and the desktop sticky list, gating each with `md:hidden` / `hidden md:block`. We render `<StickyToc>` twice in this layout — once inside the desktop `<aside>` (which is `hidden md:block`) and once at the top in a `md:hidden` wrapper for mobile. Each render only displays the variant that matches the current breakpoint, so the user sees one TOC at a time. Keeping both renders in `PostgresTab` (rather than relying on a single `StickyToc` placement) makes the desktop sticky positioning work without grid-row gymnastics.
+
+- [ ] **Step 2: Add e2e assertions for all four pillars and TOC**
+
+Append these tests to `frontend/e2e/mocked/database-page.spec.ts` inside the same `test.describe`:
+
+```ts
+  test("PostgreSQL tab renders all four pillar headings", async ({ page }) => {
+    await page.goto("/database");
+    await expect(page.getByRole("heading", { name: "Query Optimization & Benchmarking", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Schema Design — Partitioning & Materialized Views", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Migration Safety — migration-lint", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Reliability & Recovery", level: 2 })).toBeVisible();
+  });
+
+  test("each pillar has a stable anchor id", async ({ page }) => {
+    await page.goto("/database");
+    for (const id of ["optimization", "schema", "migrations", "reliability"]) {
+      await expect(page.locator(`#${id}`)).toBeVisible();
+    }
+  });
+
+  test("PostgreSQL tab includes recruiter keywords inline", async ({ page }) => {
+    await page.goto("/database");
+    // A few high-signal keywords spread across pillars — each is a recruiter ATS hit.
+    await expect(page.getByText("PostgreSQL 16", { exact: false })).toBeVisible();
+    await expect(page.getByText("Range partitioning", { exact: false })).toBeVisible();
+    await expect(page.getByText("CREATE INDEX CONCURRENTLY", { exact: false }).first()).toBeVisible();
+    await expect(page.getByText("postgres_exporter", { exact: false })).toBeVisible();
+  });
+
+  test("clicking a TOC link scrolls to the corresponding pillar", async ({ page }) => {
+    await page.goto("/database");
+    await page.locator('a[href="#migrations"]').first().click();
+    // After the hash navigation the migrations heading should be in view.
+    await expect(page.getByRole("heading", { name: "Migration Safety — migration-lint", level: 2 })).toBeInViewport();
+  });
+```
+
+- [ ] **Step 3: Run the spec**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run e2e -- database-page.spec.ts
+```
+
+Expected: 11 tests pass.
+
+- [ ] **Step 4: Manually verify the layout in a browser**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run dev
+# Browse: http://localhost:3000/database
+# Verify: page renders, all four pillars visible, sticky TOC tracks the active section as you scroll, mobile chip row appears at narrow viewports.
+```
+
+Stop the dev server (Ctrl-C) before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/database/PostgresTab.tsx frontend/e2e/mocked/database-page.spec.ts
+git commit -m "feat(database): PostgreSQL tab with four pillars and sticky TOC"
+```
+
+---
+
+## Task 6: Homepage card
+
+**Files:**
+- Modify: `frontend/src/app/page.tsx`
+- Modify: `frontend/e2e/mocked/database-page.spec.ts`
+
+The card slots between `/cicd` (around lines 112–131 of `page.tsx`) and `/security` (lines 132+) per the spec.
+
+- [ ] **Step 1: Add the card to `frontend/src/app/page.tsx`**
+
+Insert the new `<Link>` block immediately after the closing `</Link>` of the `/cicd` card and before the `<Link href="/security"…>` block. The exact insertion point in the current file is the line containing `</Link>` immediately followed by `<Link href="/security" className="block">` (around line 131–132).
+
+The card to insert:
+
+```tsx
+          <Link href="/database" className="block">
+            <Card className="hover:ring-foreground/20 transition-all">
+              <CardHeader>
+                <CardTitle>Database Engineering</CardTitle>
+                <CardDescription>
+                  Production PostgreSQL — optimization, partitioning, migration
+                  safety, and reliability
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-sm">
+                  Real benchmarks against PostgreSQL 16, range partitioning with
+                  materialized views, a custom AST-based migration linter, and
+                  an operational track with backups and recovery runbooks.
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+```
+
+- [ ] **Step 2: Add a homepage assertion**
+
+Append to `frontend/e2e/mocked/database-page.spec.ts` (still inside the same `test.describe`):
+
+```ts
+  test("homepage links to /database", async ({ page }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /Database Engineering/ });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/database");
+  });
+```
+
+- [ ] **Step 3: Run the spec**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page/frontend
+npm run e2e -- database-page.spec.ts
+```
+
+Expected: 12 tests pass.
+
+- [ ] **Step 4: Verify the homepage looks right manually**
+
+```bash
+npm run dev
+# http://localhost:3000 — confirm the Database card shows between CI/CD and Security, with hover ring matching the others.
+```
+
+Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/page.tsx frontend/e2e/mocked/database-page.spec.ts
+git commit -m "feat(home): add Database Engineering card linking to /database"
+```
+
+---
+
+## Task 7: Final preflight, push, and PR
+
+**Files:** none (verification + push)
+
+- [ ] **Step 1: Run the frontend preflight gates**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page
+make preflight-frontend
+```
+
+Expected: tsc + eslint + `next build` pass clean.
+
+- [ ] **Step 2: Run the full mocked-e2e suite (catches regressions in other pages)**
+
+```bash
+make preflight-e2e
+```
+
+Expected: every spec passes, including the 12 new `database-page.spec.ts` tests.
+
+> If the e2e run is slow on Mac and you only changed the database page, you can run the new spec in isolation with `cd frontend && npm run e2e -- database-page.spec.ts`. The full sweep is what CI runs, though, so do it before pushing.
+
+- [ ] **Step 3: Confirm the branch state**
+
+```bash
+git -C /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page status
+git -C /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page log --oneline main..HEAD
+```
+
+You should see ~6 commits and a clean working tree.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git -C /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page push -u origin agent/feat-database-page
+```
+
+- [ ] **Step 5: Open the PR to `qa`**
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.claude/worktrees/agent/feat-database-page
+gh pr create --base qa --title "feat: /database portfolio page (PostgreSQL focus, NoSQL/Vector stubs)" --body "$(cat <<'EOF'
+## Summary
+
+- New top-level `/database` page surfaces existing PostgreSQL work under a single recruiter-discoverable URL.
+- Three-tab layout: PostgreSQL (full content), NoSQL (stub → /java), Vector (stub → /ai).
+- PostgreSQL tab is single-scroll across four pillars (Query Optimization, Schema Design, Migration Safety, Reliability & Recovery), each with a narrative paragraph, 4–7 keyword-rich bullets, and links to the matching ADR / runbook.
+- `IntersectionObserver`-driven sticky TOC on the right column (desktop) / chip row (mobile).
+- Homepage gets a new "Database Engineering" card slotted between CI/CD and Security.
+
+## Closes / refs
+
+- Spec: `docs/superpowers/specs/2026-04-27-database-portfolio-page-design.md`
+- Plan: `docs/superpowers/plans/2026-04-27-database-portfolio-page.md`
+- Surfaces work from `docs/adr/ecommerce/go-database-optimization.md`, `docs/adr/ecommerce/go-sql-optimization-reporting.md`, `docs/adr/database/migration-lint.md`, and `docs/runbooks/postgres-recovery.md`.
+
+## Test plan
+
+- [x] Local: `npm run e2e -- database-page.spec.ts` — 12 tests pass
+- [x] Local: `make preflight-frontend` — tsc + eslint + next build clean
+- [x] Local: `make preflight-e2e` — full mocked suite passes
+- [x] Manual: page renders correctly at `localhost:3000/database`, sticky TOC tracks active pillar on scroll, mobile chip TOC appears below the bio at narrow viewports
+- [ ] CI: Frontend Checks job passes
+- [ ] CI: e2e job passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Notify Kyle and stop**
+
+Per `CLAUDE.md` feature-branch flow: do NOT watch CI. Kyle will check results.
+
+---
+
+## Self-review checklist (executed by the plan author)
+
+**Spec coverage map:**
+- ✅ Top-level `/database` page → Task 1
+- ✅ Three tabs (PostgreSQL / NoSQL / Vector) with shared tab pattern → Task 1
+- ✅ Tab state local to page (no URL routing) → Task 1
+- ✅ NoSQL stub → /java + Vector stub → /ai → Task 2
+- ✅ `PillarSection` reusable component → Task 3
+- ✅ `StickyToc` with IntersectionObserver, desktop + mobile variants → Task 4
+- ✅ Four pillars (Optimization, Schema, Migrations, Reliability) with narratives + bullets + ADR links → Task 5
+- ✅ Two-column layout w/ sticky TOC (desktop) + chip row (mobile) → Task 5
+- ✅ Homepage card between /cicd and /security → Task 6
+- ✅ Playwright e2e covering page load, tab switching, stub links, pillar headings, recruiter keywords, TOC scroll behavior, homepage card → Tasks 1, 2, 5, 6
+- ✅ Out-of-scope (NoSQL/Vector full content, URL-synced tab state, charts, sandbox) → not implemented, matches spec
+
+**Placeholder scan:** none. Each step has the actual code or command. Tasks that say "verify in browser" describe specifically what to check.
+
+**Type / name consistency check:**
+- `DatabaseTab` union and `databaseTabs` array defined in Task 1 (`tabs.ts`), imported unchanged by `page.tsx`.
+- `PillarSection` props (`PillarSectionProps`, `PillarLink`) defined in Task 3, used unchanged in Task 5.
+- `StickyToc` props (`StickyTocProps`, `StickyTocItem`) defined in Task 4, used unchanged in Task 5.
+- `data-testid="postgres-tab" | "nosql-tab" | "vector-tab"` placeholder names from Task 1 carry through to the real components in Tasks 2 and 5 — Playwright assertions remain valid.
+- Pillar anchor ids (`optimization`, `schema`, `migrations`, `reliability`) declared in Task 5 (`tocItems` and each `PillarSection.id`) and referenced in the e2e tests by exact match.

--- a/docs/superpowers/specs/2026-04-27-backup-verification-design.md
+++ b/docs/superpowers/specs/2026-04-27-backup-verification-design.md
@@ -1,0 +1,316 @@
+# Design: Automated Backup Verification
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Roadmap position:** Item 4 of 10 in the `db-roadmap` GitHub label
+- **GitHub issue:** [#158 — Automated backup verification](https://github.com/kabradshaw1/portfolio/issues/158)
+- **Builds on:**
+  - `docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md` (the `pg_dump` CronJob this verifies)
+  - `docs/superpowers/specs/2026-04-27-pitr-design.md` (the WAL archive + base backups verified in Phase 2)
+  - `docs/runbooks/postgres-recovery.md` (the recovery scenarios this proves are working)
+
+## Context
+
+The shared PostgreSQL instance has two backup mechanisms once the prior roadmap items land: (1) daily `pg_dump` files and (2) weekly `pg_basebackup` + continuous WAL archive. **Neither is verified.** A backup file that exists on disk says nothing about whether it can be restored — backups silently corrupt, scripts silently break, disk failures masquerade as healthy writes.
+
+The most common cause of catastrophic data loss in production systems is not "we had no backups" but "we had backups that didn't restore." A senior engineer is expected to treat untested backups as no backups, and to wire continuous verification into the same observability stack as the rest of the system.
+
+This spec ships an automated weekly verification CronJob that actually restores each backup type, runs smoke checks, and emits Prometheus metrics that drive a "we know our backups work" alert. The work is split into two phases — Phase 1 (`pg_dump` verification) ships first; Phase 2 (PITR verification) ships once roadmap item #157 has merged.
+
+## Goals
+
+- Restore every weekly `pg_dump` file to a fresh, isolated Postgres and run smoke checks against it.
+- Restore the latest `pg_basebackup` + replay WAL to a randomly chosen point-in-time, and verify the resulting state matches an expected sentinel (Phase 2).
+- Emit per-database Prometheus metrics so dashboards and alerts can see *which* DB's verification is failing or stale.
+- Alert on stale verification (no success in > 8 days) and on outright verification failure.
+- Run the verification in complete isolation from prod traffic — restoration happens in an ephemeral Postgres process inside the verify pod.
+
+## Non-goals
+
+- Cross-region or cross-cluster verification.
+- Schema-evolution-aware verification (e.g., diffing migration history) — that's a separate concern.
+- Verification of `pg_dump` files older than the latest (the most recent file is the only one that matters operationally).
+- Java-managed schemas — Spring/JPA owns those at startup; nothing to verify against a backup.
+
+## Architecture
+
+```
+monitoring namespace
+└── Pushgateway (NEW)              prom/pushgateway:v1.9.0
+    ├── Deployment, single replica
+    ├── PVC for /metrics persistence
+    └── Service exposed on :9091
+                ▲
+                │ scraped by Prometheus via existing kubernetes-services job
+                │
+java-tasks namespace
+└── postgres-backup-verify (NEW CronJob, Mondays 04:00 UTC)
+    └── single Job → single pod → single container running:
+        Volumes:
+          • emptyDir   at /var/lib/postgresql/data    (ephemeral postgres data dir)
+          • PV (RO)    at /backups/postgres           (existing pg_dump output)
+          • PV (RO)    at /backups/wal-archive        (Phase 2 only — from #157)
+          • PV (RO)    at /backups/basebackup        (Phase 2 only — from #157)
+          • ConfigMap  at /usr/local/bin             (the verification scripts)
+
+        Container = postgres:17-alpine + curl + python3
+          1. initdb -D /var/lib/postgresql/data
+          2. start postgres locally on socket only (no TCP)
+          3. Phase 1: for each *.dump file → createdb _verify → pg_restore →
+             run smoke checks → drop → push metric to pushgateway
+          4. Phase 2: for the latest base backup → restore tarball → set
+             recovery_target_time to a random recent timestamp →
+             promote → query a sentinel row → tear down → push metric
+          5. exit 0 if all DBs verified, exit 1 otherwise
+
+Grafana
+├── extends existing PostgreSQL dashboard (3 new panels)
+└── extends PostgreSQL alert group (2 new rules)
+```
+
+The verification pod is fully self-contained: it spawns its own Postgres, restores into emptyDir storage, and tears down at exit. The only outbound traffic is metric pushes to Pushgateway. Prod Postgres is never touched.
+
+## Pushgateway
+
+Pushgateway is the Prometheus team's blessed solution for batch/cron jobs that don't run long enough to be scraped directly. We add one Pushgateway deployment to the `monitoring` namespace.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pushgateway
+  namespace: monitoring
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: pushgateway
+          image: prom/pushgateway:v1.9.0
+          args:
+            - --persistence.file=/data/metrics
+            - --persistence.interval=5m
+          ports:
+            - containerPort: 9091
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pushgateway-data
+```
+
+`--persistence.file` ensures metrics survive a Pushgateway pod restart — without it, a Pushgateway crash would wipe verification state and falsely fire the staleness alert.
+
+A `Service` of type ClusterIP exposes the gateway. Prometheus already scrapes services with the appropriate annotations via the existing `kubernetes-services` scrape config — adding `prometheus.io/scrape: "true"` and `prometheus.io/port: "9091"` to the Service is enough.
+
+A 1Gi PVC for persistence is plenty (Pushgateway holds metric snapshots in a single file, ~hundreds of bytes per metric).
+
+## The verification script
+
+Mounted from a new ConfigMap `postgres-verify-scripts` into `/usr/local/bin/` in the verify pod. The Phase 1 script:
+
+```bash
+#!/bin/sh
+# pg-verify-backups.sh
+# Restore each pg_dump file to an ephemeral local Postgres, smoke-check, push metrics.
+set -eu
+
+DBS="authdb productdb orderdb cartdb paymentdb ecommercedb"
+PUSHGATEWAY="${PUSHGATEWAY_URL:-http://pushgateway.monitoring.svc.cluster.local:9091}"
+DUMPS_DIR="/backups/postgres"
+DATA_DIR="/var/lib/postgresql/data"
+SOCKET_DIR="/tmp/pg-verify"
+
+mkdir -p "$SOCKET_DIR"
+chmod 700 "$SOCKET_DIR"
+
+# 1) initdb if empty
+if [ ! -f "$DATA_DIR/PG_VERSION" ]; then
+  initdb -D "$DATA_DIR" -U verify --auth=trust --no-locale --encoding=UTF8
+fi
+
+# 2) start postgres on Unix socket only — no TCP exposure
+pg_ctl -D "$DATA_DIR" -l /tmp/pg-verify.log -o "-k $SOCKET_DIR -h ''" -w start
+
+trap 'pg_ctl -D "$DATA_DIR" -m fast stop || true' EXIT
+
+OVERALL_OK=true
+
+for DB in $DBS; do
+  echo "Verifying $DB..."
+  DUMP=$(ls -t "$DUMPS_DIR/$DB"-*.dump 2>/dev/null | head -1 || true)
+  if [ -z "$DUMP" ]; then
+    echo "  FAIL: no dump file found for $DB"
+    push_failure "$DB" "no_dump_file"
+    OVERALL_OK=false
+    continue
+  fi
+
+  TARGET="${DB}_verify"
+  psql -h "$SOCKET_DIR" -U verify -d postgres -c "DROP DATABASE IF EXISTS $TARGET;" >/dev/null
+  psql -h "$SOCKET_DIR" -U verify -d postgres -c "CREATE DATABASE $TARGET;" >/dev/null
+
+  if ! pg_restore -h "$SOCKET_DIR" -U verify -d "$TARGET" --no-owner --no-acl "$DUMP"; then
+    echo "  FAIL: pg_restore exited non-zero"
+    push_failure "$DB" "pg_restore_failed"
+    OVERALL_OK=false
+    psql -h "$SOCKET_DIR" -U verify -d postgres -c "DROP DATABASE $TARGET;" >/dev/null
+    continue
+  fi
+
+  # Smoke check: at least one table has rows
+  ROWS=$(psql -h "$SOCKET_DIR" -U verify -d "$TARGET" -t -A -c "
+    SELECT COALESCE(SUM(reltuples)::bigint, 0)
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'r' AND n.nspname = 'public';
+  ")
+
+  if [ "${ROWS:-0}" -lt 1 ]; then
+    echo "  FAIL: restored DB has zero rows in public schema"
+    push_failure "$DB" "empty_after_restore"
+    OVERALL_OK=false
+  else
+    echo "  OK: $ROWS rows restored"
+    push_success "$DB" "$ROWS" "$DUMP"
+  fi
+
+  psql -h "$SOCKET_DIR" -U verify -d postgres -c "DROP DATABASE $TARGET;" >/dev/null
+done
+
+# Final overall status
+if [ "$OVERALL_OK" = "true" ]; then
+  push_overall_success
+  exit 0
+else
+  push_overall_failure
+  exit 1
+fi
+```
+
+The `push_success` / `push_failure` helper functions emit metrics:
+
+```bash
+push_success() {
+  local db="$1" rows="$2" dump="$3"
+  local dump_age_sec
+  dump_age_sec=$(( $(date +%s) - $(stat -c %Y "$dump") ))
+  cat <<EOF | curl -fsS --data-binary @- "$PUSHGATEWAY/metrics/job/postgres_backup_verify/instance/$db"
+# TYPE backup_verification_last_success_timestamp gauge
+backup_verification_last_success_timestamp $(date +%s)
+# TYPE backup_verification_restored_rows gauge
+backup_verification_restored_rows $rows
+# TYPE backup_verification_dump_age_seconds gauge
+backup_verification_dump_age_seconds $dump_age_sec
+EOF
+}
+
+push_failure() {
+  local db="$1" reason="$2"
+  cat <<EOF | curl -fsS --data-binary @- "$PUSHGATEWAY/metrics/job/postgres_backup_verify/instance/$db"
+# TYPE backup_verification_last_failure_timestamp gauge
+backup_verification_last_failure_timestamp $(date +%s)
+# TYPE backup_verification_last_failure_reason gauge
+backup_verification_last_failure_reason{reason="$reason"} 1
+EOF
+}
+```
+
+The `instance` label per DB is essential — it's how the alert can say *which* DB failed.
+
+## Phase 2: PITR verification
+
+Once roadmap item #157 (WAL archiving + PITR) lands, a second script `pg-verify-pitr.sh` runs alongside Phase 1 in the same Job. It restores the latest base backup, configures `recovery_target_time` to a random timestamp within the last 6 days (after the second-newest base backup, before now), promotes, and verifies a sentinel row's expected value at that target.
+
+The sentinel: an inserted row with `app_state='verified-2026-04-27T03:00:00Z'` written by the seed and updated by a separate weekly CronJob. The verifier knows what value to expect at any given timestamp and asserts it.
+
+Phase 2 is in the same spec but is conditionally implemented — the plan flags steps as "Phase 2 only; implement after #157 has merged."
+
+## Resource considerations
+
+The verify pod restores all six prod DBs sequentially. At current data sizes (~few hundred MB total dumps), the pod completes in 2–5 minutes. The schedule (Monday 04:00 UTC) deliberately follows the daily `pg_dump` (02:00) and weekly `pg_basebackup` (Sunday 03:00 UTC) so the latest backups exist when verification runs.
+
+CPU/memory: the pod gets `requests: { cpu: "200m", memory: "512Mi" }`, `limits: { cpu: "1", memory: "2Gi" }`. The transient memory spike during `pg_restore` is the limiting factor.
+
+Disk: emptyDir for the data dir is sized via the pod's ephemeral storage limit (`requests.ephemeral-storage: "5Gi"`). For datasets > 5 Gi this would need to switch to a dedicated PVC.
+
+## Observability
+
+### Metrics emitted (per DB, via Pushgateway)
+
+- `backup_verification_last_success_timestamp{instance="<db>"}` — gauge, Unix epoch seconds
+- `backup_verification_last_failure_timestamp{instance="<db>"}` — gauge, Unix epoch seconds
+- `backup_verification_last_failure_reason{instance="<db>",reason="<reason>"}` — gauge value 1 (set on each failure)
+- `backup_verification_restored_rows{instance="<db>"}` — gauge, last successful row count
+- `backup_verification_dump_age_seconds{instance="<db>"}` — gauge, age of the verified dump file
+
+### Dashboard panels
+
+Append three panels to the existing PostgreSQL health dashboard:
+
+| Panel | Type | Source | Purpose |
+|---|---|---|---|
+| Time since last verification (per DB) | Stat (multi-value) | Prometheus | Should be < 8 days for every DB |
+| Verification failures (last 30d) | Time series | Prometheus | Spike = trend toward backup unreliability |
+| Restored row counts | Bar gauge | Prometheus | Sudden drop = `pg_dump` truncation |
+
+### Alerts (appended to the `PostgreSQL` group, all `noDataState: OK`)
+
+| Alert | Threshold | Why |
+|---|---|---|
+| `PgBackupVerificationFailed` | `backup_verification_last_failure_timestamp > backup_verification_last_success_timestamp` for 5m, per `instance` | A failure newer than the latest success means the most recent verification is bad |
+| `PgBackupVerificationStale` | `time() - backup_verification_last_success_timestamp > 691200` (8 days), per `instance` | Verification hasn't succeeded in over a week — pipeline is silently broken |
+
+Per-instance labels make the alert message say `paymentdb is unverified` rather than `something is unverified`.
+
+## Testing
+
+**Integration test** at `go/pkg/db/backup_verification_integration_test.go` (testcontainers, build-tagged):
+
+1. Spin up a Postgres container, seed a small schema with N rows.
+2. Run `pg_dump --format=custom` on it, drop the source DB.
+3. Spin up a SECOND Postgres container, run the verification script (mounted from the project) against the dump file.
+4. Assert the script exits 0, that the temp `_verify` DB is gone afterward, and that a `curl`-mockable Pushgateway endpoint received the success metric with the right row count.
+
+The Pushgateway interaction can be verified by pointing `PUSHGATEWAY_URL` at a tiny Go test server that records the body, rather than a real Pushgateway. Faster and deterministic.
+
+**Failure-mode test:** corrupt the dump file by truncating, re-run the script, assert it exits 1 and pushes a failure metric.
+
+## Rollout
+
+1. Land Pushgateway (Deployment + PVC + Service + scrape annotations).
+2. Land the verification script ConfigMap.
+3. Land the CronJob (Phase 1 only).
+4. Manually trigger one run (`kubectl create job --from=cronjob/...`) and verify the Pushgateway shows metrics.
+5. Land dashboard panels.
+6. Land alerts.
+7. After #157 has merged: land Phase 2 (PITR verification) as a follow-up PR using the same CronJob.
+
+## ADR
+
+Companion ADR at `docs/adr/database/backup-verification.md` covering:
+
+- Why Pushgateway over kube-state-metrics-only (kube-state-metrics gives "did the cron run" but no per-DB granularity)
+- Why ephemeral-Postgres-in-a-pod over restoring into the prod Postgres (isolation; never touches prod connections)
+- Why the smoke check is "rows > 0 in public schema" rather than per-table assertions (resilient to schema evolution)
+- Why Pushgateway persistence is mandatory (a Pushgateway pod restart without persistence would falsely fire `PgBackupVerificationStale`)
+- The Phase 2 sentinel-row design and its assumption that we have a known-state row to verify against
+
+## Consequences
+
+**Positive:**
+- Backups go from "we have files" to "we know they restore." Most production teams never close this gap.
+- Per-DB metrics turn a backup failure into actionable signal — the alert says exactly which DB to investigate.
+- Verification runs in complete isolation from prod, so a slow or failing verification never degrades user-facing latency.
+
+**Trade-offs:**
+- Pushgateway is now a piece of stateful monitoring infrastructure. If it goes down without persistence, every verification metric falsely appears stale. The PVC mitigates this; the alert on Pushgateway pod up/down covers the rest.
+- Verification CPU/memory burns on the Minikube node weekly. Acceptable at current scale; would be moved to a dedicated node pool at scale.
+- The smoke check is shallow ("rows > 0") — a `pg_restore` that quietly drops half the rows would still pass. Strengthening this is Phase 2/3 work (sentinel rows, schema diff).
+
+**Phase 2 / 3:**
+- PITR-restore verification (Phase 2 of this spec, after #157 merges)
+- Schema diff between prod and verified DB (would need a snapshot of expected schema)
+- Cross-region or off-host backup verification once the no-paid-services constraint relaxes

--- a/docs/superpowers/specs/2026-04-27-database-portfolio-page-design.md
+++ b/docs/superpowers/specs/2026-04-27-database-portfolio-page-design.md
@@ -1,0 +1,302 @@
+# Design: `/database` Portfolio Page
+
+- **Date:** 2026-04-27
+- **Status:** Approved — pending implementation
+- **Roadmap position:** Portfolio surface area for the database/SQL track of `db-roadmap`. Not itself a `db-roadmap` item — it's the recruiter-facing index for them.
+- **Builds on:**
+  - `docs/adr/ecommerce/go-database-optimization.md`
+  - `docs/adr/ecommerce/go-sql-optimization-reporting.md`
+  - `docs/adr/database/migration-lint.md`
+  - `docs/superpowers/specs/2026-04-23-postgres-data-integrity-design.md`
+
+## Context
+
+The portfolio has accumulated four substantial pieces of production-grade
+PostgreSQL work — query optimization with real benchmarks, range partitioning
+with materialized views, a custom safe-migration linter, and a backup +
+recovery operational track. None of it is currently surfaced anywhere a
+recruiter would find it without clicking deep into `/go` and reading ADRs.
+
+Most of the roles Kyle is applying to list "PostgreSQL" or "SQL" as a primary
+requirement. ATS systems and recruiter scans key on those terms. The current
+homepage cards (`/go`, `/aws`, `/java`, `/ai`, plus `/observability`,
+`/security`, `/cicd`) demonstrate that cross-cutting specialty pages already
+have an established home in the IA — `/observability` and `/security` aren't
+languages, they're capabilities. Database engineering belongs in that family.
+
+The portfolio also already touches MongoDB (Java task-management activity feed
+and read models) and Qdrant (Document Q&A and Debug Assistant). Those are
+worth surfacing in the same place over time, but they aren't the current
+priority — the page should reserve space for them without delaying the
+PostgreSQL story.
+
+## Goals
+
+- Make the existing PostgreSQL work discoverable from the homepage in one
+  click.
+- Surface specific recruiter keywords (PostgreSQL, partitioning, materialized
+  views, CONCURRENTLY, NOT VALID, libpg_query, pg_dump, postgres_exporter)
+  inline in the page text, not buried in linked PDFs.
+- Provide a "scan then dig" reading experience: a recruiter scrolling sees the
+  breadth in 30 seconds; an interested hiring manager has links into every
+  ADR for the depth.
+- Reserve IA for NoSQL (MongoDB) and Vector (Qdrant) so adding them later is
+  additive, not restructuring.
+
+## Non-goals
+
+- Filling in the NoSQL and Vector tabs with full content — they ship as
+  stubs that point at `/java` and `/ai` respectively.
+- Live query playgrounds, embedded `psql` shells, or interactive benchmark
+  charts. Static numbers and a code snippet or two are sufficient.
+- Reorganizing the existing `/go` tabs to remove database content from
+  there. Both pages can reference the same work; the `/database` page is
+  the indexed entry point, the `/go` content remains as service-level
+  context.
+
+## Architecture & IA placement
+
+New top-level page at `frontend/src/app/database/page.tsx`. Surfaced as the
+seventh card on the homepage (`frontend/src/app/page.tsx`), placed after `/cicd`
+and before `/security` (so the order reads: portfolio → infra → quality
+specialties).
+
+**Homepage card:**
+
+- Title: "Database Engineering"
+- Description: "Production PostgreSQL — optimization, partitioning,
+  migration safety, and reliability"
+- Body (one sentence): "Real benchmarks against PostgreSQL 16, range
+  partitioning with materialized views, a custom AST-based migration
+  linter, and an operational track with backups and recovery runbooks."
+
+The card matches the existing `<Card>` / `<CardHeader>` / `<CardContent>`
+pattern used for every other portfolio entry, no new components.
+
+## Page structure
+
+Three-tab layout using the same `border-b` tab pattern `/go` already uses.
+Tab state managed locally in the page (mirrors `/go` page.tsx).
+
+| Tab | Slug | Content |
+|---|---|---|
+| **PostgreSQL** | default | Full content — four pillars, single-scroll, sticky TOC |
+| **NoSQL** | `?tab=nosql` | Stub: short blurb + link to `/java` |
+| **Vector** | `?tab=vector` | Stub: short blurb + link to `/ai` |
+
+Tabs are visual only — no URL routing required for the MVP (matches `/go`'s
+pattern). If we want shareable deep-links later, add `?tab=` query-param
+sync, but that's not in scope here.
+
+### NoSQL stub copy
+
+> "MongoDB powers the activity feed and analytics aggregations in the Java
+> task-management portfolio. A dedicated NoSQL section is on the way — for
+> now, the working code lives in `/java`."
+
+With a button-style link: "View MongoDB usage in /java →".
+
+### Vector stub copy
+
+> "Qdrant backs the RAG pipeline behind the Document Q&A assistant and the
+> code-aware Debug Assistant. A dedicated vector-database section is on the
+> way — for now, the working code lives in `/ai`."
+
+With a button-style link: "View vector DB usage in /ai →".
+
+## PostgreSQL tab — single scroll, sticky TOC, four pillars
+
+The tab body has a two-column layout on desktop (≥ md): the four pillar
+sections take the main column, the sticky TOC takes a narrow right column
+that stays in view as the user scrolls, with the active section highlighted
+via `IntersectionObserver`. On mobile (< md), the TOC collapses to a
+horizontal scrollable chip row pinned below the bio paragraph.
+
+Each pillar follows the same shape (one reusable component, see Components
+below):
+
+1. **Section header** — pillar name as `<h2>` with `id` matching the TOC
+   anchor.
+2. **Narrative paragraph** — 2–4 sentences setting up the why and the
+   high-level approach.
+3. **Bullet list** — 4–6 concrete bullets with specific techniques,
+   measured results, and recruiter keywords. Bullets are factual claims
+   matched to the linked ADRs.
+4. **ADR / runbook link row** — one or two "Read the ADR →" / "Read the
+   runbook →" links rendered as a muted button row.
+
+The four pillars in narrative order:
+
+### 1. Query Optimization & Benchmarking
+
+**Anchor:** `#optimization`
+
+**Narrative:** Functional ORM-style code is a starting point, not the
+finish line. The Go services were re-benchmarked against a real PostgreSQL
+16 container and rewritten where the data showed it. testcontainers-go made
+the benchmarks runnable on any Docker-equipped machine; results were
+captured to `go/benchdata/` for interview-ready evidence.
+
+**Bullets:**
+
+- Real-DB benchmarks via `testcontainers-go` against PostgreSQL 16; results
+  in `go/benchdata/baseline-results.txt` and `optimized-results.txt`
+- Batch INSERT for order items: **3.5× speedup on 20-item orders**
+  (4.5ms → 1.3ms), single round trip instead of N
+- `COUNT(*) OVER()` window function replaces COUNT-then-data double query
+- CTE-based atomic conflict resolution in cart updates
+  (`WITH updated AS (UPDATE ... RETURNING) SELECT EXISTS(...)`)
+- pgx prepared-statement cache enabled (`QueryExecModeCacheDescribe`)
+- Targeted indexes: `idx_orders_saga_step`, partial
+  `idx_products_low_stock WHERE stock < 10`, composite
+  `idx_cart_items_user_reserved`
+- Typed pgx error checks: `errors.Is(err, pgx.ErrNoRows)`,
+  `errors.As(err, &pgconn.PgError)` for code `23505`
+
+**Links:** Read the ADR → `docs/adr/ecommerce/go-database-optimization.md`
+
+### 2. Schema Design — Partitioning & Materialized Views
+
+**Anchor:** `#schema`
+
+**Narrative:** Reporting workloads on a monotonically growing `orders`
+table forced a schema-design pass. Range partitioning by `created_at`
+prunes scan scope; three materialized views give constant-time reads for
+the dashboard queries; CTE + window functions express the rolling-average
+business logic without application-side aggregation.
+
+**Bullets:**
+
+- Range partitioning on `orders.created_at` (monthly), with 18 months
+  pre-provisioned and a default catch-all partition
+- Background goroutine creates partitions 3 months ahead daily; idempotent
+  `CREATE TABLE IF NOT EXISTS`
+- Three materialized views (`mv_daily_revenue`, `mv_product_performance`,
+  `mv_customer_summary`) refreshed `CONCURRENTLY` on a 15-min cadence
+- Unique indexes per MV to support `REFRESH CONCURRENTLY`
+- CTE-driven reporting queries with `SUM(...) OVER (ORDER BY day ROWS
+  BETWEEN 6 PRECEDING AND CURRENT ROW)` for rolling 7/30-day averages
+- `DENSE_RANK()` for tie-aware top-N (turnover, top customers)
+- Composite primary key trade-off documented (`(id, created_at)` removes
+  FK target on `id` alone — referential integrity moves to the saga)
+
+**Links:** Read the ADR → `docs/adr/ecommerce/go-sql-optimization-reporting.md`
+
+### 3. Migration Safety — `migration-lint`
+
+**Anchor:** `#migrations`
+
+**Narrative:** `golang-migrate` catches syntactic errors when the migration
+runs against Docker; it doesn't catch operationally unsafe DDL that's
+syntactically valid. A custom Go linter (`migration-lint`) walks each
+`.up.sql` AST via `libpg_query` and flags eight common foot-guns at lint
+time, before any container starts. Each rule pairs with a recipe in a
+checked-in safe-migration runbook.
+
+**Bullets:**
+
+- Custom Go CLI built on `pganalyze/pg_query_go` (CGO wrapper around
+  `libpg_query`, the upstream PG parser)
+- Eight rules: CREATE INDEX without CONCURRENTLY (MIG001), NOT NULL ADD
+  COLUMN with volatile default (MIG002), table-rewrite ALTER COLUMN TYPE
+  (MIG003), CHECK without NOT VALID (MIG004), DROP COLUMN (MIG005),
+  RENAME COLUMN (MIG006), CONCURRENTLY mixed with other DDL (MIG007),
+  LOCK TABLE (MIG008)
+- Per-statement opt-out: `-- migration-lint: ignore=MIGNNN reason="..."`
+  with mandatory `reason="..."`
+- Wired into `make preflight-go-migrations` and the CI matrix as a hard
+  prerequisite to the runtime migration pipeline
+- Companion 8-recipe runbook: `docs/runbooks/postgres-migrations.md`
+- Worked example: `CREATE INDEX CONCURRENTLY` in its own migration file
+  (`go/product-service/migrations/005_add_product_search_index.up.sql`)
+
+**Links:** Read the ADR → `docs/adr/database/migration-lint.md` · Read the
+runbook → `docs/runbooks/postgres-migrations.md`
+
+### 4. Reliability & Recovery
+
+**Anchor:** `#reliability`
+
+**Narrative:** Production-grade SQL isn't only about queries. Postgres
+needs scheduled backups, monitored health, and a written runbook for the
+day someone has to restore from one. The portfolio's Postgres deployment
+ships with all three.
+
+**Bullets:**
+
+- Automated `pg_dump` CronJob writing to a persistent volume on the
+  Minikube node; retention policy in the manifest
+- Pod Disruption Budget on the StatefulSet (`maxUnavailable: 1`) so node
+  drains don't block on a single-replica DB
+- `postgres_exporter` sidecar feeding Prometheus; Grafana dashboard
+  surfaces connection counts, replication lag, table sizes, and slow
+  queries
+- Alert rules: backup-job failure, replication-lag-too-high, disk-full,
+  long-running-transaction
+- Written recovery runbook: `docs/runbooks/postgres-recovery.md` (step by
+  step from `pg_dump` artifact to a hot standby)
+
+**Links:** Read the runbook → `docs/runbooks/postgres-recovery.md` · Read
+the spec → `docs/superpowers/specs/2026-04-23-postgres-data-integrity-design.md`
+
+## Components
+
+```
+frontend/src/app/database/
+├── page.tsx                            # Three-tab page, mirrors /go pattern
+└── error.tsx                           # Standard error boundary
+
+frontend/src/components/database/
+├── PostgresTab.tsx                     # Two-column layout: pillars + sticky TOC
+├── NoSqlTab.tsx                        # Stub component
+├── VectorTab.tsx                       # Stub component
+├── PillarSection.tsx                   # Reusable: header + narrative + bullets + links
+├── StickyToc.tsx                       # IntersectionObserver-based active highlight
+└── tabs.ts                             # `Tab` union, tab labels (matches /go style)
+```
+
+`PillarSection` props (informal):
+
+- `id: string` — anchor id
+- `title: string`
+- `narrative: ReactNode` — paragraph(s)
+- `bullets: ReactNode[]`
+- `links: { label: string; href: string }[]`
+
+The sticky TOC takes a list of `{ id, label }` and tracks active section via
+`IntersectionObserver` on the section headings. The "active" item gets a
+left border accent matching the existing tab pattern.
+
+## Homepage card
+
+Edit `frontend/src/app/page.tsx`, add a new `<Link href="/database">` block
+matching the existing card structure. Place it between the `/cicd` and
+`/security` cards.
+
+## Testing
+
+- **Playwright smoke** at `frontend/e2e/database.spec.ts`:
+  - Loads `/database`, asserts `<h1>` contains "Database Engineering"
+  - Asserts all three tab labels render (PostgreSQL, NoSQL, Vector)
+  - Clicks the NoSQL tab, asserts the stub copy and the "View MongoDB
+    usage in /java" link render
+  - Clicks the Vector tab, asserts the stub copy renders
+  - Switches back to PostgreSQL, clicks each TOC anchor, asserts the
+    corresponding `<h2>` is in the visible viewport
+- **Type/lint sweep** — `npm run typecheck` and `npm run lint` (already
+  in `make preflight-frontend`)
+- **Visual** — manual: load locally, scroll the PostgreSQL tab, verify
+  the sticky TOC highlights the right pillar at each scroll position
+
+## Out of scope (Phase 2)
+
+- Filling NoSQL and Vector tabs with content
+- URL-synced tab state (`?tab=nosql`)
+- Animated benchmark charts or live `pg_stat_statements` snapshots
+- A "Try the linter" embedded sandbox
+
+## Open questions
+
+- None blocking. Rendering polish (exact spacing of the sticky TOC,
+  whether bullet keywords get a subtle highlight color) is best handled
+  during implementation against the live page.

--- a/docs/superpowers/specs/2026-04-27-pgbouncer-design.md
+++ b/docs/superpowers/specs/2026-04-27-pgbouncer-design.md
@@ -1,0 +1,265 @@
+# Design: PgBouncer Connection Pooling Layer
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Roadmap position:** Item 6 of 10 in the `db-roadmap` GitHub label
+- **GitHub issue:** [#160 — PgBouncer connection pooling layer](https://github.com/kabradshaw1/portfolio/issues/160)
+- **Builds on:**
+  - `go/CLAUDE.md` — existing `pgxpool` tuning per service
+  - `docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md` — Phase 2 todo
+
+## Context
+
+Every Go service today connects directly to the shared Postgres instance with its own `pgxpool`. That works at portfolio scale, but it's wrong for any system that grows. Postgres is *bad at idle connections* — each backend connection allocates significant memory (~10 MB), eats a backend slot, and competes for `max_connections` (default 100). Multiplying out:
+
+- 5 Go services × 1 replica each × `pgxpool.MaxConns = 25` (typical default) = 125 potential connections
+- Plus Java services, plus migration jobs, plus ad-hoc psql sessions
+- Plus QA copies of every service
+
+Even at one-replica-per-service, this saturates `max_connections` quickly. Bumping `max_connections` is the wrong fix — Postgres performance degrades because each backend has overhead. The right fix is a **connection pooler** between the apps and Postgres: PgBouncer in transaction-pooling mode lets apps keep many cheap client-side connections while PgBouncer holds a small, stable server-side pool to Postgres.
+
+This is table stakes at any company with more than one service. "Why do you need a connection pooler in front of Postgres?" is asked in nearly every backend interview that touches scale.
+
+## Goals
+
+- Drop a single PgBouncer between every app's `DATABASE_URL` and the Postgres pod.
+- Keep Postgres `max_connections` low (default 100) by aggressively fanning in via transaction-mode pooling.
+- Preserve `pgx` prepared-statement caching (`QueryExecModeCacheDescribe` is set on every Go service).
+- Observe pool wait times and saturation as first-class signals.
+- Don't introduce new auth secrets — reuse existing Postgres credentials via `auth_query`.
+
+## Non-goals
+
+- PgBouncer HA via multiple replicas. A single replica is sufficient at portfolio scale; HA is straightforward (`replicas: 2`, ClusterIP Service in front) and noted in trade-offs.
+- pgcat / Supavisor / Odyssey alternatives — PgBouncer is the established standard.
+- Routing reads to a separate replica (separate roadmap item #161; this spec leaves a hook for it).
+- Eliminating per-service `pgxpool.MaxConns`. The local pool is still useful for connection warmth and per-process behavior — it just gets *smaller*.
+
+## Architecture
+
+```
+java-tasks namespace
+├── postgres (existing)
+│   └── port 5432, accepts connections from PgBouncer's server pool
+│
+├── pgbouncer (NEW)
+│   ├── Deployment, single replica
+│   ├── Image: edoburu/pgbouncer:1.23.1 (or community)
+│   ├── pgbouncer.ini       per-DB pool, transaction mode, prepared statements
+│   ├── userlist.txt        empty (auth_query handles it)
+│   ├── ConfigMap-mounted; secret password injected via env
+│   └── Service: pgbouncer.java-tasks.svc.cluster.local:6432
+│
+└── pgbouncer-exporter (NEW)
+    ├── sidecar in pgbouncer pod (or separate Deployment)
+    ├── Image: prometheuscommunity/pgbouncer-exporter:v0.10.2
+    └── Scraped at :9127 by Prometheus
+
+Go services
+└── DATABASE_URL changes:
+       was:  postgres://user@postgres.java-tasks.svc.cluster.local:5432/<db>
+       now:  postgres://user@pgbouncer.java-tasks.svc.cluster.local:6432/<db>
+    pgxpool.MaxConns lowered (math below).
+
+Java services
+└── Same DATABASE_URL change for any service that connects to Postgres.
+
+Migration jobs (golang-migrate)
+└── Bypass PgBouncer — connect directly to Postgres on 5432.
+    Migrations need session-level features (transaction wrapping, advisory locks)
+    that transaction-pooling mode doesn't preserve.
+```
+
+## Pool sizing math
+
+```
+Per-app:
+  pgxpool.MaxConns = 8     (down from typical 25 default)
+
+Across the cluster:
+  5 Go services × 1 pod × 8 conn  = 40 client conns
+  3 Java services × 1 pod × 10    = 30 client conns
+  TOTAL client side                = ~70
+
+PgBouncer config:
+  default_pool_size      = 25     (server conns per (user, db) pair)
+  max_client_conn        = 200    (room for QA + ad-hoc + future growth)
+  max_db_connections     = 80     (cap toward Postgres regardless of pools)
+
+Postgres:
+  max_connections = 100   (unchanged)
+```
+
+The fan-in: 70+ client connections compress into ~25 server-side. Idle apps hold open client connections cheaply (PgBouncer keeps them in memory, not on Postgres). The pool only checks out a server connection while a transaction is in flight.
+
+`max_db_connections = 80` is a hard ceiling that protects Postgres regardless of pool config drift — even if every per-pool limit were misconfigured, Postgres would never see more than 80 PgBouncer connections, leaving headroom under the 100 default `max_connections`.
+
+## Pool mode — transaction
+
+`pool_mode = transaction` is chosen because:
+
+- **Session mode** holds a server connection for the entire client session — no fan-in, defeats the point.
+- **Statement mode** is finer-grained but breaks any multi-statement transaction. Every Go service uses transactions; this would break the ecommerce saga.
+- **Transaction mode** holds a server connection only for the duration of a `BEGIN`...`COMMIT`. Best fan-in compatible with our workload.
+
+Trade-offs of transaction mode:
+- `LISTEN` / `NOTIFY` doesn't work (we don't use it).
+- Session-level `SET` (e.g., `SET LOCAL` is fine, `SET` is not) doesn't persist. We don't depend on this either.
+- Prepared statements need explicit support (next section).
+
+## Prepared statements (the gotcha)
+
+`pgx` defaults to `QueryExecModeCacheDescribe`, which uses prepared statements. PgBouncer in `transaction` mode historically broke this — a prepared statement is bound to a server connection, but the next query might land on a different server connection that doesn't have it.
+
+PgBouncer 1.21+ added **protocol-level prepared statement support** in transaction mode (`max_prepared_statements > 0`). Each PgBouncer client connection caches its prepared statements; PgBouncer transparently re-prepares them on whatever server connection it routes to.
+
+Configuration:
+
+```ini
+max_prepared_statements = 200
+```
+
+This adds memory per client connection (~few KB per cached statement). Acceptable.
+
+Verification: an integration test asserts that the same query, sent twice through PgBouncer, parses to the same plan id (`pg_stat_statements.queryid` is stable) — proof that prepared-statement reuse is working.
+
+## Authentication via `auth_query`
+
+`auth_query` lets PgBouncer ask Postgres for the password hash of a connecting user, rather than maintaining a static `userlist.txt`. New users are picked up automatically — no PgBouncer restart on user rotation.
+
+```ini
+auth_user = pgbouncer_auth
+auth_query = SELECT usename, passwd FROM pg_shadow WHERE usename=$1
+```
+
+A new role `pgbouncer_auth` is created with `pg_read_server_files`-equivalent access to `pg_shadow`:
+
+```sql
+CREATE ROLE pgbouncer_auth LOGIN PASSWORD :'pw';
+CREATE FUNCTION pg_temp.pgbouncer_auth(text) RETURNS TABLE(uname TEXT, phash TEXT) AS $$
+  SELECT usename, passwd FROM pg_shadow WHERE usename = $1
+$$ LANGUAGE SQL SECURITY DEFINER;
+GRANT EXECUTE ON FUNCTION pg_temp.pgbouncer_auth(text) TO pgbouncer_auth;
+```
+
+(The exact `auth_query` is finalized in the plan; the SECURITY DEFINER wrapper avoids granting `pg_shadow` access broadly.)
+
+The `pgbouncer_auth` password is stored in `java-secrets` as a new key.
+
+## Migrations bypass PgBouncer
+
+`golang-migrate` Jobs and any other migration tool need session-level semantics. The migration K8s Jobs keep the existing direct `DATABASE_URL` to `postgres.java-tasks.svc.cluster.local:5432`. This is documented in the migration playbook (#156) and called out explicitly in the manifests.
+
+## Observability
+
+### `prometheus-pgbouncer-exporter`
+
+Sidecar in the pgbouncer pod (or separate small Deployment — sidecar is simpler). Exposes:
+
+- `pgbouncer_pools_client_active_connections{database, user}`
+- `pgbouncer_pools_client_waiting_connections{database, user}`
+- `pgbouncer_pools_server_active_connections`
+- `pgbouncer_pools_server_idle_connections`
+- `pgbouncer_pools_server_used_connections`
+- `pgbouncer_stats_avg_query_time_seconds`
+- `pgbouncer_stats_avg_wait_time_seconds`
+
+### Dashboard
+
+A new dashboard `pgbouncer.json` in `grafana-dashboards.yml` (separate from the PostgreSQL health dashboard, but cross-linked):
+
+| Panel | Type | Source | Purpose |
+|---|---|---|---|
+| Client connections (active vs waiting) | Time series | Prometheus | Saturation early warning |
+| Server connection usage | Time series | Prometheus | Capacity planning |
+| Avg wait time per pool | Time series | Prometheus | The key SLI for PgBouncer |
+| Avg query time per pool | Time series | Prometheus | Compare to direct-Postgres baseline |
+| Top pools by waiting clients | Bar gauge | Prometheus | Hotspot identification |
+| Total Postgres backends (before/after) | Stat | Prometheus | The "did this work?" answer |
+
+### Alerts (appended to `PostgreSQL` group, all `noDataState: OK`)
+
+| Alert | Threshold | Why |
+|---|---|---|
+| `PgBouncerPoolWaitTimeHigh` | `pgbouncer_stats_avg_wait_time_seconds > 0.1` for 5m, per pool | Wait > 100ms means the pool is too small or the DB is slow |
+| `PgBouncerClientsWaiting` | `pgbouncer_pools_client_waiting_connections > 0` for 10m | Sustained queueing, not just bursts |
+| `PgBouncerServerConnectionFailures` | `rate(pgbouncer_stats_total_xact_count[5m]) drops to 0` while client conns active | PgBouncer can't reach Postgres |
+
+## Per-service config changes
+
+The Go services that need touching (one-line `DATABASE_URL` change in each Deployment env, plus a `pgxpool.MaxConns` retune):
+
+| Service | Current `MaxConns` | New `MaxConns` | Notes |
+|---|---|---|---|
+| auth-service | 25 | 8 | |
+| product-service | 25 | 8 | |
+| order-service | 25 | 8 | Reporting pool to follow once #161 lands |
+| cart-service | 25 | 8 | |
+| payment-service | 25 | 8 | |
+| ai-service | n/a (no Postgres) | n/a | |
+
+Java services (Spring HikariCP):
+| Service | `maximumPoolSize` was | New | Notes |
+|---|---|---|---|
+| task-service | 10 | 5 | |
+| activity-service | 10 | 5 | |
+
+The exact current values are confirmed during plan-writing by reading each service's config.
+
+## Testing
+
+**Integration test** at `go/pkg/db/pgbouncer_integration_test.go` (testcontainers, build-tagged):
+
+1. Spin up a Postgres container.
+2. Spin up a PgBouncer container linked to it, with `pool_mode=transaction`, `max_prepared_statements=200`.
+3. Open a `pgxpool` against PgBouncer using `QueryExecModeCacheDescribe`.
+4. Run the same parameterized query 100× across 20 goroutines.
+5. Assert: no errors, all queries return correct results, `pg_stat_statements.calls = 100` for that queryid (proving prepared statements were reused).
+6. Assert: `pg_stat_database.numbackends` on Postgres stays ≤ pool_size (proving fan-in worked).
+
+**QA smoke test:**
+1. After deploy, exec into a Go service pod and verify `psql $DATABASE_URL -c '\conninfo'` shows port 6432.
+2. Run a load test (Apache Bench or hey) against an endpoint that hits the database.
+3. Watch `kubectl exec postgres -- psql -c "SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE 'pgbouncer%'"` — should stay flat as load increases.
+4. Verify the dashboard's "Total Postgres backends" panel drops dramatically post-deploy.
+
+## Rollout
+
+This is a blast-radius-y change — every service's connection path moves. Mitigation: deploy in QA first, observe for 24h, then prod.
+
+1. Land the PgBouncer Deployment, Service, ConfigMap, sidecar exporter, and the `pgbouncer_auth` Job. PgBouncer is up but unused.
+2. Verify QA: connect manually with `psql -h pgbouncer.java-tasks-qa -p 6432 -U taskuser -d productdb`. Confirm prepared statements work via the integration test in QA.
+3. Switch *one* QA service's `DATABASE_URL` (start with auth-service — smallest surface). Watch logs and the new dashboard for 1h.
+4. Switch the rest of QA services in a single PR, observe overnight.
+5. Repeat in prod.
+6. Land observability (dashboard + alerts) early — they're harmless without PgBouncer running.
+7. Migration Jobs explicitly keep the direct URL — verified by reading the Job manifests during plan execution.
+
+## ADR
+
+Companion ADR at `docs/adr/database/pgbouncer.md` covering:
+
+- Why transaction mode (with the LISTEN/NOTIFY caveat)
+- Why `auth_query` over `userlist.txt`
+- Pool sizing math (the headline numbers above) and the `max_db_connections` safety rail
+- Why migrations bypass PgBouncer
+- Why `max_prepared_statements` is non-negotiable in our setup
+- The single-replica HA trade-off and the "two replicas behind a Service" upgrade path
+
+## Consequences
+
+**Positive:**
+- Postgres `max_connections = 100` becomes safe headroom even as services scale.
+- Idle apps cost nothing on Postgres (server-side conns are recycled at end of transaction).
+- Pool wait time becomes a first-class SLI — alerting on it catches real saturation before user-facing timeouts.
+- Adds a layered architecture story: pgx pool (per-process) + PgBouncer (cluster) is exactly how production shops do it.
+
+**Trade-offs:**
+- PgBouncer is now a SPOF for every Postgres-dependent service. Single-replica is acceptable at portfolio scale; HA upgrade is small. The PDB and `nodeAffinity` keep it from being voluntarily evicted.
+- Transaction-mode pooling forecloses LISTEN/NOTIFY and session-level state. We don't use these; future work that wants them must connect directly.
+- Migrations carve out an exception. Documented in the playbook (#156) and the PgBouncer ADR.
+- `max_prepared_statements > 0` adds modest memory per client connection. Not material.
+
+**Phase 2:**
+- Multi-replica PgBouncer (`replicas: 2`, headless service, client-side connection retry).
+- Replica-aware PgBouncer pools once #161 (read replica) lands — separate `pgbouncer.ini` `[databases]` entries `productdb_ro` etc. routing reads to the replica.

--- a/docs/superpowers/specs/2026-04-27-read-replica-design.md
+++ b/docs/superpowers/specs/2026-04-27-read-replica-design.md
@@ -1,0 +1,330 @@
+# Design: PostgreSQL Streaming Read Replica
+
+- **Date:** 2026-04-27
+- **Status:** Draft — pending implementation
+- **Roadmap position:** Item 7 of 10 in the `db-roadmap` GitHub label
+- **GitHub issue:** [#161 — Streaming read replica for reporting](https://github.com/kabradshaw1/portfolio/issues/161)
+- **Builds on:**
+  - `docs/superpowers/specs/2026-04-27-pitr-design.md` — the `replicator` role and the WAL stream this replica taps into
+  - `docs/adr/ecommerce/go-sql-optimization-reporting.md` — the reporting handler whose reads move to the replica
+  - `docs/superpowers/specs/2026-04-27-pgbouncer-design.md` — PgBouncer as the primary front; this spec leaves a hook for replica routing
+
+## Context
+
+The order-service exposes a `/reporting/*` endpoint group backed by the materialized views `mv_daily_revenue`, `mv_product_performance`, and `mv_customer_summary`, plus CTE-based reporting queries. These reads compete with OLTP traffic on the same Postgres pod — the same I/O queue, the same CPU, the same `shared_buffers`.
+
+That's fine at portfolio scale, but it's the opposite of how production teams scale Postgres. The standard playbook is:
+
+- **Primary** handles the OLTP workload (writes, latency-sensitive reads).
+- **One or more async replicas** receive WAL via streaming replication and serve read-heavy traffic.
+- **Application code** routes reads to the replica when staleness is acceptable.
+
+This spec adds one async streaming replica and routes the reporting handler's reads to it. The same WAL stream that already feeds the archive (from the PITR work in roadmap item #157) feeds the replica — no duplicated infrastructure. "Async streaming replica" / "read/write split" / "physical vs logical replication" are foundational interview vocabulary.
+
+## Goals
+
+- Stand up a second Postgres pod as a hot standby of the primary.
+- Replicate via physical streaming replication using a replication slot (so WAL isn't pruned before the replica catches up).
+- Route the order-service reporting reads to the replica.
+- Observe replica lag as a first-class metric, alert on it.
+- Document a manual promotion procedure (the runbook scenario for "primary is dead").
+
+## Non-goals
+
+- Synchronous replication (`synchronous_commit = on` w/ `synchronous_standby_names`). Async is the right default for read-scaling; sync replication is a separate concern (durability vs. throughput trade-off).
+- Automated failover / Patroni / repmgr. Manual promotion runbook only.
+- Connection-string-level read/write splitting (e.g., a `?target_session_attrs=read-only` hack on a single URL). The Go services use *separate pools* for primary vs replica — explicit beats clever.
+- Multi-replica fan-out. One replica is sufficient for the current reporting load and the HA story. Two-replica is a one-line StatefulSet change.
+
+## Architecture
+
+```
+java-tasks namespace
+├── postgres (primary) — existing
+│   ├── wal_level = replica  (already set in PITR spec)
+│   ├── max_wal_senders = 10
+│   ├── max_replication_slots = 5
+│   ├── replicator role (created in PITR spec)
+│   └── physical replication slot: replica_1
+│
+├── postgres-replica (NEW)
+│   ├── StatefulSet, single replica
+│   ├── Image: postgres:17-alpine (same as primary)
+│   ├── Bootstrapped via pg_basebackup at first start
+│   ├── standby.signal in data dir → starts in recovery
+│   ├── primary_conninfo points at postgres.java-tasks.svc.cluster.local:5432
+│   ├── primary_slot_name = replica_1
+│   ├── hot_standby = on (default)
+│   └── Service: postgres-replica.java-tasks.svc.cluster.local:5432 (read-only)
+│
+└── postgres-replica-bootstrap (NEW one-shot Job)
+    └── Runs pg_basebackup against primary into the replica's PVC on first boot
+
+go-ecommerce namespace
+└── order-service
+    ├── DATABASE_URL          (unchanged) → primary
+    ├── DATABASE_URL_REPLICA  (NEW) → replica
+    ├── two pgxpool instances: Pool (primary), ReportingPool (replica)
+    └── ReportingRepository takes *pgxpool.Pool of replica
+        Materialized-view refresh keeps writing to primary (replicas are RO)
+
+monitoring namespace
+└── Grafana extends existing PostgreSQL dashboard (3 new panels)
+└── Grafana extends PostgreSQL alert group (3 new rules)
+```
+
+Replication is **physical** (byte-level WAL replay), not **logical** (per-table change feed). Physical replication means the replica is an exact copy of the primary, including all tables, indexes, materialized views, and roles.
+
+## Replica setup
+
+The replica is a `StatefulSet` (not Deployment) because it has identity — the data dir is keyed to one specific replica, and you can't replace it without re-running `pg_basebackup`.
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-replica
+  namespace: java-tasks
+spec:
+  serviceName: postgres-replica
+  replicas: 1
+  selector:
+    matchLabels: { app: postgres-replica }
+  template:
+    metadata:
+      labels: { app: postgres-replica }
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9187"
+    spec:
+      initContainers:
+        - name: bootstrap
+          image: postgres:17-alpine
+          command: ["/scripts/bootstrap-replica.sh"]
+          env:
+            - name: PRIMARY_HOST
+              value: postgres.java-tasks.svc.cluster.local
+            - name: PGPASSWORD
+              valueFrom: { secretKeyRef: { name: java-secrets, key: replicator-password } }
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data }
+            - { name: scripts, mountPath: /scripts }
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          # same args/lifecycle/probes as primary
+          # plus: data dir contains standby.signal so it starts in recovery
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data, subPath: pgdata }
+        - name: postgres-exporter
+          # same as primary's exporter
+      volumes:
+        - name: scripts
+          configMap: { name: postgres-replica-scripts, defaultMode: 0755 }
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources: { requests: { storage: 10Gi } }
+```
+
+### `bootstrap-replica.sh`
+
+```bash
+#!/bin/sh
+set -eu
+DATA_DIR="/var/lib/postgresql/data/pgdata"
+
+if [ -f "$DATA_DIR/PG_VERSION" ]; then
+  echo "Replica already initialized — skipping pg_basebackup."
+  exit 0
+fi
+
+echo "Bootstrapping replica from $PRIMARY_HOST..."
+mkdir -p "$DATA_DIR"
+pg_basebackup \
+  --host="$PRIMARY_HOST" \
+  --username=replicator \
+  --pgdata="$DATA_DIR" \
+  --format=plain \
+  --wal-method=stream \
+  --slot=replica_1 \
+  --create-slot \
+  --write-recovery-conf \
+  --progress \
+  --verbose
+
+# pg_basebackup with --write-recovery-conf creates standby.signal automatically
+# and writes primary_conninfo + primary_slot_name into postgresql.auto.conf.
+
+chmod 0700 "$DATA_DIR"
+echo "Replica bootstrapped."
+```
+
+Notes:
+- `--create-slot --slot=replica_1` creates the physical replication slot on the primary at bootstrap time. If the slot exists, `pg_basebackup` errors — use `IF NOT EXISTS`-style pre-check or just let it fail loudly on re-bootstrap (a re-bootstrap is itself an unusual event that warrants attention).
+- `--write-recovery-conf` is the modern (PG 12+) way to set up the recovery file — it writes `standby.signal` and `postgresql.auto.conf` entries.
+
+### Why a replication slot (and the trade-off)
+
+The slot guarantees primary keeps WAL until the replica acknowledges it. Without a slot, primary can prune WAL the replica still needs → replica falls off → manual re-bootstrap required.
+
+The cost: if the replica goes offline for an extended period, primary's data dir grows because WAL accumulates. Mitigation: the `PgWalArchiveStale` alert from #157 catches "primary's WAL retention is unhappy"; a new alert (`PgReplicationSlotLagHigh`) catches "the slot is the cause."
+
+`max_slot_wal_keep_size = 4GB` is set on the primary as a safety rail — beyond 4 GB of slot retention, the slot is invalidated rather than filling the disk. This trades correctness (replica needs re-bootstrap) for safety (primary stays up).
+
+## Application-side routing
+
+The order-service is the only consumer right now. Two pools live side by side:
+
+```go
+// internal/db/pools.go
+type Pools struct {
+    Primary   *pgxpool.Pool
+    Reporting *pgxpool.Pool
+}
+
+func New(ctx context.Context, primaryDSN, replicaDSN string) (*Pools, error) {
+    primary, err := newPool(ctx, primaryDSN, "primary")
+    if err != nil { return nil, err }
+    reporting, err := newPool(ctx, replicaDSN, "reporting")
+    if err != nil {
+        primary.Close()
+        return nil, err
+    }
+    return &Pools{Primary: primary, Reporting: reporting}, nil
+}
+```
+
+`newPool` sets `pgxpool.Config.ConnConfig.RuntimeParams["application_name"] = name` so primary vs. replica traffic is distinguishable in `pg_stat_activity`.
+
+The reporting repository constructor takes the replica pool:
+
+```go
+// internal/reporting/repository.go
+func NewRepository(pool *pgxpool.Pool) *Repository {
+    return &Repository{pool: pool}
+}
+```
+
+Wiring in `cmd/server/main.go`:
+
+```go
+pools, err := db.New(ctx, cfg.DatabaseURL, cfg.DatabaseURLReplica)
+// ...
+reportingRepo := reporting.NewRepository(pools.Reporting)
+```
+
+`cfg.DatabaseURLReplica` falls back to `cfg.DatabaseURL` if unset — so local development without a replica still works.
+
+### What writes still go to primary
+
+- All non-reporting endpoints (orders CRUD, saga step transitions, etc.) — `pools.Primary`.
+- Materialized view refreshes — `pools.Primary`. Materialized views can't be refreshed on a hot standby (writes only). The existing 15-min refresh interval is unchanged; the *reads* of those views move to the replica.
+- Migrations — direct to primary on port 5432 (already the case from the PgBouncer spec's exception).
+
+### Staleness expectations
+
+The reporting endpoints are *already* serving 15-minute-stale data (materialized views refresh every 15 min). Adding sub-second replica lag on top is invisible to the consumer. This is exactly the workload that should run on a replica — staleness was already accepted.
+
+## Observability
+
+Replica lag is the central new metric. Two complementary views:
+
+- **From primary:** `pg_stat_replication.replay_lag` (interval), `.write_lag`, `.flush_lag`. Reports how far each replica is behind.
+- **From replica:** `pg_last_xact_replay_timestamp()`, `pg_last_wal_replay_lsn()`. Reports "what time was the last replayed transaction."
+
+Both are exposed by `postgres_exporter` out of the box (the replica gets its own exporter sidecar). Metrics:
+
+- `pg_stat_replication_replay_lag_seconds{slot_name="replica_1"}` (from primary)
+- `pg_last_xact_replay_timestamp` (from replica)
+
+### Dashboard panels (extend existing PostgreSQL health dashboard)
+
+| Panel | Type | Source | Purpose |
+|---|---|---|---|
+| Replica lag (seconds) | Time series | Prometheus, primary view | Single most important replica SLI |
+| Replication slot retention bytes | Time series | Prometheus | "Is primary about to invalidate the slot?" |
+| Replica replay LSN vs primary LSN | Stat | Prometheus | Visual confidence the stream is live |
+
+### Alerts (appended to `PostgreSQL` group, all `noDataState: OK`)
+
+| Alert | Threshold | Why |
+|---|---|---|
+| `PgReplicationLagHigh` | `pg_stat_replication_replay_lag_seconds > 30` for 5m | 30s lag is the SLA for reporting reads |
+| `PgReplicationSlotLagHigh` | `pg_replication_slots_active = 0` OR `slot retention bytes > 2GB` for 5m | Slot is unhealthy or about to be invalidated |
+| `PgReplicaDown` | `up{job="postgres-replica-exporter"} = 0` for 2m | Replica pod is gone — reporting reads will start hitting the fallback (primary) |
+
+## Promotion runbook
+
+A new section in `docs/runbooks/postgres-recovery.md` (peer with the existing scenarios + the PITR scenario from #157):
+
+> **Scenario 5: Promote the replica (primary is unrecoverable)**
+>
+> *Symptoms:* primary pod won't start, data is corrupt beyond `pg_dump` recovery, or a failover drill.
+>
+> *Steps:*
+> 1. Stop the primary's Service so apps can't reach it: `kubectl scale deployment postgres -n java-tasks --replicas=0`.
+> 2. Verify replica replay LSN is current: `kubectl exec postgres-replica-0 -- psql -c "SELECT pg_last_wal_replay_lsn();"`.
+> 3. Promote the replica: `kubectl exec postgres-replica-0 -- psql -c "SELECT pg_promote();"`. Replica becomes primary.
+> 4. Update the `postgres` Service selector to point at `postgres-replica`. Apps reconnect.
+> 5. Bring up a NEW replica pointed at the now-promoted instance. The old primary's data is left as-is for forensics.
+
+The runbook flags this as a manual-only procedure and references the future Patroni/repmgr work for automation.
+
+## Testing
+
+**Integration test** at `go/pkg/db/replica_integration_test.go` (testcontainers, build-tagged):
+
+1. Spin up a primary container with `wal_level=replica`, `max_wal_senders=4`, plus a `replicator` role + a physical replication slot.
+2. Spin up a second container that runs `pg_basebackup` from the primary, sets `standby.signal`, and starts in recovery.
+3. Wait for replica to report `pg_last_xact_replay_timestamp()`.
+4. Insert a row on primary, wait briefly, query the replica.
+5. Assert the row is visible on the replica.
+6. Kill the replica, write more rows on primary, restart the replica.
+7. Assert the replica catches up via the slot (no `pg_basebackup` re-run needed).
+
+**QA smoke test:**
+1. After deploy, verify replica pod is in `RUNNING` state and `pg_is_in_recovery()` returns `true`.
+2. Hit the order-service `/reporting/sales-trends` endpoint; verify in the primary's `pg_stat_activity` that the query did NOT execute there.
+3. In replica's `pg_stat_activity`, verify the connection has `application_name = 'reporting'`.
+4. Insert a test row on primary; query for it on the replica within 1s — should be visible.
+
+## Rollout
+
+1. Land the StatefulSet, bootstrap script, replica Service, exporter sidecar config — replica boots, replicates, but no app uses it yet.
+2. Add `DATABASE_URL_REPLICA` env var to order-service Deployment, defaulted to the replica Service. The Go code's fallback to `DATABASE_URL` means the change is no-op until the replica DSN is actually set.
+3. Wire the replica pool through `db.New` and pass it to `reporting.NewRepository`. Reporting reads now hit the replica.
+4. Land dashboard panels and alerts.
+5. QA verify; observe overnight for slot/lag behavior.
+6. Repeat in prod.
+
+## ADR
+
+Companion ADR at `docs/adr/database/read-replica.md` covering:
+
+- Why physical (streaming) replication over logical for this use case
+- Why a replication slot, with the WAL-retention failure mode and the `max_slot_wal_keep_size` mitigation
+- Why two pools instead of a connection-string-level read/write split
+- The async (not sync) durability trade-off and what reporting consumers can expect
+- Why this spec is scoped to the order-service reporting handler, not all reads
+
+## Consequences
+
+**Positive:**
+- The OLTP path on primary is no longer competing with reporting I/O.
+- Read scaling is now horizontal — additional replicas are a one-line StatefulSet change.
+- Replica is also passive HA — manual promotion is a documented one-command failover.
+- "How do you scale Postgres reads?" becomes a real demo, not a theoretical answer.
+
+**Trade-offs:**
+- Async replication means the replica is *always* slightly stale. Acceptable for the materialized-view-backed reporting workload (already 15-min stale by design).
+- The replication slot can fill primary's WAL volume if the replica is down for an extended period. `max_slot_wal_keep_size` limits the damage at the cost of replica re-bootstrap.
+- Replica is on the same Minikube node as primary. A node-level failure takes both down. That's a Phase 3 (multi-node) problem.
+- One more pod, one more PVC (10Gi), one more exporter to monitor. Modest.
+
+**Phase 2:**
+- Replica-aware PgBouncer pools (`productdb_ro` etc. routing to the replica) so apps connect through PgBouncer for both primary and replica reads.
+- Second replica for true HA — the StatefulSet `replicas: 2` change.
+- Patroni or repmgr for automated failover.
+- Logical replication (`wal_level = logical`) — different feature for a different need (CDC, downstream consumers); roadmap item #163.

--- a/frontend/e2e/mocked/database-page.spec.ts
+++ b/frontend/e2e/mocked/database-page.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "./fixtures";
+
+test.describe("/database page", () => {
+  test("renders the page heading", async ({ page }) => {
+    await page.goto("/database");
+    await expect(
+      page.getByRole("heading", { name: "Database Engineering", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("renders all three tab labels", async ({ page }) => {
+    await page.goto("/database");
+    await expect(page.getByRole("button", { name: "PostgreSQL", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "NoSQL", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Vector", exact: true })).toBeVisible();
+  });
+
+  test("PostgreSQL tab is active by default", async ({ page }) => {
+    await page.goto("/database");
+    await expect(page.getByTestId("postgres-tab")).toBeVisible();
+    await expect(page.getByTestId("nosql-tab")).not.toBeVisible();
+    await expect(page.getByTestId("vector-tab")).not.toBeVisible();
+  });
+
+  test("clicking NoSQL switches to the NoSQL tab", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "NoSQL", exact: true }).click();
+    await expect(page.getByTestId("nosql-tab")).toBeVisible();
+    await expect(page.getByTestId("postgres-tab")).not.toBeVisible();
+  });
+
+  test("clicking Vector switches to the Vector tab", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Vector", exact: true }).click();
+    await expect(page.getByTestId("vector-tab")).toBeVisible();
+  });
+});

--- a/frontend/e2e/mocked/database-page.spec.ts
+++ b/frontend/e2e/mocked/database-page.spec.ts
@@ -50,4 +50,49 @@ test.describe("/database page", () => {
     const link = page.getByRole("link", { name: /View vector DB usage in \/ai/ });
     await expect(link).toHaveAttribute("href", "/ai");
   });
+
+  test("PostgreSQL tab renders all four pillar headings", async ({ page }) => {
+    await page.goto("/database");
+    await expect(
+      page.getByRole("heading", { name: "Query Optimization & Benchmarking", level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Schema Design — Partitioning & Materialized Views", level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Migration Safety — migration-lint", level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Reliability & Recovery", level: 2 }),
+    ).toBeVisible();
+  });
+
+  test("each pillar has a stable anchor id", async ({ page }) => {
+    await page.goto("/database");
+    for (const id of ["optimization", "schema", "migrations", "reliability"]) {
+      await expect(page.locator(`#${id}`)).toBeVisible();
+    }
+  });
+
+  test("PostgreSQL tab includes recruiter keywords inline", async ({ page }) => {
+    await page.goto("/database");
+    // Several of these keywords appear in both narrative + bullet — first match is enough.
+    await expect(page.getByText("PostgreSQL 16", { exact: false }).first()).toBeVisible();
+    await expect(page.getByText("Range partitioning", { exact: false }).first()).toBeVisible();
+    await expect(
+      page.getByText("CREATE INDEX CONCURRENTLY", { exact: false }).first(),
+    ).toBeVisible();
+    await expect(page.getByText("postgres_exporter", { exact: false }).first()).toBeVisible();
+  });
+
+  test("clicking a TOC link scrolls to the corresponding pillar", async ({ page }) => {
+    await page.goto("/database");
+    // Default viewport is desktop-sized; the sidebar TOC is the visible one.
+    await page
+      .locator('[data-testid="sticky-toc-sidebar"] a[href="#migrations"]')
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Migration Safety — migration-lint", level: 2 }),
+    ).toBeInViewport();
+  });
 });

--- a/frontend/e2e/mocked/database-page.spec.ts
+++ b/frontend/e2e/mocked/database-page.spec.ts
@@ -34,4 +34,20 @@ test.describe("/database page", () => {
     await page.getByRole("button", { name: "Vector", exact: true }).click();
     await expect(page.getByTestId("vector-tab")).toBeVisible();
   });
+
+  test("NoSQL stub points to /java", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "NoSQL", exact: true }).click();
+    await expect(page.getByText("MongoDB powers the activity feed", { exact: false })).toBeVisible();
+    const link = page.getByRole("link", { name: /View MongoDB usage in \/java/ });
+    await expect(link).toHaveAttribute("href", "/java");
+  });
+
+  test("Vector stub points to /ai", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Vector", exact: true }).click();
+    await expect(page.getByText("Qdrant backs the retrieval layer", { exact: false })).toBeVisible();
+    const link = page.getByRole("link", { name: /View vector DB usage in \/ai/ });
+    await expect(link).toHaveAttribute("href", "/ai");
+  });
 });

--- a/frontend/e2e/mocked/database-page.spec.ts
+++ b/frontend/e2e/mocked/database-page.spec.ts
@@ -95,4 +95,11 @@ test.describe("/database page", () => {
       page.getByRole("heading", { name: "Migration Safety — migration-lint", level: 2 }),
     ).toBeInViewport();
   });
+
+  test("homepage links to /database", async ({ page }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /Database Engineering/ });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/database");
+  });
 });

--- a/frontend/src/app/database/error.tsx
+++ b/frontend/src/app/database/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+export default function DatabaseError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="text-2xl font-bold">Something went wrong on /database</h1>
+      <p className="mt-4 text-muted-foreground">{error.message}</p>
+      <button
+        onClick={reset}
+        className="mt-6 rounded-lg border px-4 py-2 text-sm hover:bg-accent transition-colors"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/database/page.tsx
+++ b/frontend/src/app/database/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { databaseTabs, type DatabaseTab } from "@/components/database/tabs";
+import { PostgresTab } from "@/components/database/PostgresTab";
+import { NoSqlTab } from "@/components/database/NoSqlTab";
+import { VectorTab } from "@/components/database/VectorTab";
+
+export default function DatabasePage() {
+  const [activeTab, setActiveTab] = useState<DatabaseTab>("postgres");
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="mt-8 text-3xl font-bold">Database Engineering</h1>
+
+      {/* Bio Section */}
+      <section className="mt-8">
+        <p className="text-muted-foreground leading-relaxed">
+          Production-grade PostgreSQL is one of the load-bearing skills behind
+          this portfolio: real-database benchmarks, range partitioning with
+          materialized views, a custom AST-based migration linter, and an
+          operational track with backups and recovery runbooks. MongoDB and
+          Qdrant are also in use elsewhere in the portfolio — dedicated tabs
+          for each are coming.
+        </p>
+      </section>
+
+      {/* Project Section with Tabs */}
+      <section className="mt-12">
+        <h2 className="text-2xl font-semibold">Database Tracks</h2>
+
+        {/* Tab Bar */}
+        <div className="mt-4 flex gap-0 border-b border-foreground/10">
+          {databaseTabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                activeTab === tab.key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab Content */}
+        <div className="mt-8">
+          {activeTab === "postgres" && <PostgresTab />}
+          {activeTab === "nosql" && <NoSqlTab />}
+          {activeTab === "vector" && <VectorTab />}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -129,6 +129,24 @@ export default function Home() {
               </CardContent>
             </Card>
           </Link>
+          <Link href="/database" className="block">
+            <Card className="hover:ring-foreground/20 transition-all">
+              <CardHeader>
+                <CardTitle>Database Engineering</CardTitle>
+                <CardDescription>
+                  Production PostgreSQL — optimization, partitioning, migration
+                  safety, and reliability
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground text-sm">
+                  Real benchmarks against PostgreSQL 16, range partitioning with
+                  materialized views, a custom AST-based migration linter, and
+                  an operational track with backups and recovery runbooks.
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
           <Link href="/security" className="block">
             <Card className="hover:ring-foreground/20 transition-all">
               <CardHeader>

--- a/frontend/src/components/database/NoSqlTab.tsx
+++ b/frontend/src/components/database/NoSqlTab.tsx
@@ -1,0 +1,7 @@
+export function NoSqlTab() {
+  return (
+    <div data-testid="nosql-tab">
+      <p className="text-muted-foreground">NoSQL content — coming in Task 6.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/database/NoSqlTab.tsx
+++ b/frontend/src/components/database/NoSqlTab.tsx
@@ -1,7 +1,23 @@
+import Link from "next/link";
+
 export function NoSqlTab() {
   return (
-    <div data-testid="nosql-tab">
-      <p className="text-muted-foreground">NoSQL content — coming in Task 6.</p>
+    <div data-testid="nosql-tab" className="space-y-6">
+      <p className="text-muted-foreground leading-relaxed">
+        MongoDB powers the activity feed and analytics aggregations in the
+        Java task-management portfolio — document-shaped activity events,
+        time-bucketed aggregations, and a Redis read-cache layered on top.
+        A dedicated NoSQL section is on the way; for now, the running code
+        and its supporting docs live on the Java page.
+      </p>
+      <div>
+        <Link
+          href="/java"
+          className="inline-flex items-center gap-2 rounded-lg border px-6 py-3 text-sm font-medium hover:bg-accent transition-colors"
+        >
+          View MongoDB usage in /java &rarr;
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/database/PillarSection.tsx
+++ b/frontend/src/components/database/PillarSection.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+export type PillarLink = {
+  label: string;
+  href: string;
+};
+
+export type PillarSectionProps = {
+  /** Anchor id, used by the sticky TOC and as the section's id. */
+  id: string;
+  /** Section heading, e.g. "Query Optimization & Benchmarking". */
+  title: string;
+  /** Two- to four-sentence narrative paragraph(s). */
+  narrative: ReactNode;
+  /** 4–6 concrete-claim bullets. Strings or ReactNodes. */
+  bullets: ReactNode[];
+  /** ADR / runbook links rendered as a muted button row. */
+  links: PillarLink[];
+};
+
+export function PillarSection({ id, title, narrative, bullets, links }: PillarSectionProps) {
+  return (
+    <section id={id} className="scroll-mt-24" data-testid={`pillar-${id}`}>
+      <h2 className="text-2xl font-semibold">{title}</h2>
+      <div className="mt-4 text-muted-foreground leading-relaxed space-y-3">{narrative}</div>
+      <ul className="mt-4 space-y-2 list-disc pl-5 text-sm text-muted-foreground">
+        {bullets.map((bullet, i) => (
+          <li key={i} className="leading-relaxed">
+            {bullet}
+          </li>
+        ))}
+      </ul>
+      {links.length > 0 && (
+        <div className="mt-5 flex flex-wrap gap-3">
+          {links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium hover:bg-accent transition-colors"
+              target={link.href.startsWith("http") ? "_blank" : undefined}
+              rel={link.href.startsWith("http") ? "noopener noreferrer" : undefined}
+            >
+              {link.label} &rarr;
+            </a>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/database/PostgresTab.tsx
+++ b/frontend/src/components/database/PostgresTab.tsx
@@ -1,7 +1,232 @@
+import { PillarSection } from "@/components/database/PillarSection";
+import {
+  StickyTocChips,
+  StickyTocSidebar,
+  type StickyTocItem,
+} from "@/components/database/StickyToc";
+
+const tocItems: StickyTocItem[] = [
+  { id: "optimization", label: "Query Optimization" },
+  { id: "schema", label: "Schema Design" },
+  { id: "migrations", label: "Migration Safety" },
+  { id: "reliability", label: "Reliability & Recovery" },
+];
+
 export function PostgresTab() {
   return (
-    <div data-testid="postgres-tab">
-      <p className="text-muted-foreground">PostgreSQL content — coming in Task 5.</p>
+    <div data-testid="postgres-tab" className="md:grid md:grid-cols-[1fr_220px] md:gap-10">
+      {/* Mobile chip TOC: top of tab content, hidden at md+. */}
+      <div className="md:hidden">
+        <StickyTocChips items={tocItems} />
+      </div>
+
+      <div className="space-y-16 min-w-0">
+        <PillarSection
+          id="optimization"
+          title="Query Optimization & Benchmarking"
+          narrative={
+            <>
+              <p>
+                Functional ORM-style code is a starting point, not the finish line.
+                The Go services were re-benchmarked against a real PostgreSQL 16
+                container and rewritten where the data showed it.
+              </p>
+              <p>
+                <code>testcontainers-go</code> made the benchmarks runnable on any
+                Docker-equipped machine; results were captured to{" "}
+                <code>go/benchdata/</code> for interview-ready evidence.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Real-DB benchmarks via <code>testcontainers-go</code> against PostgreSQL 16; results in{" "}
+              <code>go/benchdata/baseline-results.txt</code> and <code>optimized-results.txt</code>
+            </>,
+            <>
+              <strong>Batch INSERT for order items: 3.5× speedup on 20-item orders</strong> (4.5ms → 1.3ms),
+              single round trip instead of N
+            </>,
+            <>
+              <code>COUNT(*) OVER()</code> window function replaces COUNT-then-data double query
+            </>,
+            <>
+              CTE-based atomic conflict resolution in cart updates (
+              <code>WITH updated AS (UPDATE … RETURNING) SELECT EXISTS(...)</code>)
+            </>,
+            <>
+              pgx prepared-statement cache enabled (<code>QueryExecModeCacheDescribe</code>)
+            </>,
+            <>
+              Targeted indexes: <code>idx_orders_saga_step</code>, partial{" "}
+              <code>idx_products_low_stock WHERE stock &lt; 10</code>, composite{" "}
+              <code>idx_cart_items_user_reserved</code>
+            </>,
+            <>
+              Typed pgx error checks: <code>errors.Is(err, pgx.ErrNoRows)</code>,{" "}
+              <code>errors.As(err, &amp;pgconn.PgError)</code> for code <code>23505</code>
+            </>,
+          ]}
+          links={[
+            {
+              label: "Read the ADR",
+              href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/ecommerce/go-database-optimization.md",
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="schema"
+          title="Schema Design — Partitioning & Materialized Views"
+          narrative={
+            <>
+              <p>
+                Reporting workloads on a monotonically growing <code>orders</code> table forced a
+                schema-design pass. Range partitioning by <code>created_at</code> prunes scan scope;
+                three materialized views give constant-time reads for dashboard queries; CTE +
+                window functions express the rolling-average business logic without
+                application-side aggregation.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Range partitioning on <code>orders.created_at</code> (monthly), 18 months
+              pre-provisioned with a default catch-all partition
+            </>,
+            <>
+              Background goroutine creates partitions 3 months ahead daily; idempotent{" "}
+              <code>CREATE TABLE IF NOT EXISTS</code>
+            </>,
+            <>
+              Three materialized views (<code>mv_daily_revenue</code>,{" "}
+              <code>mv_product_performance</code>, <code>mv_customer_summary</code>) refreshed{" "}
+              <code>CONCURRENTLY</code> on a 15-min cadence
+            </>,
+            <>
+              Unique indexes per MV to support <code>REFRESH CONCURRENTLY</code>
+            </>,
+            <>
+              CTE-driven reporting with{" "}
+              <code>SUM(...) OVER (ORDER BY day ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)</code> for
+              rolling 7/30-day averages
+            </>,
+            <>
+              <code>DENSE_RANK()</code> for tie-aware top-N (turnover, top customers)
+            </>,
+            <>
+              Composite primary key trade-off documented (<code>(id, created_at)</code> removes
+              single-column FK target — referential integrity moves to the saga)
+            </>,
+          ]}
+          links={[
+            {
+              label: "Read the ADR",
+              href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/ecommerce/go-sql-optimization-reporting.md",
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="migrations"
+          title="Migration Safety — migration-lint"
+          narrative={
+            <>
+              <p>
+                <code>golang-migrate</code> catches syntactic errors when the migration runs against
+                Docker; it doesn&apos;t catch operationally unsafe DDL that&apos;s syntactically
+                valid. A custom Go linter (<code>migration-lint</code>) walks each{" "}
+                <code>.up.sql</code> AST via <code>libpg_query</code> and flags eight common
+                foot-guns at lint time, before any container starts.
+              </p>
+              <p>Each rule pairs with a recipe in a checked-in safe-migration runbook.</p>
+            </>
+          }
+          bullets={[
+            <>
+              Custom Go CLI built on <code>pganalyze/pg_query_go</code> (CGO wrapper around{" "}
+              <code>libpg_query</code>, the upstream PG parser)
+            </>,
+            <>
+              Eight rules: CREATE INDEX without CONCURRENTLY (MIG001), NOT NULL ADD COLUMN with
+              volatile default (MIG002), table-rewrite ALTER COLUMN TYPE (MIG003), CHECK without
+              NOT VALID (MIG004), DROP COLUMN (MIG005), RENAME COLUMN (MIG006), CONCURRENTLY mixed
+              with other DDL (MIG007), LOCK TABLE (MIG008)
+            </>,
+            <>
+              Per-statement opt-out:{" "}
+              <code>{`-- migration-lint: ignore=MIGNNN reason="..."`}</code> with mandatory{" "}
+              <code>reason=&quot;…&quot;</code>
+            </>,
+            <>
+              Wired into <code>make preflight-go-migrations</code> and the CI matrix as a hard
+              prerequisite to the runtime migration pipeline
+            </>,
+            <>Companion 8-recipe runbook</>,
+            <>
+              Worked example: <code>CREATE INDEX CONCURRENTLY</code> in its own migration file (
+              <code>go/product-service/migrations/005_add_product_search_index.up.sql</code>)
+            </>,
+          ]}
+          links={[
+            {
+              label: "Read the ADR",
+              href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/adr/database/migration-lint.md",
+            },
+            {
+              label: "Read the runbook",
+              href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/runbooks/postgres-migrations.md",
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="reliability"
+          title="Reliability & Recovery"
+          narrative={
+            <>
+              <p>
+                Production-grade SQL isn&apos;t only about queries. Postgres needs scheduled
+                backups, monitored health, and a written runbook for the day someone has to restore
+                from one. The portfolio&apos;s Postgres deployment ships with all three.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Automated <code>pg_dump</code> CronJob writing to a persistent volume on the Minikube
+              node; retention policy in the manifest
+            </>,
+            <>
+              Pod Disruption Budget on the StatefulSet (<code>maxUnavailable: 1</code>) so node
+              drains don&apos;t block on a single-replica DB
+            </>,
+            <>
+              <code>postgres_exporter</code> sidecar feeding Prometheus; Grafana dashboard surfaces
+              connection counts, replication lag, table sizes, and slow queries
+            </>,
+            <>
+              Alert rules: backup-job failure, replication-lag-too-high, disk-full,
+              long-running-transaction
+            </>,
+            <>
+              Written recovery runbook: step-by-step from <code>pg_dump</code> artifact to a
+              restored database
+            </>,
+          ]}
+          links={[
+            {
+              label: "Read the runbook",
+              href: "https://github.com/kabradshaw1/portfolio/blob/main/docs/runbooks/postgres-recovery.md",
+            },
+          ]}
+        />
+      </div>
+
+      {/* Desktop sidebar TOC: right column at md+. */}
+      <aside className="hidden md:block">
+        <StickyTocSidebar items={tocItems} />
+      </aside>
     </div>
   );
 }

--- a/frontend/src/components/database/PostgresTab.tsx
+++ b/frontend/src/components/database/PostgresTab.tsx
@@ -1,0 +1,7 @@
+export function PostgresTab() {
+  return (
+    <div data-testid="postgres-tab">
+      <p className="text-muted-foreground">PostgreSQL content — coming in Task 5.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/database/StickyToc.tsx
+++ b/frontend/src/components/database/StickyToc.tsx
@@ -11,7 +11,8 @@ export type StickyTocProps = {
   items: StickyTocItem[];
 };
 
-export function StickyToc({ items }: StickyTocProps) {
+/** Tracks which section is currently most-prominent in the viewport. */
+function useActiveSection(items: StickyTocItem[]): string {
   const [activeId, setActiveId] = useState<string>(items[0]?.id ?? "");
 
   useEffect(() => {
@@ -25,8 +26,8 @@ export function StickyToc({ items }: StickyTocProps) {
 
     // Pick the section closest to the top of the viewport that is still
     // intersecting. The rootMargin biases toward sections whose top has
-    // crossed about 25% of the viewport, which avoids flicker when two
-    // sections are partially in view.
+    // crossed about 25% of the viewport, avoiding flicker when two sections
+    // are partially in view.
     const observer = new IntersectionObserver(
       (entries) => {
         const visible = entries
@@ -46,56 +47,64 @@ export function StickyToc({ items }: StickyTocProps) {
     return () => observer.disconnect();
   }, [items]);
 
-  return (
-    <>
-      {/* Mobile: horizontal chip row */}
-      <nav
-        aria-label="Section navigation"
-        className="md:hidden -mx-6 mb-6 overflow-x-auto px-6"
-        data-testid="sticky-toc-mobile"
-      >
-        <ul className="flex gap-2 whitespace-nowrap">
-          {items.map((item) => (
-            <li key={item.id}>
-              <a
-                href={`#${item.id}`}
-                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
-                  activeId === item.id
-                    ? "border-primary text-foreground bg-accent"
-                    : "border-foreground/10 text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
+  return activeId;
+}
 
-      {/* Desktop: sticky right-column TOC */}
-      <nav
-        aria-label="Section navigation"
-        className="hidden md:block sticky top-24 self-start"
-        data-testid="sticky-toc-desktop"
-      >
-        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-3">On this page</p>
-        <ul className="space-y-2 border-l border-foreground/10">
-          {items.map((item) => (
-            <li key={item.id}>
-              <a
-                href={`#${item.id}`}
-                className={`block border-l-2 pl-3 -ml-px text-sm transition-colors ${
-                  activeId === item.id
-                    ? "border-primary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                {item.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
-    </>
+/** Mobile horizontal chip row — render once at the top of the tab content. */
+export function StickyTocChips({ items }: StickyTocProps) {
+  const activeId = useActiveSection(items);
+  return (
+    <nav
+      aria-label="Section navigation"
+      className="-mx-6 mb-6 overflow-x-auto px-6"
+      data-testid="sticky-toc-chips"
+    >
+      <ul className="flex gap-2 whitespace-nowrap">
+        {items.map((item) => (
+          <li key={item.id}>
+            <a
+              href={`#${item.id}`}
+              className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                activeId === item.id
+                  ? "border-primary text-foreground bg-accent"
+                  : "border-foreground/10 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+/** Desktop sticky right-column TOC — render once inside an `<aside>`. */
+export function StickyTocSidebar({ items }: StickyTocProps) {
+  const activeId = useActiveSection(items);
+  return (
+    <nav
+      aria-label="Section navigation"
+      className="sticky top-24 self-start"
+      data-testid="sticky-toc-sidebar"
+    >
+      <p className="text-xs uppercase tracking-wide text-muted-foreground mb-3">On this page</p>
+      <ul className="space-y-2 border-l border-foreground/10">
+        {items.map((item) => (
+          <li key={item.id}>
+            <a
+              href={`#${item.id}`}
+              className={`block border-l-2 pl-3 -ml-px text-sm transition-colors ${
+                activeId === item.id
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }

--- a/frontend/src/components/database/StickyToc.tsx
+++ b/frontend/src/components/database/StickyToc.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type StickyTocItem = {
+  id: string;
+  label: string;
+};
+
+export type StickyTocProps = {
+  items: StickyTocItem[];
+};
+
+export function StickyToc({ items }: StickyTocProps) {
+  const [activeId, setActiveId] = useState<string>(items[0]?.id ?? "");
+
+  useEffect(() => {
+    if (typeof window === "undefined" || items.length === 0) return;
+
+    const sections = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (sections.length === 0) return;
+
+    // Pick the section closest to the top of the viewport that is still
+    // intersecting. The rootMargin biases toward sections whose top has
+    // crossed about 25% of the viewport, which avoids flicker when two
+    // sections are partially in view.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      {
+        rootMargin: "-25% 0px -65% 0px",
+        threshold: 0,
+      },
+    );
+
+    sections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, [items]);
+
+  return (
+    <>
+      {/* Mobile: horizontal chip row */}
+      <nav
+        aria-label="Section navigation"
+        className="md:hidden -mx-6 mb-6 overflow-x-auto px-6"
+        data-testid="sticky-toc-mobile"
+      >
+        <ul className="flex gap-2 whitespace-nowrap">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  activeId === item.id
+                    ? "border-primary text-foreground bg-accent"
+                    : "border-foreground/10 text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Desktop: sticky right-column TOC */}
+      <nav
+        aria-label="Section navigation"
+        className="hidden md:block sticky top-24 self-start"
+        data-testid="sticky-toc-desktop"
+      >
+        <p className="text-xs uppercase tracking-wide text-muted-foreground mb-3">On this page</p>
+        <ul className="space-y-2 border-l border-foreground/10">
+          {items.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className={`block border-l-2 pl-3 -ml-px text-sm transition-colors ${
+                  activeId === item.id
+                    ? "border-primary text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+}

--- a/frontend/src/components/database/VectorTab.tsx
+++ b/frontend/src/components/database/VectorTab.tsx
@@ -1,7 +1,24 @@
+import Link from "next/link";
+
 export function VectorTab() {
   return (
-    <div data-testid="vector-tab">
-      <p className="text-muted-foreground">Vector content — coming in Task 6.</p>
+    <div data-testid="vector-tab" className="space-y-6">
+      <p className="text-muted-foreground leading-relaxed">
+        Qdrant backs the retrieval layer behind the Document Q&amp;A
+        assistant and the code-aware Debug Assistant — chunked PDF
+        embeddings, code-aware splitting, and approximate-nearest-neighbor
+        search feeding RAG prompts. A dedicated vector-database section is
+        on the way; for now, the running code and its supporting docs live
+        on the AI page.
+      </p>
+      <div>
+        <Link
+          href="/ai"
+          className="inline-flex items-center gap-2 rounded-lg border px-6 py-3 text-sm font-medium hover:bg-accent transition-colors"
+        >
+          View vector DB usage in /ai &rarr;
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/database/VectorTab.tsx
+++ b/frontend/src/components/database/VectorTab.tsx
@@ -1,0 +1,7 @@
+export function VectorTab() {
+  return (
+    <div data-testid="vector-tab">
+      <p className="text-muted-foreground">Vector content — coming in Task 6.</p>
+    </div>
+  );
+}

--- a/frontend/src/components/database/tabs.ts
+++ b/frontend/src/components/database/tabs.ts
@@ -1,0 +1,7 @@
+export type DatabaseTab = "postgres" | "nosql" | "vector";
+
+export const databaseTabs: { key: DatabaseTab; label: string }[] = [
+  { key: "postgres", label: "PostgreSQL" },
+  { key: "nosql", label: "NoSQL" },
+  { key: "vector", label: "Vector" },
+];


### PR DESCRIPTION
## Summary

- New top-level `/database` page surfaces existing PostgreSQL work under a single recruiter-discoverable URL.
- Three-tab layout: PostgreSQL (full content), NoSQL (stub → /java), Vector (stub → /ai).
- PostgreSQL tab is single-scroll across four pillars (Query Optimization, Schema Design, Migration Safety, Reliability & Recovery), each with a narrative paragraph, 4–7 keyword-rich bullets, and links to the matching ADR / runbook.
- `IntersectionObserver`-driven sticky TOC on the right column (desktop) / chip row (mobile).
- Homepage gets a new "Database Engineering" card slotted between CI/CD and Security.

## Closes / refs

- Spec: `docs/superpowers/specs/2026-04-27-database-portfolio-page-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-database-portfolio-page.md`
- Surfaces work from `docs/adr/ecommerce/go-database-optimization.md`, `docs/adr/ecommerce/go-sql-optimization-reporting.md`, `docs/adr/database/migration-lint.md`, and `docs/runbooks/postgres-recovery.md`.

## Test plan

- [x] Local: `npm run e2e -- database-page.spec.ts` — 12 tests pass
- [x] Local: `make preflight-frontend` — tsc + eslint + next build clean
- [x] Local: `make preflight-e2e` — full mocked suite passes (43 tests)
- [ ] CI: Frontend Checks job passes
- [ ] CI: e2e job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)