### PR TITLE
fix(qa-overlay): exclude WAL-archive PVCs + pin volumeName

### DIFF
--- a/java/k8s/volumes/postgres-basebackup-pv.yml
+++ b/java/k8s/volumes/postgres-basebackup-pv.yml
@@ -22,6 +22,8 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: manual
+  # Pin to the named PV so two PVCs of identical shape can't cross-bind.
+  volumeName: postgres-basebackup-pv
   resources:
     requests:
       storage: 10Gi

--- a/java/k8s/volumes/postgres-wal-archive-pv.yml
+++ b/java/k8s/volumes/postgres-wal-archive-pv.yml
@@ -22,6 +22,8 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: manual
+  # Pin to the named PV so two PVCs of identical shape can't cross-bind.
+  volumeName: postgres-wal-archive-pv
   resources:
     requests:
       storage: 10Gi

--- a/k8s/overlays/qa-java/kustomization.yaml
+++ b/k8s/overlays/qa-java/kustomization.yaml
@@ -189,3 +189,25 @@ patches:
       kind: Job
       metadata:
         name: postgres-replicator-bootstrap
+  # --- Remove WAL-archive PVCs (the underlying PVs are claimed by prod) ---
+  # Without these deletes, QA's PVCs raced prod's for the only two matching PVs
+  # and cross-bound, leaving prod's postgres pod unschedulable.
+  # See incident note in docs/runbooks/postgres-recovery.md.
+  - target:
+      kind: PersistentVolumeClaim
+      name: postgres-wal-archive
+    patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: postgres-wal-archive
+  - target:
+      kind: PersistentVolumeClaim
+      name: postgres-basebackup
+    patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: postgres-basebackup


### PR DESCRIPTION
## Summary

**Hotfix** for the 2026-04-28 outage where both prod (\`main\`) and QA went down because postgres couldn't schedule.

**Root cause:** the QA java overlay deletes the postgres Deployment and the \`postgres-data\` PVC (QA shares prod's Postgres) but PR #174 added two new PVCs (\`postgres-wal-archive\`, \`postgres-basebackup\`) without matching delete patches. Both PVCs are 10Gi RWO \`manual\` storage class — identical to each other and to the only two matching PVs. QA's PVCs race-claimed prod's PVs (cross-bound — QA's \`postgres-wal-archive\` PVC bound to \`postgres-basebackup-pv\`, and vice versa). Prod's PVCs sat \`Pending\`, postgres pod never scheduled, every dependent service crash-looped.

**Two-part fix:**
1. QA overlay \`\$patch: delete\` on both new PVCs so QA stops emitting them — mirrors the existing \`postgres-pvc\` delete pattern in the same file.
2. \`volumeName\` pin on the base PVCs so any future identically-shaped PVC can't cross-bind even if the overlay regresses again.

**Cluster recovered manually** before this PR — kubectl-deleted the bad QA PVCs, cleared \`claimRef\` on both PVs, re-applied the prod PVCs with explicit \`volumeName\`, force-recreated the postgres pod. Public smoke endpoints (\`/go-auth/health\`, \`/go-products/products\`) returning 200 across both envs.

**Operator action still pending (separate from this PR):** the live \`java-secrets\` Secret needs both \`replicator-password\` (for the basebackup CronJob) and \`grafana-reader-password\` (pre-existing — its bootstrap Job has been failing for 8h+) added. Both Jobs are \`CreateContainerConfigError\` until that's done; neither blocks the cluster.

## Test plan
- [ ] \`kubectl kustomize k8s/overlays/qa-java/\` emits zero \`PersistentVolumeClaim\` resources (verified locally)
- [ ] CI green on \`qa\`
- [ ] After deploy to QA: only the prod \`postgres-wal-archive\` and \`postgres-basebackup\` PVCs exist (both \`Bound\`), no QA copies
- [ ] After deploy to main: postgres pod stays Running, public smoke endpoints return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)