### PR TITLE
feat: streaming read replica for reporting (db-roadmap 7/10)

### DIFF
--- a/docs/adr/database/read-replica.md
+++ b/docs/adr/database/read-replica.md
@@ -1,0 +1,157 @@
+# ADR: PostgreSQL Streaming Read Replica for Reporting
+
+- **Date:** 2026-04-28
+- **Status:** Accepted
+- **Roadmap position:** Item 7 of 10 in the `db-roadmap` GitHub label
+- **GitHub issue:** [#161 — Streaming read replica for reporting](https://github.com/kabradshaw1/portfolio/issues/161)
+- **Spec:** [`docs/superpowers/specs/2026-04-27-read-replica-design.md`](../../superpowers/specs/2026-04-27-read-replica-design.md)
+- **Builds on:** [`wal-archiving-pitr.md`](./wal-archiving-pitr.md) — the `replicator` role and primary's WAL configuration
+
+## Context
+
+The order-service exposes a `/reporting/*` endpoint group backed by three
+materialized views (`mv_daily_revenue`, `mv_product_performance`,
+`mv_customer_summary`) and a handful of CTE-based queries. Until this work
+landed, those reads competed with OLTP traffic on the same Postgres pod —
+same I/O queue, same CPU, same `shared_buffers`.
+
+This is fine at portfolio scale, but it's the opposite of how production
+teams scale Postgres reads. The standard playbook is *primary serves
+writes + latency-sensitive reads, async replicas serve read-heavy traffic.*
+Implementing it here is both an operational improvement (reporting reads
+no longer compete with OLTP) and a portfolio demonstration of vocabulary
+that comes up in every database-adjacent interview ("read/write split,"
+"physical vs. logical replication," "replication slots").
+
+## Decision
+
+Stand up a single async streaming read replica as a `StatefulSet` in
+`java-tasks`, bootstrapped from the primary via `pg_basebackup` using a
+named physical replication slot (`replica_1`). Wire the order-service to
+use two `pgxpool` instances — one against the primary, one against the
+replica — and route the existing reporting handler's reads to the replica
+pool. Reporting writes (materialized-view refresh) stay on the primary.
+
+## Considered alternatives
+
+### Logical replication (`wal_level=logical`, publication/subscription)
+
+**Rejected for this use case.** Logical replication ships per-row CDC
+events, not raw WAL bytes; subscribers can be on different schemas, can
+filter tables, and can target a different major version. That flexibility
+costs (a) replay throughput, (b) handling of DDL (logical replication
+*doesn't* replicate DDL — schema changes have to be coordinated by hand),
+and (c) materialized views, which logical replication doesn't replicate at
+all.
+
+We want a *byte-identical* copy of the primary because the consumers are
+reading the same materialized views that already exist on the primary;
+physical streaming gives that for free. Logical replication is on the
+roadmap (issue #163) for genuinely-different needs — feeding analytics
+warehouses, downstream consumers — where the trade-off flips.
+
+### Connection-string-level read/write split
+
+`pgx` and pooled drivers can be configured with multiple hosts and a
+`target_session_attrs=read-only` hint. The driver picks a read-only host
+when the application opens a transaction it has marked read-only.
+
+**Rejected** because it pushes routing into per-call ergonomics: every
+reporting query becomes "remember to set the session attr" or "remember
+to pass the right context tag." The two-pool approach makes the
+distinction structural — the reporting repository is *constructed* with a
+replica pool and physically cannot accidentally write through it. The
+trade-off is one extra config knob; the upside is that the routing rule
+is enforced by the type system, not by reviewer vigilance.
+
+### Sync replication (`synchronous_commit = on` + `synchronous_standby_names`)
+
+Sync replication trades write latency for zero-data-loss HA. We don't have
+the latency budget on the primary's commit path for that — and reporting
+reads tolerate sub-second staleness easily because the materialized views
+they query are *already* refreshed every 15 minutes. Sync replication is
+the right answer for a different problem (durability), not this one
+(read scaling).
+
+### Multi-replica fan-out (replicas: 2+)
+
+A single replica is sufficient for current reporting load and doubles as
+passive HA (Scenario 5 in the postgres recovery runbook). Going to two
+replicas is a one-line StatefulSet change when load justifies it; doing
+it now would be premature.
+
+## Why a replication slot — and the trade-off
+
+Streaming replication can run with or without a named slot. Without one,
+primary prunes WAL on its normal recycle schedule; if the replica falls
+behind by more than that, it's lost (and `pg_basebackup` re-bootstrap is
+the only recovery). With a slot, primary keeps WAL until *the slot* says
+the replica acknowledged it.
+
+The cost is that an offline replica forces the primary's `pg_wal/`
+directory to grow. Without a guard, a long-dead replica would fill the
+primary's data volume and take it down. The mitigation is
+`max_slot_wal_keep_size = 4GB` on the primary: once the slot's retention
+crosses 4GB, Postgres invalidates it rather than keep retaining WAL. The
+replica then needs `pg_basebackup` again — but the primary stays up, which
+is the right priority.
+
+The `Postgres Replication Slot Lag High` alert fires before invalidation
+hits, so a healthy operator response is "go fix the replica" rather than
+"go promote a fallback."
+
+## Async replication is fine here
+
+The materialized views the reporting handler reads are already 15-minute
+stale by design (the refresh interval). Layering sub-second async-replica
+lag on top is invisible to consumers — staleness was already accepted at
+a much coarser granularity. The `Postgres Replication Lag High` alert
+fires at 30s, which is well inside that envelope.
+
+## Scope: order-service reporting only, not all reads
+
+Decisions about which reads to route through the replica are case-by-case:
+some reads are latency-sensitive (auth lookups, cart reads) and should
+stay on the primary even though they could technically run on the
+replica. The reporting handler is the obvious candidate because it's
+already read-only, already non-latency-sensitive, and already serving
+stale-by-design data. Future routing decisions for other handlers should
+be made when those handlers' workloads warrant it, not as part of this
+ADR.
+
+## Promotion = manual
+
+`pg_promote()` is a one-line failover (see Scenario 5 in the postgres
+recovery runbook), and at portfolio scale that's appropriate. Patroni or
+repmgr would automate this — and would also bring leader election,
+fencing, and consensus, which are appropriate when the cost of being
+*wrong* about who the primary is exceeds the cost of running a consensus
+layer. We're not there yet.
+
+## Consequences
+
+**Positive:**
+- The OLTP path on primary is no longer competing with reporting I/O.
+- Read scaling is now horizontal — additional replicas are a one-line
+  StatefulSet change.
+- Replica is also passive HA — manual promotion is a documented one-step
+  procedure.
+- "How do you scale Postgres reads?" stops being a theoretical
+  interview answer and becomes a live demo.
+
+**Trade-offs:**
+- One more pod, one more PVC (10Gi), one more exporter to scrape. Modest.
+- An offline replica still puts WAL pressure on the primary up to the
+  `max_slot_wal_keep_size` ceiling — observable, alerted, but real.
+- Replica is on the same Minikube node as primary, so a node-level
+  failure takes both down. That's a Phase 3 (multi-node) problem.
+- Reporting queries that *would* benefit from replica-side write caching
+  (e.g., a future write-back caching layer) won't get it; reporting reads
+  are uncached on the replica end.
+
+**Phase 2 follow-ups:**
+- Replica-aware PgBouncer pools (`*_ro` routing).
+- Second replica for true HA.
+- Patroni or repmgr for automated failover.
+- Logical replication (`wal_level = logical`) as a separate feature for
+  CDC / downstream consumers (roadmap #163).

--- a/docs/runbooks/postgres-recovery.md
+++ b/docs/runbooks/postgres-recovery.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The shared PostgreSQL instance (`postgres` deployment in `java-tasks` namespace) hosts all Go and Java service databases. This runbook covers four recovery scenarios ordered by severity.
+The shared PostgreSQL instance (`postgres` deployment in `java-tasks` namespace) hosts all Go and Java service databases. This runbook covers five recovery scenarios ordered by severity.
 
 **Related alerts:**
 - `Postgres Backup Stale` — no successful pg_dump in 26h → Scenario 2
@@ -14,6 +14,9 @@ The shared PostgreSQL instance (`postgres` deployment in `java-tasks` namespace)
 - `Postgres Archive Command Failing` — `archive_command` exiting non-zero → Scenario 4 (preventive — not a recovery trigger by itself)
 - `Postgres WAL Archive Stale` — no new WAL archived in 10+ min → Scenario 4 (preventive)
 - `Postgres Base Backup Stale` — no successful weekly base backup in 8d → Scenario 4 (preventive)
+- `Postgres Replication Lag High` — replica replay lag > 30s → Scenario 5 (review, not yet promote)
+- `Postgres Replication Slot Lag High` — slot is inactive or near `max_slot_wal_keep_size` → Scenario 5 (review)
+- `Postgres Replica Down` — replica pod is gone → Scenario 5 (review)
 
 **Backup locations on the Debian host:**
 - `/backups/postgres/` — daily `pg_dump` per database (Scenario 2)
@@ -369,3 +372,81 @@ Restoring from backup preserves data created after the last seed run.
 - If the target timestamp turned out to be wrong, you can re-run this entire
   procedure from the same base backup tarball; the WAL archive is unchanged
   by the restore.
+
+---
+
+## Scenario 5: Promote the Replica (primary is unrecoverable)
+
+### Symptoms
+
+- Primary postgres pod won't start (`CrashLoopBackOff`) and the data PVC is
+  unrecoverable, so neither Scenario 1 (fresh PVC) nor Scenario 2 (pg_dump
+  restore) will preserve the most recent writes.
+- A failover drill — exercising the replica as the primary on demand.
+
+This is the *physical* HA scenario. If Postgres is healthy but data is
+logically wrong, use Scenario 4 (PITR) instead.
+
+### Prerequisites
+
+- The streaming replica (`postgres-replica-0` StatefulSet) is running and
+  caught up — verify before you do anything destructive:
+  ```bash
+  ssh debian "kubectl exec -n java-tasks postgres-replica-0 -c postgres -- \
+    psql -U taskuser -d postgres -c 'SELECT pg_is_in_recovery(), pg_last_wal_replay_lsn(), pg_last_xact_replay_timestamp();'"
+  ```
+  Expect `t` (true — still a standby) and a recent timestamp. If the replica
+  is hours behind the primary's last known state, accept that loss before
+  proceeding — promotion turns "current replay LSN" into the new source of
+  truth.
+
+**Estimated time:** 5-10 minutes.
+
+### Steps
+
+1. **Stop traffic to the broken primary.** Scaling its Deployment to zero
+   prevents apps from racing to reconnect during promotion:
+   ```bash
+   ssh debian "kubectl scale deployment postgres -n java-tasks --replicas=0"
+   ssh debian "kubectl wait --for=delete pod -l app=postgres -n java-tasks --timeout=60s"
+   ```
+
+2. **Confirm replay is current,** then promote:
+   ```bash
+   ssh debian "kubectl exec -n java-tasks postgres-replica-0 -c postgres -- \
+     psql -U taskuser -d postgres -c 'SELECT pg_promote();'"
+   ```
+   `pg_promote()` returns `t` once the replica becomes a normal read-write
+   primary. `pg_is_in_recovery()` should now return `f`.
+
+3. **Repoint the `postgres` Service at the promoted pod** so applications
+   don't have to be re-configured. Patch the Service selector:
+   ```bash
+   ssh debian "kubectl patch service postgres -n java-tasks --type=merge \
+     -p '{\"spec\":{\"selector\":{\"app\":\"postgres-replica\"}}}'"
+   ```
+   Existing pods will reconnect on their next pool health-check tick. The
+   `postgres-replica` Service still resolves the same pod, so anything that
+   was already pointed at the replica (e.g., order-service reporting reads)
+   keeps working.
+
+4. **Verify applications are healthy:**
+   ```bash
+   ssh debian "curl -s -o /dev/null -w '%{http_code}' http://192.168.49.2/go-auth/health"
+   ssh debian "curl -s -o /dev/null -w '%{http_code}' http://192.168.49.2/go-products/products"
+   ```
+
+### After-action
+
+- The promoted instance is the new primary; the old `postgres` Deployment
+  data PVC is left untouched for forensics. Do NOT scale the old Deployment
+  back up against that PVC — it will try to start as a standalone primary
+  and split-brain the cluster.
+- Bring up a *new* replica by recycling the StatefulSet's PVC and letting
+  the bootstrap initContainer re-run `pg_basebackup` against the new
+  primary. This is the "first deploy" path; no special procedure is needed.
+- Take a fresh `pg_dump` and `pg_basebackup` against the new primary so the
+  rest of the recovery toolchain is anchored to the new timeline.
+- Automated failover (Patroni / repmgr) is the long-term answer; this
+  manual procedure exists because the trade-off (operational simplicity vs.
+  RTO) is appropriate for portfolio scale.

--- a/docs/superpowers/plans/2026-04-28-read-replica.md
+++ b/docs/superpowers/plans/2026-04-28-read-replica.md
@@ -1,0 +1,40 @@
+# Plan: Streaming Read Replica (db-roadmap 7/10)
+
+Spec: `docs/superpowers/specs/2026-04-27-read-replica-design.md`
+Issue: #161
+Branch: `agent/feat-read-replica`
+
+## Step 1 — Primary postgres config (set replication knobs explicitly)
+- `java/k8s/deployments/postgres.yml`: append `-c max_wal_senders=10 -c max_replication_slots=10 -c max_slot_wal_keep_size=4GB -c hot_standby=on` to `args`. (The PG17 defaults already set `max_wal_senders=10` and `max_replication_slots=10`, but we make them explicit so the safety rail and intent are self-documenting.)
+
+## Step 2 — Replica StatefulSet, scripts, service, PVC
+- `java/k8s/configmaps/postgres-replica-scripts.yml` — bootstrap-replica.sh (idempotent pg_basebackup using slot `replica_1`).
+- `java/k8s/statefulsets/postgres-replica.yml` — single-replica StatefulSet, initContainer running bootstrap, postgres container, postgres-exporter sidecar, volumeClaimTemplate.
+- `java/k8s/services/postgres-replica.yml` — ClusterIP service on 5432 selecting replica pods.
+- `java/k8s/kustomization.yaml` — register the new resources.
+- `java/k8s/network-policy.yml` — allow ingress to replica from go-ecommerce + monitoring (review existing rules).
+
+## Step 3 — Order-service: two-pool wiring
+- `go/order-service/cmd/server/config.go` — add `DatabaseURLReplica` (env `DATABASE_URL_REPLICA`); fall back to `DatabaseURL` when unset.
+- `go/order-service/internal/db/pools.go` — new `Pools` struct (`Primary`, `Reporting`); `newPool` sets `application_name` runtime param.
+- `go/order-service/cmd/server/deps.go` — replace `connectPostgres` callsite with `db.New`; existing single-pool callers continue against `Primary`.
+- `go/order-service/cmd/server/main.go` — pass `pools.Reporting` to `reporting.NewRepository`; primary pool unchanged everywhere else; refresher stays on primary.
+- `go/k8s/configmaps/order-service-config.yml` — add `DATABASE_URL_REPLICA` pointing at `postgres-replica.java-tasks.svc.cluster.local:5432`.
+
+No changes required to existing reporting tests — `NewRepository` signature unchanged; the test still passes any `*pgxpool.Pool`.
+
+## Step 4 — Observability
+- `k8s/monitoring/configmaps/grafana-alerting.yml` — append three rules to the `PostgreSQL` group: `PgReplicationLagHigh`, `PgReplicationSlotLagHigh`, `PgReplicaDown`.
+- `k8s/monitoring/configmaps/grafana-dashboards.yml` — append three panels to the `postgresql` dashboard: replica lag, slot retention bytes, replica replay LSN vs primary LSN.
+- `docs/runbooks/postgres-recovery.md` — append "Scenario 5: Promote the replica".
+
+## Step 5 — ADR
+- `docs/adr/database/read-replica.md` — physical vs logical, slot trade-off + `max_slot_wal_keep_size`, two-pool vs URL-level split, async durability, scope.
+
+## Step 6 — Lint + commit + PR
+- `make preflight-go` (order-service builds with the new pool wiring).
+- Commit by step (k8s primary tweak, replica resources, app wiring + config, observability, runbook + ADR, plan).
+- Push to `qa`-targeted PR.
+
+## Out of scope
+- Multi-replica fan-out, automated failover (Patroni/repmgr), replica-aware PgBouncer routing, logical replication, integration test for streaming pair (testcontainers two-container chain is heavy and out-of-scope per spec scoping; existing nil-pool unit tests on reporting repo are unchanged).

--- a/go/k8s/configmaps/order-service-config.yml
+++ b/go/k8s/configmaps/order-service-config.yml
@@ -4,7 +4,13 @@ metadata:
   name: order-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable&application_name=order-service
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable
+  # Reporting reads (mv_daily_revenue / mv_product_performance /
+  # mv_customer_summary) target the streaming read replica. internal/db.New
+  # sets application_name on each pool so primary ("order-service") vs
+  # reporting ("order-service-reporting") traffic is distinguishable in
+  # pg_stat_activity on either endpoint.
+  DATABASE_URL_REPLICA: postgres://taskuser:taskpass@postgres-replica.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   RABBITMQ_URL: amqp://guest:guest@rabbitmq.java-tasks.svc.cluster.local:5672
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev

--- a/go/order-service/cmd/server/config.go
+++ b/go/order-service/cmd/server/config.go
@@ -8,9 +8,10 @@ import (
 
 // Config holds all environment-driven configuration for the ecommerce service.
 type Config struct {
-	DatabaseURL  string // required
-	JWTSecret    string // required
-	RabbitmqURL  string // required
+	DatabaseURL        string // required
+	DatabaseURLReplica string // optional; falls back to DatabaseURL when unset
+	JWTSecret          string // required
+	RabbitmqURL        string // required
 	AllowedOrigins string // default "http://localhost:3000"
 	Port           string // default "8092"
 	RedisURL       string // optional
@@ -28,9 +29,10 @@ type Config struct {
 // It fatals on missing required values.
 func loadConfig() Config {
 	cfg := Config{
-		DatabaseURL:    os.Getenv("DATABASE_URL"),
-		JWTSecret:      os.Getenv("JWT_SECRET"),
-		RabbitmqURL:    os.Getenv("RABBITMQ_URL"),
+		DatabaseURL:        os.Getenv("DATABASE_URL"),
+		DatabaseURLReplica: os.Getenv("DATABASE_URL_REPLICA"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
+		RabbitmqURL:        os.Getenv("RABBITMQ_URL"),
 		AllowedOrigins: os.Getenv("ALLOWED_ORIGINS"),
 		Port:           os.Getenv("PORT"),
 		RedisURL:       os.Getenv("REDIS_URL"),

--- a/go/order-service/cmd/server/deps.go
+++ b/go/order-service/cmd/server/deps.go
@@ -5,39 +5,12 @@ import (
 	"log"
 	"log/slog"
 	"strings"
-	"time"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/redis/go-redis/v9"
 
 	appkafka "github.com/kabradshaw1/portfolio/go/order-service/internal/kafka"
 )
-
-// connectPostgres creates a tuned pgxpool connection.
-func connectPostgres(ctx context.Context, databaseURL string) *pgxpool.Pool {
-	poolConfig, err := pgxpool.ParseConfig(databaseURL)
-	if err != nil {
-		log.Fatalf("failed to parse database URL: %v", err)
-	}
-	poolConfig.MaxConns = 25
-	poolConfig.MinConns = 5
-	poolConfig.MaxConnIdleTime = 5 * time.Minute
-	poolConfig.MaxConnLifetime = 30 * time.Minute
-	poolConfig.HealthCheckPeriod = 30 * time.Second
-	poolConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheDescribe
-
-	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
-	if err != nil {
-		log.Fatalf("failed to connect to database: %v", err)
-	}
-	if err := pool.Ping(ctx); err != nil {
-		log.Fatalf("failed to ping database: %v", err)
-	}
-	slog.Info("connected to database")
-	return pool
-}
 
 // connectRedis optionally connects to Redis. Returns nil if URL is empty or unreachable.
 func connectRedis(ctx context.Context, redisURL string) *redis.Client {

--- a/go/order-service/cmd/server/main.go
+++ b/go/order-service/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kabradshaw1/portfolio/go/auth-service/authmiddleware"
 	authpb "github.com/kabradshaw1/portfolio/go/auth-service/pb/auth/v1"
 	"github.com/kabradshaw1/portfolio/go/order-service/internal/cartclient"
+	"github.com/kabradshaw1/portfolio/go/order-service/internal/db"
 	"github.com/kabradshaw1/portfolio/go/order-service/internal/handler"
 	"github.com/kabradshaw1/portfolio/go/order-service/internal/partition"
 	"github.com/kabradshaw1/portfolio/go/order-service/internal/paymentclient"
@@ -46,7 +47,14 @@ func main() {
 	))
 	buildinfo.Log()
 
-	pool := connectPostgres(ctx, cfg.DatabaseURL)
+	pools, err := db.New(ctx, cfg.DatabaseURL, cfg.DatabaseURLReplica)
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+	pool := pools.Primary
+	slog.Info("connected to database",
+		"replica_configured", cfg.DatabaseURLReplica != "",
+	)
 
 	redisClient := connectRedis(ctx, cfg.RedisURL)
 
@@ -149,8 +157,10 @@ func main() {
 	refresher := reporting.NewRefresher(pool, 15*time.Minute)
 	go refresher.Run(ctx)
 
-	// Create reporting repository and handler
-	reportingRepo := reporting.NewRepository(pool, pgBreaker)
+	// Create reporting repository and handler. Reporting reads target the
+	// streaming read replica when DATABASE_URL_REPLICA is set; otherwise
+	// pools.Reporting falls back to the primary (see internal/db.New).
+	reportingRepo := reporting.NewRepository(pools.Reporting, pgBreaker)
 	reportingHandler := handler.NewReportingHandler(reportingRepo)
 
 	orderSvc := service.NewOrderService(orderRepo, cartClient, orch)
@@ -208,7 +218,7 @@ func main() {
 	sm.Register("drain-http", 0, shutdown.DrainHTTP("order-http", srv))
 	sm.Register("wait-saga", 10, shutdown.WaitForInflight("order-saga", consumer.IsIdle, 100*time.Millisecond))
 	sm.Register("postgres", 20, func(_ context.Context) error {
-		pool.Close()
+		pools.Close()
 		return nil
 	})
 	sm.Register("rabbitmq", 20, func(_ context.Context) error {

--- a/go/order-service/internal/db/pools.go
+++ b/go/order-service/internal/db/pools.go
@@ -1,0 +1,108 @@
+// Package db wires the order-service's PostgreSQL connection pools.
+//
+// The service uses two physical pools that point at different Postgres
+// instances:
+//
+//   - Primary    — the read/write primary (postgres.java-tasks). All OLTP
+//                  traffic (orders CRUD, saga state, partition maintenance,
+//                  materialized-view refresh) runs here.
+//   - Reporting  — an async streaming read replica (postgres-replica.java-tasks)
+//                  that serves the /reporting/* endpoints. Falls back to the
+//                  primary DSN when DATABASE_URL_REPLICA is unset (local dev,
+//                  CI, single-pod environments).
+//
+// Each pool sets a distinct `application_name` runtime parameter so primary
+// vs reporting traffic is trivially distinguishable in pg_stat_activity —
+// "did the reporting reads actually move off the primary?" becomes a single
+// query instead of guesswork.
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Pool tuning constants — kept here (not magic numbers in newPool) so that
+// any future per-pool divergence (e.g., a smaller MaxConns on the replica)
+// is a one-line change with explanatory context.
+const (
+	poolMaxConns          = 25
+	poolMinConns          = 5
+	poolMaxConnIdleTime   = 5 * time.Minute
+	poolMaxConnLifetime   = 30 * time.Minute
+	poolHealthCheckPeriod = 30 * time.Second
+)
+
+// Pools holds the physical connection pools used by the order-service.
+type Pools struct {
+	Primary   *pgxpool.Pool
+	Reporting *pgxpool.Pool
+}
+
+// New connects both pools. If replicaDSN is empty, the reporting pool is
+// pointed at the primary DSN — this keeps local dev and CI working without
+// a second Postgres instance, and the application_name still differentiates
+// the traffic in pg_stat_activity.
+func New(ctx context.Context, primaryDSN, replicaDSN string) (*Pools, error) {
+	primary, err := newPool(ctx, primaryDSN, "order-service")
+	if err != nil {
+		return nil, fmt.Errorf("primary pool: %w", err)
+	}
+
+	effectiveReplicaDSN := replicaDSN
+	if effectiveReplicaDSN == "" {
+		effectiveReplicaDSN = primaryDSN
+	}
+	reporting, err := newPool(ctx, effectiveReplicaDSN, "order-service-reporting")
+	if err != nil {
+		primary.Close()
+		return nil, fmt.Errorf("reporting pool: %w", err)
+	}
+
+	return &Pools{Primary: primary, Reporting: reporting}, nil
+}
+
+// Close shuts down both pools. Safe to call once on shutdown.
+func (p *Pools) Close() {
+	if p == nil {
+		return
+	}
+	if p.Reporting != nil && p.Reporting != p.Primary {
+		p.Reporting.Close()
+	}
+	if p.Primary != nil {
+		p.Primary.Close()
+	}
+}
+
+func newPool(ctx context.Context, dsn, appName string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse dsn: %w", err)
+	}
+	cfg.MaxConns = poolMaxConns
+	cfg.MinConns = poolMinConns
+	cfg.MaxConnIdleTime = poolMaxConnIdleTime
+	cfg.MaxConnLifetime = poolMaxConnLifetime
+	cfg.HealthCheckPeriod = poolHealthCheckPeriod
+	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheDescribe
+
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["application_name"] = appName
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("ping: %w", err)
+	}
+	return pool, nil
+}

--- a/java/k8s/configmaps/postgres-replica-scripts.yml
+++ b/java/k8s/configmaps/postgres-replica-scripts.yml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-replica-scripts
+  namespace: java-tasks
+data:
+  bootstrap-replica.sh: |
+    #!/bin/sh
+    # Idempotent bootstrap for the streaming read replica.
+    #
+    # Runs as an initContainer on the postgres-replica StatefulSet. On first
+    # boot the data dir is empty, so we run pg_basebackup against the primary
+    # (creating the physical replication slot if it does not exist) and let
+    # --write-recovery-conf drop the standby.signal + primary_conninfo bits
+    # into the data dir. On subsequent boots PG_VERSION exists and we exit
+    # early; the data dir is reused and Postgres replays WAL from the slot.
+    set -eu
+
+    DATA_DIR="/var/lib/postgresql/data/pgdata"
+
+    if [ -f "$DATA_DIR/PG_VERSION" ]; then
+      echo "Replica data dir already initialized — skipping pg_basebackup."
+      exit 0
+    fi
+
+    echo "Bootstrapping replica from ${PRIMARY_HOST}..."
+    mkdir -p "$DATA_DIR"
+
+    # The replication slot may already exist on the primary from a previous
+    # bootstrap that left state behind. We attempt --create-slot first and
+    # fall back to a no-create run if the slot already exists.
+    if ! pg_basebackup \
+          --host="$PRIMARY_HOST" \
+          --username=replicator \
+          --pgdata="$DATA_DIR" \
+          --format=plain \
+          --wal-method=stream \
+          --slot=replica_1 \
+          --create-slot \
+          --write-recovery-conf \
+          --progress \
+          --verbose; then
+      echo "pg_basebackup with --create-slot failed (slot may already exist); retrying without --create-slot..."
+      rm -rf "$DATA_DIR"/*
+      pg_basebackup \
+        --host="$PRIMARY_HOST" \
+        --username=replicator \
+        --pgdata="$DATA_DIR" \
+        --format=plain \
+        --wal-method=stream \
+        --slot=replica_1 \
+        --write-recovery-conf \
+        --progress \
+        --verbose
+    fi
+
+    chmod 0700 "$DATA_DIR"
+    echo "Replica bootstrapped."

--- a/java/k8s/deployments/postgres.yml
+++ b/java/k8s/deployments/postgres.yml
@@ -54,6 +54,14 @@ spec:
             - "archive_timeout=300"
             - "-c"
             - "wal_level=replica"
+            - "-c"
+            - "max_wal_senders=10"
+            - "-c"
+            - "max_replication_slots=10"
+            - "-c"
+            - "max_slot_wal_keep_size=4GB"
+            - "-c"
+            - "hot_standby=on"
           lifecycle:
             preStop:
               exec:

--- a/java/k8s/kustomization.yaml
+++ b/java/k8s/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - configmaps/postgres-exporter-queries.yml
   - configmaps/postgres-initdb.yml
   - configmaps/postgres-wal-scripts.yml
+  - configmaps/postgres-replica-scripts.yml
   - configmaps/rabbitmq-definitions.yml
   - configmaps/task-service-config.yml
   - configmaps/postgres-verify-scripts.yml
@@ -25,6 +26,8 @@ resources:
   - services/mongodb.yml
   - services/notification-service.yml
   - services/postgres.yml
+  - services/postgres-replica.yml
+  - statefulsets/postgres-replica.yml
   - services/rabbitmq.yml
   - services/redis.yml
   - services/task-service.yml

--- a/java/k8s/services/postgres-replica.yml
+++ b/java/k8s/services/postgres-replica.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-replica
+  namespace: java-tasks
+spec:
+  selector:
+    app: postgres-replica
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+    - name: metrics
+      port: 9187
+      targetPort: 9187

--- a/java/k8s/statefulsets/postgres-replica.yml
+++ b/java/k8s/statefulsets/postgres-replica.yml
@@ -1,0 +1,158 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-replica
+  namespace: java-tasks
+spec:
+  serviceName: postgres-replica
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-replica
+  template:
+    metadata:
+      labels:
+        app: postgres-replica
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9187"
+        prometheus.io/path: "/metrics"
+    spec:
+      terminationGracePeriodSeconds: 60
+      initContainers:
+        - name: bootstrap
+          image: postgres:17-alpine
+          command: ["/scripts/bootstrap-replica.sh"]
+          env:
+            - name: PRIMARY_HOST
+              value: postgres.java-tasks.svc.cluster.local
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: replicator-password
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: scripts
+              mountPath: /scripts
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          ports:
+            - containerPort: 5432
+          # standby.signal + primary_conninfo are written into pgdata by
+          # pg_basebackup --write-recovery-conf, so Postgres starts directly
+          # in standby mode and replays WAL from the primary via slot
+          # replica_1. We pass the same args as the primary for everything
+          # that is server-wide (shared_preload_libraries, etc.) and add
+          # hot_standby=on so the replica accepts read-only queries.
+          args:
+            - "-c"
+            - "shared_preload_libraries=pg_stat_statements,auto_explain"
+            - "-c"
+            - "pg_stat_statements.max=5000"
+            - "-c"
+            - "pg_stat_statements.track=top"
+            - "-c"
+            - "pg_stat_statements.track_utility=off"
+            - "-c"
+            - "auto_explain.log_min_duration=500ms"
+            - "-c"
+            - "auto_explain.log_analyze=true"
+            - "-c"
+            - "auto_explain.log_buffers=true"
+            - "-c"
+            - "auto_explain.log_timing=true"
+            - "-c"
+            - "auto_explain.log_format=json"
+            - "-c"
+            - "auto_explain.sample_rate=1.0"
+            - "-c"
+            - "hot_standby=on"
+            - "-c"
+            - "hot_standby_feedback=on"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["gosu", "postgres", "pg_ctl", "stop", "-m", "fast", "-D", "/var/lib/postgresql/data/pgdata"]
+          readinessProbe:
+            exec:
+              # On a hot standby `pg_isready` returns 0 once the recovery
+              # process is accepting connections; queries fail until then.
+              command: ["pg_isready", "-U", "taskuser", "-d", "postgres"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "taskuser", "-d", "postgres"]
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          env:
+            # POSTGRES_* env vars are honored on first boot only; on a
+            # bootstrapped replica they are no-ops because pg_basebackup
+            # has already populated the data dir.
+            - name: POSTGRES_USER
+              value: taskuser
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: postgres-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "768Mi"
+              cpu: "500m"
+        - name: postgres-exporter
+          image: prometheuscommunity/postgres-exporter:v0.16.0
+          ports:
+            - containerPort: 9187
+          env:
+            - name: DATA_SOURCE_USER
+              value: taskuser
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: postgres-password
+            # The exporter targets the postgres database (which exists on
+            # any standby) — most replication metrics are server-scoped, not
+            # database-scoped, so we don't need a per-DB connection.
+            - name: DATA_SOURCE_URI
+              value: "localhost:5432/postgres?sslmode=disable"
+            - name: PG_EXPORTER_AUTO_DISCOVER_DATABASES
+              value: "false"
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+      volumes:
+        - name: scripts
+          configMap:
+            name: postgres-replica-scripts
+            defaultMode: 0755
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app: postgres-replica
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -1867,6 +1867,117 @@ data:
             annotations:
               summary: "No WAL archived in 10+ minutes — archive_timeout is 5m so this should never happen under normal load"
 
+          - uid: pg-replication-lag-high
+            title: Postgres Replication Lag High
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: max(pg_stat_replication_replay_lag_seconds)
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [30] }
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Postgres replica replay lag > 30s — reporting reads are now seeing data older than the staleness SLA"
+
+          - uid: pg-replication-slot-lag-high
+            title: Postgres Replication Slot Lag High
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  # Either no slot is currently active OR the slot's WAL
+                  # retention has crossed 2GB — both mean the slot is
+                  # heading toward invalidation by max_slot_wal_keep_size.
+                  expr: >-
+                    (max(pg_replication_slots_active{slot_name="replica_1"}) == bool 0)
+                    or
+                    (max(pg_replication_slots_safe_wal_size_bytes{slot_name="replica_1"}) < 2147483648)
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0] }
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Replication slot replica_1 is inactive or within 2GB of max_slot_wal_keep_size — replica is at risk of being dropped"
+
+          - uid: pg-replica-down
+            title: Postgres Replica Down
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: max(up{namespace="java-tasks", pod=~"postgres-replica-.*"})
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: lt, params: [1] }
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Postgres replica is down — reporting reads will fall back to the primary and primary's WAL retention will start growing"
+
           - uid: pg-basebackup-stale
             title: Postgres Base Backup Stale
             noDataState: OK

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -3681,6 +3681,118 @@ data:
             "orientation": "horizontal",
             "displayMode": "gradient"
           }
+        },
+        {
+          "title": "Replica Replay Lag",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 38 },
+          "id": 14,
+          "description": "Seconds the replica is behind the primary. Sourced from pg_stat_replication on the primary; the alert fires at 30s.",
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "max(pg_stat_replication_replay_lag_seconds)",
+              "legendFormat": "replay lag",
+              "refId": "A"
+            },
+            {
+              "expr": "max(pg_stat_replication_write_lag_seconds)",
+              "legendFormat": "write lag",
+              "refId": "B"
+            },
+            {
+              "expr": "max(pg_stat_replication_flush_lag_seconds)",
+              "legendFormat": "flush lag",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 10 },
+                  { "color": "red", "value": 30 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi" },
+            "legend": { "displayMode": "list", "placement": "bottom" }
+          }
+        },
+        {
+          "title": "Replication Slot WAL Retention",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 38 },
+          "id": 15,
+          "description": "How much WAL the replication slot is forcing the primary to retain. max_slot_wal_keep_size is set to 4GB; once the slot crosses that, Postgres will invalidate it rather than fill the data volume.",
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "max(pg_replication_slots_safe_wal_size_bytes{slot_name=\"replica_1\"})",
+              "legendFormat": "safe wal headroom",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi" },
+            "legend": { "displayMode": "list", "placement": "bottom" }
+          }
+        },
+        {
+          "title": "Replica Replay LSN vs Primary LSN",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 24, "x": 0, "y": 46 },
+          "id": 16,
+          "description": "Visual confidence the WAL stream is live. The replica's last replayed transaction timestamp; if this stops moving, replication has stalled even if `up` still reports healthy.",
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            {
+              "expr": "time() - max(pg_last_xact_replay_timestamp)",
+              "legendFormat": "age of last replayed xact",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 30 },
+                  { "color": "red", "value": 120 }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "colorMode": "value",
+            "orientation": "horizontal"
+          }
         }
       ],
       "schemaVersion": 39,

--- a/k8s/overlays/qa-go/kustomization.yaml
+++ b/k8s/overlays/qa-go/kustomization.yaml
@@ -35,6 +35,9 @@ patches:
         path: /data/DATABASE_URL
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb_qa?sslmode=disable&application_name=order-service"
       - op: replace
+        path: /data/DATABASE_URL_REPLICA
+        value: "postgres://taskuser:taskpass@postgres-replica.java-tasks.svc.cluster.local:5432/orderdb_qa?sslmode=disable"
+      - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
       - op: replace

--- a/k8s/overlays/qa-java/kustomization.yaml
+++ b/k8s/overlays/qa-java/kustomization.yaml
@@ -99,6 +99,18 @@ patches:
       kind: Deployment
       metadata:
         name: rabbitmq
+  # postgres-replica is shared with prod (the replica streams the entire
+  # primary, including QA databases); delete the StatefulSet here and
+  # ExternalName the Service back at the prod replica below.
+  - target:
+      kind: StatefulSet
+      name: postgres-replica
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: postgres-replica
   # --- Gateway service: ClusterIP in QA (prod holds cluster-wide NodePort 30080) ---
   - target:
       kind: Service
@@ -150,6 +162,15 @@ patches:
         value:
           type: ExternalName
           externalName: rabbitmq.java-tasks.svc.cluster.local
+  - target:
+      kind: Service
+      name: postgres-replica
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: postgres-replica.java-tasks.svc.cluster.local
   # --- Remove PVC (no local storage needed) ---
   - target:
       kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary

db-roadmap item 7 of 10 — closes #161.

Stands up a single async streaming read replica for Postgres in the `java-tasks` namespace and routes the order-service `/reporting/*` reads to it.

- **Primary:** `max_slot_wal_keep_size=4GB` safety rail; `max_wal_senders` / `max_replication_slots` / `hot_standby` made explicit (PG17 defaults are sufficient, but intent is now self-documenting).
- **Replica:** new `postgres-replica` StatefulSet bootstrapped from the primary via `pg_basebackup` with named physical replication slot `replica_1`. Idempotent init container (skips on subsequent boots; falls back to no-create-slot if the slot already exists). `postgres-exporter` sidecar so replica metrics show up in Prometheus.
- **Order-service:** new `internal/db.Pools` with `Primary` + `Reporting` pools, each setting a distinct `application_name`. Reporting repository takes the replica pool. `DATABASE_URL_REPLICA` falls back to `DATABASE_URL` when unset (local dev still works). Materialized-view refresh stays on the primary because hot standbys can't `REFRESH MATERIALIZED VIEW`.
- **QA overlay:** replica StatefulSet is deleted in `qa-java`; replica Service is `ExternalName`'d back at the prod replica — same shared-infra pattern already used for postgres / redis / rabbitmq / mongodb.
- **Observability:** three new alerts (`PgReplicationLagHigh`, `PgReplicationSlotLagHigh`, `PgReplicaDown`) appended to the existing PostgreSQL alert group, three panels appended to the existing PostgreSQL dashboard.
- **Runbook:** Scenario 5 (Promote the Replica) appended to `docs/runbooks/postgres-recovery.md`.
- **ADR:** new `docs/adr/database/read-replica.md`.

Spec: `docs/superpowers/specs/2026-04-27-read-replica-design.md`. Implementation plan: `docs/superpowers/plans/2026-04-28-read-replica.md`.

## Test plan

- [ ] CI: `make preflight-go` passes (build + golangci-lint + tests across all Go services). Verified locally.
- [ ] CI: kustomize builds for `java/k8s`, `k8s/overlays/qa-java`, `k8s/overlays/qa-go` succeed.
- [ ] Post-deploy QA smoke: `kubectl get statefulset postgres-replica -n java-tasks-qa` resolves to the prod-shared instance via ExternalName (no QA replica pod).
- [ ] Post-deploy prod: `kubectl exec -n java-tasks postgres-replica-0 -c postgres -- psql -U taskuser -d postgres -c 'SELECT pg_is_in_recovery();'` returns `t`.
- [ ] Post-deploy: `kubectl exec -n java-tasks deployment/postgres -- psql -U taskuser -d postgres -c "SELECT slot_name, active, pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) FROM pg_replication_slots;"` shows `replica_1` active and < 100MB retained.
- [ ] Post-deploy QA: hit `/reporting/sales-trends`; verify in primary's `pg_stat_activity` that no row has `application_name='order-service-reporting'`, and the replica's `pg_stat_activity` has it.
- [ ] Replica lag panel renders on the PostgreSQL dashboard.