### PR TITLE
feat: PgBouncer connection pooling (transaction mode, auth_query)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Vercel CLI is installed, linked to `kabradshaw1s-projects`. Use `vercel env ls p
 - **Java services:** schema owned by Spring/JPA at startup. No separate migration step.
 - **Python AI services:** no relational schema (Qdrant is schemaless).
 - **`sslmode=disable` is required on Go `DATABASE_URL`s.** `golang-migrate`'s `pq` driver defaults to `sslmode=require` and will fail without it.
+- **Go migration Jobs bypass PgBouncer.** Each Go service ConfigMap defines two keys: `DATABASE_URL` (routes through `pgbouncer.java-tasks.svc.cluster.local:6432`, transaction-pooled) and `DATABASE_URL_DIRECT` (direct `postgres.java-tasks.svc.cluster.local:5432`, session-level). Migration Jobs reference `DATABASE_URL_DIRECT`; app Deployments read `DATABASE_URL`. Reason: `golang-migrate` uses session-level features (advisory locks, transaction wrapping) that PgBouncer's transaction-pool mode doesn't preserve. When adding a new Go service, define both keys in its ConfigMap and point its migrate Job at `DATABASE_URL_DIRECT`.
 
 ## Project Structure
 

--- a/docs/adr/database/pgbouncer.md
+++ b/docs/adr/database/pgbouncer.md
@@ -1,0 +1,79 @@
+# PgBouncer Connection Pooling
+
+- **Date:** 2026-04-28
+- **Status:** Accepted
+
+## Context
+
+The portfolio runs ~7 Postgres-using microservices against a single self-hosted Postgres 16 pod. Without a pooler, each service holds a long-lived `pgxpool` (or HikariCP) of 5–25 client connections, which the database backs 1:1 with a server process (~10 MB RSS each before any work). Current per-service pool ceilings sum to about 70 connections; Postgres `max_connections` is 100. Headroom for migrations, backup verifies, and ad-hoc psql sessions is uncomfortably thin, and adding any new service would push us over the wall.
+
+Two pillars at risk:
+- **Memory pressure on the Postgres pod** — every idle backend is fixed cost.
+- **Cold-start latency** — TCP+TLS+startup-packet handshakes per new connection are ~1–5 ms each, paid by every request the service decides to open a new conn for.
+
+A connection pooler in transaction mode lets us fan many short-lived "client" connections into a small number of stable "server" connections, decouples app pool sizing from Postgres backend count, and keeps per-service tuning local.
+
+### Pool sizing math (target after full rollout)
+
+| service           | client pool (`MaxConns`) | shared server backends |
+|-------------------|--------------------------|------------------------|
+| auth-service      | 8                        | 5 (default_pool_size)  |
+| product-service   | 8                        | 5                      |
+| order-service     | 8                        | 5                      |
+| cart-service      | 8                        | 5                      |
+| payment-service   | 8                        | 5                      |
+| order-projector   | 10                       | 5                      |
+| task-service (Java) | 5                       | 5                      |
+| **totals**        | **~55 client → 70 with slack** | **~25 server, capped at 80 by max_db_connections** |
+
+`max_db_connections=80` is the hard rail: even if every per-pool default expanded simultaneously, Postgres backends can't exceed it.
+
+## Decision
+
+Drop **PgBouncer 1.23.1** between every Postgres-using service and the Postgres pod. Specifically:
+
+1. **Single-replica Deployment** in the `java-tasks` namespace (the same namespace as Postgres), reachable as `pgbouncer.java-tasks.svc.cluster.local:6432`. The QA Java overlay creates an `ExternalName` Service so QA workloads share the prod pool (single instance, separate `_qa` databases).
+2. **`pool_mode=transaction`** — sessions are released back to the pool at every commit/rollback. Foregoes session-level state (`SET LOCAL`-style settings within a session, advisory locks, `LISTEN/NOTIFY`); we don't use any of these in app code.
+3. **`auth_query`** against a dedicated `pgbouncer_auth` role with a `SECURITY DEFINER` wrapper over `pg_shadow`. PgBouncer authenticates new clients dynamically — no `userlist.txt` rebuild + restart on user changes. The wrapper is scoped to `EXECUTE` for `pgbouncer_auth` only.
+4. **`max_prepared_statements=200`** — required for transaction-mode pooling with pgx's `QueryExecModeCacheStatement` / `CacheDescribe` defaults. Without it, the second use of any prepared statement would fail because PgBouncer 1.21+ now tracks server-side prepared statements and replays them on a different backend; before that, transaction-mode + prepared statements was simply broken.
+5. **Migrations bypass the pooler.** Each Go service ConfigMap defines two keys: `DATABASE_URL` (through PgBouncer) and `DATABASE_URL_DIRECT` (direct Postgres). Migration Jobs reference `DATABASE_URL_DIRECT` because `golang-migrate` uses session-level features (advisory locks, transaction wrapping) that transaction-pool mode doesn't preserve.
+6. **Observability sidecar.** A `prometheuscommunity/pgbouncer-exporter` runs alongside PgBouncer in the same Pod, scraping pool stats over the admin console, and is scraped by Prometheus via pod annotations. A dedicated Grafana dashboard (`pgbouncer-overview`) and three alerts (pool wait time, waiting clients, server connection failures) ship with this change.
+
+## Consequences
+
+### Positive
+
+- Postgres backend count is bounded and predictable. Adding a new microservice no longer pushes us toward `max_connections`.
+- Cold-start latency for short-lived connections drops to a re-bind against an already-warm backend.
+- Pool sizing becomes a per-service knob without coordinating across the cluster.
+- Failure modes are observable: waiting clients, wait time, and server connection drops are all metrics now.
+
+### Trade-offs
+
+- **SPOF risk.** Single-replica Deployment with a `Recreate` strategy means a brief outage when the pod restarts. Mitigated by a `minAvailable: 1` PDB. If the failure-domain analysis ever shifts (e.g., we add HA Postgres), scaling to two replicas behind the same ClusterIP is the next step.
+- **Transaction-mode forecloses session-level state.** No `LISTEN/NOTIFY`, no session-level `SET`, no advisory locks held across statements. We don't currently use any of these; this is a constraint on future work.
+- **Memory cost of `max_prepared_statements`** — a few KB per active server backend per cached statement. With ~25 backends and 200 cached statements, immaterial.
+
+## Alternatives considered
+
+- **pgcat** — newer, pgx-friendly, less battle-tested in production. Promising but the operational story is thinner (fewer dashboards, fewer postmortems on the public web). Revisit if PgBouncer hits a wall.
+- **Supavisor** — Supabase's pooler. Coupled to their stack assumptions (e.g., tenancy model). Overkill for a single-tenant deployment.
+- **Odyssey** — Yandex's pooler. Sparse English docs, smaller operator pool. Fast but harder to debug.
+
+PgBouncer wins on maturity, observability surface, and the existence of `max_prepared_statements` (added in 1.21, refined in 1.23) which removes the historical "transaction mode breaks prepared statements" footgun.
+
+## Rollout
+
+Two-PR rollout:
+
+1. **This PR** lands the infrastructure end-to-end (PgBouncer pod + exporter, ConfigMap, Service, PDB, bootstrap Job, dashboard, alerts, ADR, integration test) and cuts over **auth-service only** — smallest blast radius. Migration Jobs swap to `DATABASE_URL_DIRECT` (same value as before in this PR; the route flips for them only when their service's `DATABASE_URL` flips).
+2. **Follow-up PR** cuts over the remaining Go services (product, order, cart, payment, order-projector) and Java task-service. Each service's `MaxConns` retunes to 8 and Java `task-service` parameterizes its Postgres host/port.
+
+Auth-service has 24h to bake in QA before the bulk cutover ships.
+
+## References
+
+- Spec: [`docs/superpowers/specs/2026-04-27-pgbouncer-design.md`](../../superpowers/specs/2026-04-27-pgbouncer-design.md)
+- Plan: [`docs/superpowers/plans/2026-04-28-pgbouncer.md`](../../superpowers/plans/2026-04-28-pgbouncer.md)
+- GitHub issue: [#160](https://github.com/kabradshaw1/gen_ai_engineer/issues/160)
+- PgBouncer prepared statements changelog: [PgBouncer 1.21 release notes](https://www.pgbouncer.org/changelog.html#pgbouncer-121x)

--- a/docs/superpowers/plans/2026-04-28-pgbouncer.md
+++ b/docs/superpowers/plans/2026-04-28-pgbouncer.md
@@ -1,0 +1,1179 @@
+# PgBouncer Connection Pooling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drop PgBouncer (transaction-mode pooling, prepared-statement-aware) between every Postgres-using service and the shared Postgres pod, fan ~70 client connections into ~25 server-side, and add observability (dashboard + alerts) for the new layer.
+
+**Architecture:** Single-replica PgBouncer Deployment in `java-tasks` (with a sidecar `pgbouncer-exporter` for metrics) sits between every app `DATABASE_URL` and Postgres on `:5432`. Apps connect to `pgbouncer.java-tasks.svc.cluster.local:6432`. Migration Jobs keep the direct URL (session-level features). Auth uses `auth_query` against a `pgbouncer_auth` role with a `SECURITY DEFINER` wrapper over `pg_shadow`. Per-service `pgxpool.MaxConns` drops to 8.
+
+**Tech Stack:** PgBouncer 1.23.1 (`edoburu/pgbouncer`), `prometheuscommunity/pgbouncer-exporter` v0.10.2, Postgres 16, pgx v5, Spring HikariCP, Kustomize, testcontainers-go.
+
+**Rollout strategy:** This plan lands the *infrastructure* end-to-end (PgBouncer pod, exporter, dashboard, alerts, ADR, integration test) in one PR to `qa`. The plan also lands code-side changes for **auth-service only** (smallest blast radius). The remaining 5 Go services + Java task-service cut over in a follow-up PR after QA observation. This keeps each merge reversible.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-pgbouncer-design.md`
+
+**Discovered repo state (do not assume — these are confirmed):**
+- Go services with Postgres: `auth-service` (`MaxConns=10`), `product-service` (25), `order-service` (25), `cart-service` (25), `payment-service` (15), `order-projector` (10).
+- `cart`, `order`, `product` already set `pgx.QueryExecModeCacheDescribe`. `auth`, `payment`, `order-projector` do not — they default to `QueryExecModeCacheStatement` (still uses prepared statements; works with PgBouncer 1.21+ `max_prepared_statements>0`).
+- Java services with Postgres: **only `task-service`** (HikariCP `maximum-pool-size: 5`). `activity-service` is Mongo, `notification-service` is RabbitMQ-only.
+- Go migration Jobs (`go/k8s/jobs/*-migrate.yml`) all read `DATABASE_URL` via `configMapKeyRef` from each service's ConfigMap. **This is the trap:** if we just patch the ConfigMap to point at PgBouncer, migrations break because they need session-level features. Solution: add a sibling key `DATABASE_URL_DIRECT` to each ConfigMap and switch migration Jobs to reference that key.
+- Java `task-service` reads `POSTGRES_HOST` from env but has port `5432` hardcoded in `application.yml`. We'll parameterize port via `POSTGRES_PORT`.
+- QA overlay (`k8s/overlays/qa-go/kustomization.yaml`) patches `DATABASE_URL` inline per service. Needs a corresponding `DATABASE_URL_DIRECT` patch in QA so QA migration Jobs hit the QA database directly.
+
+---
+
+## File Structure
+
+**New files:**
+- `k8s/pgbouncer/namespace-note.md` — short doc on why this lives in `java-tasks`
+- `java/k8s/configmaps/pgbouncer-config.yml` — `pgbouncer.ini`, `userlist.txt` stub
+- `java/k8s/deployments/pgbouncer.yml` — Deployment with exporter sidecar
+- `java/k8s/services/pgbouncer.yml` — ClusterIP for `:6432` and exporter `:9127`
+- `java/k8s/pdb/pgbouncer-pdb.yml` — `minAvailable: 1` PDB
+- `java/k8s/jobs/pgbouncer-auth-bootstrap.yml` — creates `pgbouncer_auth` role + SECURITY DEFINER wrapper
+- `k8s/monitoring/configmaps/grafana-dashboards/pgbouncer.json` — Grafana dashboard JSON
+- `docs/adr/database/pgbouncer.md` — ADR
+- `go/pkg/db/pgbouncer_integration_test.go` — testcontainers integration test (build-tagged)
+
+**Modified files:**
+- `java/k8s/kustomization.yaml` — add new resources
+- `java/k8s/secrets/java-secrets.yml.template` — add `pgbouncer-auth-password` key
+- `java/k8s/configmaps/task-service-config.yml` — add `POSTGRES_PORT`
+- `java/task-service/src/main/resources/application.yml` — parameterize port + cap pool to 5
+- `go/k8s/configmaps/auth-service-config.yml` — add `DATABASE_URL_DIRECT`, point `DATABASE_URL` at pgbouncer
+- `go/k8s/configmaps/{product,order,cart,payment,order-projector}-service-config.yml` — add `DATABASE_URL_DIRECT` only (DATABASE_URL still direct in this PR; flipped in follow-up)
+- `go/k8s/jobs/{auth,product,order,cart,payment,order-projector}-service-migrate.yml` — change `key: DATABASE_URL` → `key: DATABASE_URL_DIRECT`
+- `go/auth-service/cmd/server/config.go` — `MaxConns 10 → 8`
+- `k8s/overlays/qa-go/kustomization.yaml` — add `DATABASE_URL_DIRECT` patches; flip `auth-service` `DATABASE_URL` to pgbouncer
+- `k8s/overlays/qa-java/kustomization.yaml` — add `pgbouncer` ExternalName so QA can reach prod's pgbouncer (matches existing pattern for `postgres`)
+- `k8s/monitoring/configmaps/alerts.yml` (or whichever holds the `PostgreSQL` group) — append three alerts
+- `k8s/monitoring/configmaps/grafana-dashboards.yml` — register new dashboard ConfigMap
+- `CLAUDE.md` — document the migration-bypass rule under "Migrations"
+
+**NOT touched in this PR (deferred to follow-up):**
+- `go/{product,order,cart,payment,order-projector}-service/cmd/server/{deps,main}.go` (`MaxConns` retune)
+- `go/k8s/configmaps/{product,order,cart,payment,order-projector}-service-config.yml` (`DATABASE_URL` cutover)
+- Java `task-service` host/port cutover
+
+---
+
+## Task 1: Create the pgbouncer-auth bootstrap Job
+
+This Job runs once per cluster bootstrap, creates the `pgbouncer_auth` role and a `SECURITY DEFINER` wrapper function that lets it read `pg_shadow`. It MUST be idempotent — re-running is a no-op.
+
+**Files:**
+- Create: `java/k8s/jobs/pgbouncer-auth-bootstrap.yml`
+- Modify: `java/k8s/secrets/java-secrets.yml.template` (add new key)
+- Modify: `java/k8s/kustomization.yaml` (register Job)
+
+- [ ] **Step 1: Add the secret key to the template**
+
+Modify `java/k8s/secrets/java-secrets.yml.template`. Find the existing keys (e.g., `postgres-password`, `jwt-secret`, etc.) and append:
+
+```yaml
+  pgbouncer-auth-password: <BASE64_ENCODED_PASSWORD>  # used by pgbouncer to authenticate to postgres for auth_query
+```
+
+Document at the top of the file (or in a sibling comment) that this is a new required key as of 2026-04-28.
+
+- [ ] **Step 2: Write the bootstrap Job**
+
+Create `java/k8s/jobs/pgbouncer-auth-bootstrap.yml`:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pgbouncer-auth-bootstrap
+  namespace: java-tasks
+  annotations:
+    description: "Creates pgbouncer_auth role + SECURITY DEFINER wrapper for auth_query. Idempotent."
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: postgres:16
+          env:
+            - name: PGHOST
+              value: postgres.java-tasks.svc.cluster.local
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: taskuser
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: postgres-password
+            - name: PGBOUNCER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: pgbouncer-auth-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              # Run against every database PgBouncer will pool. Function is per-DB.
+              for db in postgres authdb productdb orderdb cartdb paymentdb projectordb taskdb \
+                        authdb_qa productdb_qa orderdb_qa cartdb_qa paymentdb_qa projectordb_qa taskdb_qa; do
+                echo "Bootstrapping pgbouncer_auth in $db..."
+                psql -d "$db" -v ON_ERROR_STOP=1 -v pw="$PGBOUNCER_AUTH_PASSWORD" <<'SQL'
+                  DO $$
+                  BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgbouncer_auth') THEN
+                      EXECUTE format('CREATE ROLE pgbouncer_auth LOGIN PASSWORD %L', :'pw');
+                    ELSE
+                      EXECUTE format('ALTER ROLE pgbouncer_auth WITH PASSWORD %L', :'pw');
+                    END IF;
+                  END
+                  $$;
+
+                  CREATE OR REPLACE FUNCTION public.pgbouncer_get_auth(p_usename TEXT)
+                  RETURNS TABLE(usename TEXT, passwd TEXT)
+                  LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS $func$
+                    SELECT usename::TEXT, passwd::TEXT FROM pg_shadow WHERE usename = p_usename;
+                  $func$;
+
+                  REVOKE ALL ON FUNCTION public.pgbouncer_get_auth(TEXT) FROM PUBLIC;
+                  GRANT EXECUTE ON FUNCTION public.pgbouncer_get_auth(TEXT) TO pgbouncer_auth;
+                SQL
+              done
+              echo "pgbouncer_auth bootstrap complete."
+```
+
+- [ ] **Step 3: Register the Job in the kustomization**
+
+Edit `java/k8s/kustomization.yaml`. Find the `jobs/` section (already contains `postgres-extensions-bootstrap.yml`, `postgres-replicator-bootstrap.yml`, etc.) and append:
+
+```yaml
+  - jobs/pgbouncer-auth-bootstrap.yml
+```
+
+- [ ] **Step 4: Smoke-validate kustomize**
+
+Run from repo root:
+
+```bash
+kubectl kustomize java/k8s/ > /tmp/k8s-render.yaml
+grep -A3 'name: pgbouncer-auth-bootstrap' /tmp/k8s-render.yaml | head -20
+```
+
+Expected: the Job appears in the rendered output with the bootstrap container.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add java/k8s/jobs/pgbouncer-auth-bootstrap.yml \
+        java/k8s/secrets/java-secrets.yml.template \
+        java/k8s/kustomization.yaml
+git commit -m "feat(pgbouncer): add pgbouncer_auth bootstrap Job and secret key"
+```
+
+---
+
+## Task 2: PgBouncer ConfigMap (pgbouncer.ini, userlist.txt)
+
+**Files:**
+- Create: `java/k8s/configmaps/pgbouncer-config.yml`
+- Modify: `java/k8s/kustomization.yaml`
+
+- [ ] **Step 1: Write the ConfigMap**
+
+Create `java/k8s/configmaps/pgbouncer-config.yml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgbouncer-config
+  namespace: java-tasks
+data:
+  pgbouncer.ini: |
+    [databases]
+    ; Wildcard so any new DB just works. Per-DB overrides can be added later.
+    * = host=postgres.java-tasks.svc.cluster.local port=5432
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = 6432
+
+    ; --- Auth ---
+    auth_type = scram-sha-256
+    auth_user = pgbouncer_auth
+    auth_query = SELECT usename, passwd FROM public.pgbouncer_get_auth($1)
+    ; userlist.txt holds ONLY pgbouncer_auth itself (chicken-and-egg for auth_query).
+    auth_file = /etc/pgbouncer/userlist.txt
+
+    ; --- Pooling ---
+    pool_mode = transaction
+    max_client_conn = 200
+    default_pool_size = 25
+    min_pool_size = 5
+    reserve_pool_size = 5
+    reserve_pool_timeout = 3
+    max_db_connections = 80
+    server_idle_timeout = 600
+    server_lifetime = 3600
+
+    ; --- Prepared statements (PgBouncer 1.21+ transaction-mode support) ---
+    max_prepared_statements = 200
+
+    ; --- Logging / observability ---
+    log_connections = 1
+    log_disconnections = 1
+    log_pooler_errors = 1
+    stats_period = 60
+
+    ; --- Admin / stats access for the exporter ---
+    admin_users = pgbouncer_auth
+    stats_users = pgbouncer_auth
+    ignore_startup_parameters = extra_float_digits,search_path,application_name
+
+  userlist.txt: |
+    ; Only pgbouncer_auth lives here in plaintext-equivalent form.
+    ; Real password substituted at runtime via initContainer (see deployment).
+    "pgbouncer_auth" "PLACEHOLDER_REPLACED_BY_INITCONTAINER"
+```
+
+- [ ] **Step 2: Register in kustomization**
+
+Edit `java/k8s/kustomization.yaml`. In the `configmaps/` section append:
+
+```yaml
+  - configmaps/pgbouncer-config.yml
+```
+
+- [ ] **Step 3: Render check**
+
+```bash
+kubectl kustomize java/k8s/ | grep -A40 'name: pgbouncer-config' | head -60
+```
+
+Expected: ConfigMap renders with both `pgbouncer.ini` and `userlist.txt`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add java/k8s/configmaps/pgbouncer-config.yml java/k8s/kustomization.yaml
+git commit -m "feat(pgbouncer): add pgbouncer ConfigMap (transaction mode, prepared statements, auth_query)"
+```
+
+---
+
+## Task 3: PgBouncer Deployment + Service + PDB (with exporter sidecar)
+
+**Files:**
+- Create: `java/k8s/deployments/pgbouncer.yml`
+- Create: `java/k8s/services/pgbouncer.yml`
+- Create: `java/k8s/pdb/pgbouncer-pdb.yml`
+- Modify: `java/k8s/kustomization.yaml`
+
+- [ ] **Step 1: Write the Deployment**
+
+Create `java/k8s/deployments/pgbouncer.yml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer
+  namespace: java-tasks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgbouncer
+  strategy:
+    type: Recreate  # single replica, port 6432 must not double-bind
+  template:
+    metadata:
+      labels:
+        app: pgbouncer
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9127"
+        prometheus.io/path: "/metrics"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: pgbouncer-config
+        - name: rendered
+          emptyDir: {}
+      initContainers:
+        - name: render-userlist
+          image: busybox:1.36
+          env:
+            - name: PGBOUNCER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: pgbouncer-auth-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # Substitute the real password into userlist.txt. SCRAM-SHA-256 hash
+              # is what auth_query returns; the file only needs auth_user creds in
+              # md5/scram form. We use plaintext here because pgbouncer accepts
+              # plaintext entries when auth_type=scram-sha-256 — pgbouncer itself
+              # will negotiate scram against postgres on the back end.
+              sed "s|PLACEHOLDER_REPLACED_BY_INITCONTAINER|${PGBOUNCER_AUTH_PASSWORD}|" \
+                /config/userlist.txt > /rendered/userlist.txt
+              cp /config/pgbouncer.ini /rendered/pgbouncer.ini
+              chmod 600 /rendered/userlist.txt
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: rendered
+              mountPath: /rendered
+      containers:
+        - name: pgbouncer
+          image: edoburu/pgbouncer:1.23.1
+          args:
+            - /rendered/pgbouncer.ini
+          ports:
+            - containerPort: 6432
+              name: pgbouncer
+          volumeMounts:
+            - name: rendered
+              mountPath: /rendered
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 70  # pgbouncer in edoburu image
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+        - name: exporter
+          image: prometheuscommunity/pgbouncer-exporter:v0.10.2
+          args:
+            - --pgBouncer.connectionString=postgres://pgbouncer_auth:$(PGBOUNCER_AUTH_PASSWORD)@127.0.0.1:6432/pgbouncer?sslmode=disable
+            - --web.listen-address=:9127
+          env:
+            - name: PGBOUNCER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: pgbouncer-auth-password
+          ports:
+            - containerPort: 9127
+              name: metrics
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "20m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9127
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+```
+
+- [ ] **Step 2: Write the Service**
+
+Create `java/k8s/services/pgbouncer.yml`:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgbouncer
+  namespace: java-tasks
+  labels:
+    app: pgbouncer
+spec:
+  type: ClusterIP
+  selector:
+    app: pgbouncer
+  ports:
+    - name: pgbouncer
+      port: 6432
+      targetPort: 6432
+      protocol: TCP
+    - name: metrics
+      port: 9127
+      targetPort: 9127
+      protocol: TCP
+```
+
+- [ ] **Step 3: Write the PDB**
+
+Create `java/k8s/pdb/pgbouncer-pdb.yml`:
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pgbouncer-pdb
+  namespace: java-tasks
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pgbouncer
+```
+
+- [ ] **Step 4: Register all three in kustomization**
+
+Edit `java/k8s/kustomization.yaml`. Add to the right sections (deployments / services / pdb):
+
+```yaml
+  - deployments/pgbouncer.yml
+  - services/pgbouncer.yml
+  - pdb/pgbouncer-pdb.yml
+```
+
+- [ ] **Step 5: Render check**
+
+```bash
+kubectl kustomize java/k8s/ | grep -E '^(  name|kind):' | grep -A1 -B1 pgbouncer
+```
+
+Expected: Deployment, Service, PDB, ConfigMap, Job all listed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add java/k8s/deployments/pgbouncer.yml \
+        java/k8s/services/pgbouncer.yml \
+        java/k8s/pdb/pgbouncer-pdb.yml \
+        java/k8s/kustomization.yaml
+git commit -m "feat(pgbouncer): add Deployment with exporter sidecar, Service, and PDB"
+```
+
+---
+
+## Task 4: QA overlay — ExternalName for PgBouncer
+
+QA shares prod's Postgres. It must also share prod's pgbouncer (single instance for the whole cluster). The QA Java overlay already creates an `ExternalName` for `postgres`; mirror that for `pgbouncer`.
+
+**Files:**
+- Modify: `k8s/overlays/qa-java/kustomization.yaml`
+
+- [ ] **Step 1: Add the ExternalName**
+
+Open `k8s/overlays/qa-java/kustomization.yaml`. Find the existing block that creates the `postgres` ExternalName (around line 125). Below it, add the same pattern for pgbouncer. Final shape (illustrative — match the existing block style):
+
+```yaml
+  - target:
+      kind: Service
+      name: pgbouncer
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: pgbouncer.java-tasks.svc.cluster.local
+          ports:
+            - name: pgbouncer
+              port: 6432
+              targetPort: 6432
+              protocol: TCP
+```
+
+If the file uses a different patching idiom for ExternalName (read the existing `postgres` block first), match that idiom exactly.
+
+- [ ] **Step 2: Render check**
+
+```bash
+kubectl kustomize k8s/overlays/qa-java/ | grep -A6 'name: pgbouncer'
+```
+
+Expected: `pgbouncer` Service in `java-tasks-qa` is `ExternalName` pointing at `pgbouncer.java-tasks.svc.cluster.local`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add k8s/overlays/qa-java/kustomization.yaml
+git commit -m "feat(pgbouncer): add QA overlay ExternalName for pgbouncer"
+```
+
+---
+
+## Task 5: Add `DATABASE_URL_DIRECT` to every Go service ConfigMap
+
+Migration Jobs read the same key as the app. To keep migrations on the direct port without breaking the app cutover, every Go ConfigMap gets a sibling key. In this task we **only add the key** — apps still read `DATABASE_URL` (still direct in prod). Auth-service `DATABASE_URL` flips to pgbouncer in Task 7.
+
+**Files:**
+- Modify: `go/k8s/configmaps/auth-service-config.yml`
+- Modify: `go/k8s/configmaps/product-service-config.yml`
+- Modify: `go/k8s/configmaps/order-service-config.yml`
+- Modify: `go/k8s/configmaps/cart-service-config.yml`
+- Modify: `go/k8s/configmaps/payment-service-config.yml`
+- Modify: `go/k8s/configmaps/order-projector-config.yml`
+
+- [ ] **Step 1: Add the key to each ConfigMap**
+
+For each file, copy the existing `DATABASE_URL` line and add a sibling `DATABASE_URL_DIRECT` with the *same value* (direct Postgres URL, port 5432). Both are present.
+
+Example for `go/k8s/configmaps/auth-service-config.yml`:
+
+```yaml
+data:
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service
+  DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service-migrate
+  ...
+```
+
+Note: `DATABASE_URL_DIRECT` uses a distinct `application_name` suffix `-migrate` so migration backends are visible separately in `pg_stat_activity`.
+
+Repeat for product (`productdb`), order (`orderdb`), cart (`cartdb`), payment (`paymentdb`), order-projector (`projectordb`).
+
+- [ ] **Step 2: Sanity check**
+
+```bash
+grep -l DATABASE_URL_DIRECT go/k8s/configmaps/*.yml | wc -l
+```
+
+Expected: `6`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go/k8s/configmaps/
+git commit -m "feat(pgbouncer): add DATABASE_URL_DIRECT to Go service configmaps for migration jobs"
+```
+
+---
+
+## Task 6: Switch Go migration Jobs to use `DATABASE_URL_DIRECT`
+
+**Files:**
+- Modify: `go/k8s/jobs/auth-service-migrate.yml`
+- Modify: `go/k8s/jobs/product-service-migrate.yml`
+- Modify: `go/k8s/jobs/order-service-migrate.yml`
+- Modify: `go/k8s/jobs/cart-service-migrate.yml`
+- Modify: `go/k8s/jobs/payment-service-migrate.yml`
+- Modify: `go/k8s/jobs/order-projector-migrate.yml`
+
+- [ ] **Step 1: Update each Job's env reference**
+
+In every file above, find the env block:
+
+```yaml
+            - name: DATABASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  ...
+                  key: DATABASE_URL
+```
+
+Change `key: DATABASE_URL` → `key: DATABASE_URL_DIRECT`. Leave the env var name as `DATABASE_URL` (the migrate command reads `${DATABASE_URL}` — unchanged).
+
+- [ ] **Step 2: Verify all six were updated**
+
+```bash
+grep -c 'key: DATABASE_URL_DIRECT' go/k8s/jobs/*-migrate.yml
+```
+
+Expected: each file has `1`.
+
+- [ ] **Step 3: Render check**
+
+```bash
+kubectl kustomize go/k8s/ | grep -B2 -A2 'DATABASE_URL_DIRECT'
+```
+
+Expected: every migrate Job's env shows `key: DATABASE_URL_DIRECT`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/k8s/jobs/
+git commit -m "feat(pgbouncer): point go migration jobs at DATABASE_URL_DIRECT (bypass pooler)"
+```
+
+---
+
+## Task 7: Cut over auth-service to PgBouncer (prod ConfigMap + pgxpool retune)
+
+This is the only app cutover in this PR. Smallest surface area, easiest to revert.
+
+**Files:**
+- Modify: `go/k8s/configmaps/auth-service-config.yml`
+- Modify: `go/auth-service/cmd/server/config.go`
+
+- [ ] **Step 1: Flip auth-service `DATABASE_URL` to pgbouncer (prod ConfigMap)**
+
+Edit `go/k8s/configmaps/auth-service-config.yml`. Replace the `DATABASE_URL` value (NOT `DATABASE_URL_DIRECT`):
+
+```yaml
+  DATABASE_URL: postgres://taskuser:taskpass@pgbouncer.java-tasks.svc.cluster.local:6432/authdb?sslmode=disable&application_name=auth-service
+  DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service-migrate
+```
+
+- [ ] **Step 2: Lower auth-service `MaxConns` from 10 to 8**
+
+Edit `go/auth-service/cmd/server/config.go` line 117:
+
+```go
+	poolConfig.MaxConns = 8
+```
+
+- [ ] **Step 3: Run go preflight for auth-service**
+
+```bash
+cd go/auth-service && go build ./... && go test ./... && cd ../..
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/k8s/configmaps/auth-service-config.yml go/auth-service/cmd/server/config.go
+git commit -m "feat(pgbouncer): cut auth-service DATABASE_URL over to pgbouncer; MaxConns 10→8"
+```
+
+---
+
+## Task 8: QA overlay — flip auth-service to pgbouncer + add `DATABASE_URL_DIRECT` patches
+
+QA needs the same cutover (auth-service hits pgbouncer with `_qa` DB), plus every other Go service needs a `DATABASE_URL_DIRECT` patch so QA migrations stay direct.
+
+**Files:**
+- Modify: `k8s/overlays/qa-go/kustomization.yaml`
+
+- [ ] **Step 1: Flip auth-service `DATABASE_URL` patch to pgbouncer**
+
+In `k8s/overlays/qa-go/kustomization.yaml`, find the auth-service ConfigMap patch. Replace the `DATABASE_URL` value:
+
+```yaml
+      - op: replace
+        path: /data/DATABASE_URL
+        value: "postgres://taskuser:taskpass@pgbouncer.java-tasks-qa.svc.cluster.local:6432/authdb_qa?sslmode=disable&application_name=auth-service"
+```
+
+(The QA `pgbouncer` Service is the ExternalName from Task 4.)
+
+- [ ] **Step 2: Add `DATABASE_URL_DIRECT` patches for all six Go services**
+
+For each of `auth-service`, `product-service`, `order-service`, `cart-service`, `payment-service`, `order-projector` in the same file, add an `add` op below the existing `DATABASE_URL` patch:
+
+```yaml
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/<dbname>_qa?sslmode=disable&application_name=<svc>-migrate"
+```
+
+Substitute `<dbname>` per service: `authdb`, `productdb`, `orderdb`, `cartdb`, `paymentdb`, `projectordb`. Use `add`, not `replace` — the base ConfigMap may or may not have the key yet depending on what Kustomize sees first; `add` is safe because Task 5 added it to the base, but if your kustomize version errors on `add`-when-exists, use `replace` instead. Try `add` first.
+
+- [ ] **Step 3: Render the QA overlay**
+
+```bash
+kubectl kustomize k8s/overlays/qa-go/ | grep -A1 'DATABASE_URL\(_DIRECT\)\?:'
+```
+
+Expected: every ConfigMap has both keys; auth-service's `DATABASE_URL` points at `pgbouncer.java-tasks-qa.svc.cluster.local:6432`; everything else's `DATABASE_URL` still on port 5432.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k8s/overlays/qa-go/kustomization.yaml
+git commit -m "feat(pgbouncer): QA overlay — auth-service via pgbouncer; DATABASE_URL_DIRECT for all"
+```
+
+---
+
+## Task 9: Grafana dashboard for PgBouncer
+
+A new dashboard with the panels listed in the spec. Dashboards in this repo live in ConfigMaps under `k8s/monitoring/configmaps/`, mounted by Grafana via a sidecar.
+
+**Files:**
+- Create: `k8s/monitoring/configmaps/grafana-dashboards/pgbouncer.json`
+- Modify: `k8s/monitoring/configmaps/grafana-dashboards.yml` (or whatever the existing dashboards-bundle ConfigMap is — check first)
+
+- [ ] **Step 1: Inspect the existing dashboards bundle**
+
+```bash
+ls k8s/monitoring/configmaps/grafana-dashboards/ 2>/dev/null || \
+  grep -l 'kind: ConfigMap' k8s/monitoring/configmaps/grafana-dashboards*.yml
+```
+
+You should find either a directory of `.json` files or a single ConfigMap that embeds them. Match the existing pattern. If it's a directory, drop a new file. If it's an embedded ConfigMap, add a new `data:` key.
+
+- [ ] **Step 2: Write the dashboard JSON**
+
+Create the dashboard with the following panels (use the existing PostgreSQL dashboard as a layout reference — same datasource UIDs apply):
+
+- **Panel 1 — Client connections (active vs waiting):** stacked time series. Queries:
+  - `sum by (database) (pgbouncer_pools_client_active_connections)`
+  - `sum by (database) (pgbouncer_pools_client_waiting_connections)`
+- **Panel 2 — Server connection usage:** stacked time series. Queries:
+  - `sum by (database) (pgbouncer_pools_server_active_connections)`
+  - `sum by (database) (pgbouncer_pools_server_idle_connections)`
+  - `sum by (database) (pgbouncer_pools_server_used_connections)`
+- **Panel 3 — Avg wait time per pool:** time series, ms. Query: `pgbouncer_stats_avg_wait_time_seconds * 1000` by `database`.
+- **Panel 4 — Avg query time per pool:** time series, ms. Query: `pgbouncer_stats_avg_query_time_seconds * 1000` by `database`.
+- **Panel 5 — Top pools by waiting clients:** bar gauge. Query: `topk(5, pgbouncer_pools_client_waiting_connections)`.
+- **Panel 6 — Total Postgres backends (the headline answer):** stat panel. Query: `sum(pg_stat_database_numbackends)` (from postgres_exporter, already wired in this repo).
+
+Datasource: `PBFA97CFB590B2093` (from CLAUDE.md — do not change). Tag the dashboard `pgbouncer`, `postgres`, `infrastructure`. Save with `uid: pgbouncer-overview`.
+
+- [ ] **Step 3: Register the dashboard ConfigMap**
+
+If you created a new file in a directory that's already kustomized, no further work needed. Otherwise add a new ConfigMap entry in the relevant kustomization.
+
+- [ ] **Step 4: Render check**
+
+```bash
+kubectl kustomize k8s/monitoring/ | grep -A2 pgbouncer | head -20
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/
+git commit -m "feat(pgbouncer): add Grafana dashboard for PgBouncer (pools, wait time, backend count)"
+```
+
+---
+
+## Task 10: Alert rules
+
+**Files:**
+- Modify: the alerts ConfigMap under `k8s/monitoring/configmaps/` that already contains the `PostgreSQL` group (run `grep -l 'name: PostgreSQL' k8s/monitoring/configmaps/` to locate it).
+
+- [ ] **Step 1: Locate the existing PostgreSQL group**
+
+```bash
+grep -l 'name: PostgreSQL' k8s/monitoring/configmaps/
+```
+
+- [ ] **Step 2: Append three alerts**
+
+In the same file (or a new sibling group `PgBouncer`), append:
+
+```yaml
+  - alert: PgBouncerPoolWaitTimeHigh
+    expr: pgbouncer_stats_avg_wait_time_seconds > 0.1
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "PgBouncer pool {{ $labels.database }} wait time high"
+      description: "Avg wait time is {{ $value | humanizeDuration }} (>100ms) for 5m on {{ $labels.database }}. Pool may be undersized or Postgres slow."
+  - alert: PgBouncerClientsWaiting
+    expr: pgbouncer_pools_client_waiting_connections > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: "PgBouncer pool {{ $labels.database }} has waiting clients for 10m"
+      description: "{{ $value }} client(s) waiting on {{ $labels.database }}. Consider raising default_pool_size."
+  - alert: PgBouncerServerConnectionFailures
+    expr: |
+      (sum by (database) (pgbouncer_pools_client_active_connections) > 0)
+        and on(database)
+      (sum by (database) (rate(pgbouncer_stats_total_xact_count[5m])) == 0)
+    for: 3m
+    labels:
+      severity: critical
+    annotations:
+      summary: "PgBouncer cannot reach Postgres for {{ $labels.database }}"
+      description: "Clients connected but no transactions completing. PgBouncer→Postgres path likely broken."
+```
+
+All alerts have implicit `noDataState: OK` via the existing group config — verify by reading the group's settings.
+
+- [ ] **Step 3: Validate the rules file**
+
+```bash
+kubectl kustomize k8s/monitoring/ | yq '.spec.groups[] | select(.name == "PostgreSQL" or .name == "PgBouncer")'
+```
+
+Or, lacking yq, just `grep -A2 PgBouncer` and eyeball.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add k8s/monitoring/configmaps/
+git commit -m "feat(pgbouncer): add three alerts for pool wait time, waiting clients, server failures"
+```
+
+---
+
+## Task 11: Integration test (testcontainers, build-tagged)
+
+**Files:**
+- Create: `go/pkg/db/pgbouncer_integration_test.go`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `go/pkg/db/pgbouncer_integration_test.go`. Build tag `integration` to keep it out of CI's default `go test ./...` (per repo convention — confirm by grepping for `//go:build integration` in `go/pkg/dbtest/`).
+
+```go
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestPgBouncerPreparedStatementReuse boots Postgres + PgBouncer (transaction
+// mode, max_prepared_statements=200) and verifies pgx's CacheDescribe path
+// works through the pooler and that backend count stays bounded.
+func TestPgBouncerPreparedStatementReuse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// 1. Start Postgres
+	pgC, err := postgres.Run(ctx, "postgres:16",
+		postgres.WithDatabase("appdb"),
+		postgres.WithUsername("app"),
+		postgres.WithPassword("app"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer pgC.Terminate(ctx)
+
+	pgHost, _ := pgC.Host(ctx)
+	pgPort, _ := pgC.MappedPort(ctx, "5432/tcp")
+	pgInternal, _ := pgC.ContainerIP(ctx)
+
+	// 2. Bootstrap pg_stat_statements + pgbouncer auth role on Postgres
+	directURL := fmt.Sprintf("postgres://app:app@%s:%s/appdb?sslmode=disable", pgHost, pgPort.Port())
+	bootstrap, err := pgxpool.New(ctx, directURL)
+	if err != nil {
+		t.Fatalf("bootstrap pool: %v", err)
+	}
+	for _, q := range []string{
+		`CREATE EXTENSION IF NOT EXISTS pg_stat_statements`,
+		`CREATE ROLE pgbouncer_auth LOGIN PASSWORD 'auth'`,
+		`CREATE OR REPLACE FUNCTION public.pgbouncer_get_auth(p_usename TEXT)
+		   RETURNS TABLE(usename TEXT, passwd TEXT)
+		   LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS $$
+		     SELECT usename::TEXT, passwd::TEXT FROM pg_shadow WHERE usename = p_usename;
+		   $$`,
+		`GRANT EXECUTE ON FUNCTION public.pgbouncer_get_auth(TEXT) TO pgbouncer_auth`,
+		`CREATE TABLE widgets (id SERIAL PRIMARY KEY, name TEXT NOT NULL)`,
+		`INSERT INTO widgets(name) SELECT 'w'||g FROM generate_series(1,100) g`,
+	} {
+		if _, err := bootstrap.Exec(ctx, q); err != nil {
+			t.Fatalf("bootstrap %q: %v", q, err)
+		}
+	}
+	bootstrap.Close()
+
+	// 3. Start PgBouncer pointing at Postgres' internal IP
+	pgbConfig := fmt.Sprintf(`
+[databases]
+appdb = host=%s port=5432 dbname=appdb
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+auth_type = scram-sha-256
+auth_user = pgbouncer_auth
+auth_query = SELECT usename, passwd FROM public.pgbouncer_get_auth($1)
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = transaction
+max_client_conn = 200
+default_pool_size = 5
+max_prepared_statements = 200
+ignore_startup_parameters = extra_float_digits,application_name
+`, pgInternal)
+
+	pgbReq := testcontainers.ContainerRequest{
+		Image:        "edoburu/pgbouncer:1.23.1",
+		ExposedPorts: []string{"6432/tcp"},
+		WaitingFor:   wait.ForListeningPort("6432/tcp"),
+		Files: []testcontainers.ContainerFile{
+			{Reader: stringReader(pgbConfig), ContainerFilePath: "/etc/pgbouncer/pgbouncer.ini", FileMode: 0o644},
+			{Reader: stringReader(`"pgbouncer_auth" "auth"` + "\n"), ContainerFilePath: "/etc/pgbouncer/userlist.txt", FileMode: 0o600},
+		},
+		Cmd: []string{"/etc/pgbouncer/pgbouncer.ini"},
+	}
+	pgbC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: pgbReq, Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start pgbouncer: %v", err)
+	}
+	defer pgbC.Terminate(ctx)
+	pgbHost, _ := pgbC.Host(ctx)
+	pgbPort, _ := pgbC.MappedPort(ctx, "6432/tcp")
+
+	// 4. Open pgxpool through PgBouncer with CacheDescribe
+	pooledURL := fmt.Sprintf("postgres://app:app@%s:%s/appdb?sslmode=disable", pgbHost, pgbPort.Port())
+	cfg, err := pgxpool.ParseConfig(pooledURL)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg.MaxConns = 20
+	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheDescribe
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	// 5. Hammer the same parameterized query from 20 goroutines, 5 queries each = 100 total.
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				var name string
+				err := pool.QueryRow(ctx, "SELECT name FROM widgets WHERE id = $1", (i*5+j)%100+1).Scan(&name)
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("query error: %v", err)
+	}
+
+	// 6. Assert: queryid is stable in pg_stat_statements (prepared-statement reuse).
+	verify, _ := pgxpool.New(ctx, directURL)
+	defer verify.Close()
+	var calls int64
+	err = verify.QueryRow(ctx, `
+		SELECT calls FROM pg_stat_statements
+		WHERE query LIKE 'SELECT name FROM widgets WHERE id = $%' LIMIT 1`).Scan(&calls)
+	if err != nil {
+		t.Fatalf("pg_stat_statements lookup: %v", err)
+	}
+	if calls < 100 {
+		t.Errorf("expected calls >= 100, got %d (prepared statements may not be reused across pool)", calls)
+	}
+
+	// 7. Assert: backend count stayed bounded (default_pool_size = 5).
+	var backends int
+	err = verify.QueryRow(ctx, `
+		SELECT count(*) FROM pg_stat_activity
+		WHERE datname = 'appdb' AND application_name LIKE 'pgbouncer%'`).Scan(&backends)
+	if err != nil {
+		t.Fatalf("pg_stat_activity lookup: %v", err)
+	}
+	if backends > 6 { // pool=5 + small slop
+		t.Errorf("expected ≤6 pgbouncer backends, got %d (fan-in not working)", backends)
+	}
+}
+```
+
+Add the `stringReader` helper at the bottom of the same file:
+
+```go
+func stringReader(s string) *strings.Reader { return strings.NewReader(s) }
+```
+
+…and import `"strings"`.
+
+- [ ] **Step 2: Run the test (requires Docker via Colima)**
+
+```bash
+colima start  # if not already up
+cd go && go test -tags=integration -run TestPgBouncerPreparedStatementReuse ./pkg/db/... -v -timeout 5m && cd ..
+```
+
+Expected: PASS within ~60s.
+
+- [ ] **Step 3: If it fails because `pg_stat_statements` is not preloaded**
+
+Add `shared_preload_libraries=pg_stat_statements` via the `postgres.WithConfigFile` option, OR replace the assertion with a backend-count-only check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go/pkg/db/pgbouncer_integration_test.go
+git commit -m "test(pgbouncer): integration test — prepared statement reuse + backend fan-in"
+```
+
+---
+
+## Task 12: ADR
+
+**Files:**
+- Create: `docs/adr/database/pgbouncer.md`
+
+- [ ] **Step 1: Write the ADR**
+
+Use `docs/adr/template-adr.md` if present, otherwise mirror the structure of `docs/adr/database/wal-archiving-pitr.md`. Sections to cover (from the spec's "ADR" section):
+
+- **Status:** Accepted (date 2026-04-28)
+- **Context:** Why connection pooling matters (Postgres backend memory, `max_connections` saturation math).
+- **Decision:**
+  - Single-replica PgBouncer in `java-tasks` namespace
+  - `pool_mode=transaction` (with the LISTEN/NOTIFY caveat — we don't use it)
+  - `auth_query` over `userlist.txt` (no PgBouncer restart on user changes)
+  - `max_prepared_statements=200` (non-negotiable, pgx defaults to CacheDescribe)
+  - Migrations bypass the pooler via `DATABASE_URL_DIRECT`
+- **Pool sizing math:** Reproduce the table from the spec (5×8 + 3×10 = 70 client → 25 server, `max_db_connections=80` safety rail).
+- **Trade-offs:**
+  - SPOF risk — mitigated by PDB + ability to scale to `replicas: 2` behind ClusterIP later
+  - Transaction-mode forecloses session-level state (we don't use it)
+  - Memory cost of `max_prepared_statements` (~few KB × clients) — immaterial
+- **Alternatives considered:** pgcat (newer, less battle-tested), Supavisor (Supabase-coupled), Odyssey (Yandex; sparse docs). PgBouncer wins on maturity.
+- **Rollout:** Reference the staged plan above (auth-service first, observe, then bulk cutover).
+- **References:** Link to spec, GitHub issue #160, plan file.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adr/database/pgbouncer.md
+git commit -m "docs(adr): PgBouncer connection pooling — transaction mode, auth_query, prepared statements"
+```
+
+---
+
+## Task 13: Document migration-bypass rule in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (the `### Migrations` subsection under "Infrastructure")
+
+- [ ] **Step 1: Append a paragraph**
+
+Find the `### Migrations` heading. Below the existing bullets append:
+
+```markdown
+- **Go migration Jobs bypass PgBouncer.** Each Go service ConfigMap defines two keys: `DATABASE_URL` (routes through `pgbouncer.java-tasks.svc.cluster.local:6432`, transaction-pooled) and `DATABASE_URL_DIRECT` (direct `postgres.java-tasks.svc.cluster.local:5432`, session-level). Migration Jobs reference `DATABASE_URL_DIRECT`; app Deployments read `DATABASE_URL`. Reason: `golang-migrate` uses session-level features (advisory locks, transaction wrapping) that PgBouncer's transaction-pool mode doesn't preserve. When adding a new Go service, define both keys in its ConfigMap and point its migrate Job at `DATABASE_URL_DIRECT`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document PgBouncer migration-bypass rule in CLAUDE.md"
+```
+
+---
+
+## Task 14: Run full preflight + push + open PR
+
+- [ ] **Step 1: Run Go preflight**
+
+```bash
+make preflight-go
+```
+
+Expected: lint + tests pass.
+
+- [ ] **Step 2: Validate rendered manifests**
+
+```bash
+kubectl kustomize java/k8s/ > /dev/null
+kubectl kustomize go/k8s/ > /dev/null
+kubectl kustomize k8s/overlays/qa-go/ > /dev/null
+kubectl kustomize k8s/overlays/qa-java/ > /dev/null
+kubectl kustomize k8s/monitoring/ > /dev/null
+```
+
+Expected: all five succeed silently.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin agent/feat-pgbouncer
+```
+
+- [ ] **Step 4: Open the PR to `qa`**
+
+```bash
+gh pr create --base qa --title "feat: PgBouncer connection pooling (transaction mode, auth_query)" --body "$(cat <<'EOF'
+## Summary
+- Lands single-replica PgBouncer in `java-tasks` (transaction mode, `max_prepared_statements=200`, `auth_query`-based auth)
+- Cuts auth-service over to PgBouncer in QA + prod (smallest blast-radius first)
+- Adds `DATABASE_URL_DIRECT` to every Go ConfigMap so migrations keep session-level access
+- Grafana dashboard + 3 alerts for pool wait time / waiting clients / server failures
+- Integration test verifies prepared-statement reuse + backend fan-in
+- ADR + CLAUDE.md updates
+
+Spec: `docs/superpowers/specs/2026-04-27-pgbouncer-design.md`
+Plan: `docs/superpowers/plans/2026-04-28-pgbouncer.md`
+Closes #160 (in part — bulk cutover follows in #160-followup).
+
+## Rollout
+Auth-service goes through PgBouncer first; observe in QA for 24h before bulk cutover PR. Migration Jobs untouched at the application level — they only swapped to `DATABASE_URL_DIRECT`, same value as before.
+
+## Test plan
+- [ ] CI green (lint + go test + kustomize render)
+- [ ] In QA, exec into auth-service pod and run `psql $DATABASE_URL -c '\\conninfo'` — port should be 6432
+- [ ] In QA, watch `pgbouncer-overview` Grafana dashboard for 1h after deploy
+- [ ] Confirm `pgbouncer-auth-bootstrap` Job completes (`kubectl get job -n java-tasks-qa pgbouncer-auth-bootstrap`)
+- [ ] Confirm migration Jobs still pass (`kubectl get job -n go-ecommerce-qa | grep migrate`)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Notify Kyle with the PR URL**
+
+Drop the PR URL in chat. Do **not** watch CI.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Architecture diagram → Tasks 2–4. Pool sizing → Task 7 (auth only this PR; rest in follow-up, documented). Transaction mode → Task 2. `max_prepared_statements` → Task 2 + Task 11 (test). `auth_query` → Tasks 1 + 2. Migration bypass → Tasks 5 + 6 + 13. Observability → Tasks 9 + 10. Per-service config → Task 7 (auth-only scope per rollout strategy). Testing → Task 11. Rollout → PR description + plan header. ADR → Task 12.
+
+- **Scoped down on purpose:** Spec lists 6 Go services + 1 Java service for cutover. This plan lands infrastructure + auth-service only. Doing all 7 in one PR violates the spec's own "cut services over one at a time in QA" guidance and makes rollback awful. Follow-up PR (referenced in PR body) handles the bulk.
+
+- **Java task-service deferred:** Touching `application.yml` to parameterize port adds risk to a Java service unrelated to the auth-service rollout. Bundling it would require Java preflight (broken on Mac per CLAUDE.md). Move it to the follow-up PR with the rest.
+
+- **`postgres-extensions-bootstrap` interaction:** The new bootstrap Job runs against many DBs. If `postgres-extensions-bootstrap` already iterates databases, consider folding the pgbouncer_auth setup into it in a future cleanup. For this PR, keep the Job separate so its blast radius is obvious.

--- a/docs/superpowers/specs/2026-04-27-database-page-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-27-database-page-expansion-design.md
@@ -1,0 +1,226 @@
+# Design: `/database` Page Expansion — PITR, Verified Backups, Query Observability
+
+- **Date:** 2026-04-27
+- **Status:** Approved — pending implementation
+- **Roadmap position:** Portfolio surface area for the database/SQL track. Extends the original `/database` page (`docs/superpowers/specs/2026-04-27-database-portfolio-page-design.md`) with three additional pieces of work that have shipped since.
+- **Builds on:**
+  - `docs/superpowers/specs/2026-04-27-database-portfolio-page-design.md` — the original `/database` page spec
+  - `docs/adr/database/wal-archiving-pitr.md` — WAL archiving + Point-in-Time Recovery (merged in PR #174)
+  - `docs/adr/observability/2026-04-27-pg-query-observability.md` — `pg_stat_statements` + `auto_explain` (merged in PR #165 / #169)
+  - `docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md` — daily `pg_dump`, dashboard, alerts (merged earlier)
+  - Backup-verification ADR + design (PR #175 — open to qa, expected to merge before this lands)
+
+## Context
+
+The original `/database` spec landed four PostgreSQL pillars: Query Optimization, Schema Design (partitioning + MVs), Migration Safety (`migration-lint`), and a Reliability & Recovery pillar that was deliberately broad ("backups, monitored health, written runbook"). Since then three substantial pieces of operational and observability work have shipped or are about to ship:
+
+1. **WAL archiving + Point-in-Time Recovery** — `archive_command` wrapper, weekly `pg_basebackup` CronJob, `replicator` role, three new alerts on `pg_stat_archiver`, Scenario 4 in the recovery runbook.
+2. **Verified backups** — `pg_restore` of yesterday's dump against a throwaway database, success/failure pushed to a Pushgateway sidecar, Prometheus alerts on stale or failed verification.
+3. **Query observability** — `pg_stat_statements` + `auto_explain` with a dedicated query-performance dashboard, regression-detection alert, plan capture into Loki.
+
+None of these are surfaced on `/database`. The query-observability story is on `/observability` already (a Prometheus/Loki/Grafana framing), but a recruiter scanning `/database` for "how does this engineer find a slow query?" finds nothing — even though that's a baseline interview question. The PITR and verified-backup work — both of which would land on most production teams' roadmaps — are similarly invisible.
+
+The fix is additive, not a rewrite. Two new pillars (Query Observability, expanded Reliability with PITR + verified backups) join the existing four, the order is reshuffled to put the most widely applied capabilities at the top, and a small piece of database content currently misplaced under `/go` migrates back to `/database` where the keyword discovery is.
+
+## Goals
+
+- Add the two missing capabilities (Query Observability, PITR + verified backups) to the page so a recruiter scanning the page sees the full breadth of SQL/operational depth.
+- Reorder pillars so the section a recruiter encounters first is the one most likely to apply to the role they're hiring for.
+- Move the standalone "Database Optimization" benchmark-results table currently on `/go` MicroservicesTab to `/database`, leaving a one-line breadcrumb on `/go`.
+- Keep cross-linking to `/observability` for the deep query-observability story so the two pages don't drift.
+- No new components, no architectural change — reuse `PillarSection` and `StickyToc` as-is.
+
+## Non-goals
+
+- Rewriting any of the existing pillar content beyond the Reliability section (which is the natural home for the PITR + verified-backup additions).
+- Filling in the NoSQL or Vector tabs — still stubs, separate roadmap item.
+- URL-synced tab state (`?tab=…`) — out of scope as in the original spec.
+- Live or interactive content (live `pg_stat_statements` snapshots, embedded `psql`, animated charts).
+- Reorganizing `/observability` — that page already has detailed query-observability content; this work cross-links into it without modifying it.
+- Reorganizing the rest of `/go` — only the standalone "Database Optimization" sub-section moves; the surrounding service-architecture content stays put.
+
+## Pillar list and ordering rationale
+
+The pillars are ordered so the section a recruiter encounters first is the one most likely to be relevant to *any* PostgreSQL role, with breadth narrowing as the page progresses.
+
+| # | Pillar | Anchor | Why this rank |
+|---|---|---|---|
+| 1 | Query Optimization & Benchmarking | `optimization` | Every Postgres role asks "show me a slow query you fixed." Most universally applicable; recruiters expect to see it first. |
+| 2 | Query Observability — `pg_stat_statements` + `auto_explain` | `observability` | The first tool any Postgres engineer reaches for when triaging a slow query. Standard interview vocabulary. **NEW.** |
+| 3 | Reliability & Backups — `pg_dump`, WAL/PITR, verified backups | `reliability` | Every production DB needs backups; PITR is a baseline interview answer. **EXPANDED.** |
+| 4 | Migration Safety — `migration-lint` | `migrations` | Every team shipping schema changes. Specialized but widely needed. |
+| 5 | Schema Design — Partitioning & Materialized Views | `schema` | Narrow — applies once reporting workloads or large tables force the issue. Strongest depth signal but smallest audience. |
+
+Compared to the current page (`#optimization` → `#schema` → `#migrations` → `#reliability`), this shifts `#schema` to the bottom and inserts `#observability` at position 2. The existing content for pillars 1, 4, 5 is unchanged in copy; only their position changes.
+
+## Per-pillar content changes
+
+### Pillar 1: Query Optimization & Benchmarking — content addition
+
+**Anchor:** `optimization` (unchanged)
+
+The current pillar has good narrative + bullets but no numerical results. The current `/go` page has a benchmark-results table with four before/after rows that demonstrates the value of the optimizations:
+
+| Optimization | Before | After | Speedup |
+|---|---|---|---|
+| Order creation (20 items) | 4.5 ms | 1.3 ms | **3.5×** |
+| Product search | 1.0 ms | 0.55 ms | 1.9× |
+| Order creation (5 items) | 1.5 ms | 0.8 ms | 1.8× |
+| Category filter | 430 µs | 327 µs | 1.3× |
+
+Move this table to the bottom of the optimization pillar's body (after the bullet list, before the link row). The shape stays a plain `<table>` with the same Tailwind classes the `/go` table uses; it slots into the `narrative` prop or as an additional section before `bullets` — implementation choice. No new component required.
+
+On `/go` `frontend/src/components/go/tabs/MicroservicesTab.tsx`, the existing `{/* Database Optimization */}` `<section>` (currently lines ~236-353) is replaced with a one-line breadcrumb:
+
+> "Benchmark methodology and the full before/after results live on the [Database](/database#optimization) page."
+
+The breadcrumb keeps `/go` focused on service architecture and lifts SQL detail to where the keyword search lands.
+
+### Pillar 2: Query Observability — `pg_stat_statements` + `auto_explain` — NEW
+
+**Anchor:** `observability` (NEW)
+
+**Narrative** (2-3 sentences): Slow queries don't fix themselves; they have to be found first. Postgres ships two extensions that do exactly this — `pg_stat_statements` aggregates per-query latency, call counts, and IO; `auto_explain` captures full execution plans for any query that crosses a duration threshold. Both are wired into the portfolio so the slow query a hiring manager would normally have to take on faith is instead visible in Grafana.
+
+**Bullets** (5-6, focused on the SQL primitives, not the dashboard):
+
+- `shared_preload_libraries='pg_stat_statements,auto_explain'` set on the Postgres deployment — server-wide enablement; restart picked up by the existing `Recreate` strategy.
+- Per-database `CREATE EXTENSION IF NOT EXISTS pg_stat_statements` for all 7 prod databases, bootstrapped by an idempotent K8s Job (`postgres-extensions-bootstrap`).
+- `auto_explain.log_min_duration=500ms`, `log_analyze=true`, `log_format=json` — every query over 500ms writes a JSON plan to Postgres logs, which Promtail ships to Loki keyed by `query_id`.
+- Custom `postgres_exporter` queries surface the top-50 by mean latency and the top-50 by IO, with `query_text` truncated to 200 chars to bound label cardinality.
+- Three Prometheus alerts: hard ceiling on per-query mean (> 1s for 10m), regression detection (mean > 2× the 7-day baseline for 15m), and an `auto_explain`-stalled canary that fires when no plan log lines arrive in 24h.
+- Read-only `grafana_reader` role (`pg_monitor` predefined role) lets a Grafana PostgreSQL data source render live "top slow queries" tables without leaking write access.
+
+**Links:**
+- "Read the ADR →" `docs/adr/observability/2026-04-27-pg-query-observability.md`
+- "Detailed observability story →" `/observability` (in-portfolio cross-link)
+
+The cross-link is important: it makes clear the duplication is intentional (database-engineer framing here, observability-engineer framing on `/observability`) and prevents future drift between the two pages.
+
+### Pillar 3: Reliability & Backups — EXPANDED
+
+**Anchor:** `reliability` (unchanged), title changes from "Reliability & Recovery" to "Reliability & Backups" (better matches the content).
+
+**Narrative** (replaced): Production-grade SQL isn't only about queries. Postgres needs scheduled backups, continuous WAL archiving, monitored health, and a written runbook for the day someone has to restore. The portfolio's Postgres deployment ships all four — and verifies the backups are actually restorable, because a backup that hasn't been restored is a hope, not a guarantee.
+
+**Bullets**, organized into three implicit groups (no sub-headers, just ordering — keeps the bullet shape consistent with the other pillars):
+
+*Daily snapshots:*
+- Daily `pg_dump --format=custom` per database (7 prod DBs), 7-day retention; backups land on a hostPath PV (`/backups/postgres`) separate from the Postgres data PVC so PVC corruption doesn't affect backups.
+- Postgres deployment uses `Recreate` strategy + `terminationGracePeriodSeconds: 90` + `preStop: pg_ctl stop -m fast` — the combination that prevents the WAL-corruption incident the data-integrity ADR documents.
+- `PodDisruptionBudget` with `maxUnavailable: 0` on the single-replica DB so node drains don't take it out involuntarily.
+
+*Continuous archiving:*
+- `archive_mode=on` + custom `archive_command` wrapper script (`pg-archive-wal.sh`, atomic via temp + rename) ships every WAL segment to a 10Gi `wal-archive` PV.
+- `archive_timeout=300` forces a WAL switch every 5 min during idle periods, so RPO drops from ≤ 24h to ≤ 5m.
+- Weekly `pg_basebackup` CronJob (Sundays 03:00 UTC) writes `--format=tar --gzip --wal-method=fetch` tarballs; retains 4 weeklies + WAL back to the second-newest base backup. Uses a dedicated `replicator` role with only `REPLICATION LOGIN` (not `taskuser`).
+- Three `pg_stat_archiver`-based alerts: archive command failing, WAL archive stale, base backup stale.
+
+*Verified backups:*
+- Daily `postgres-backup-verify` CronJob restores yesterday's dump into a throwaway database, runs `pg_restore --list | wc -l` and a row-count smoke check, pushes success/failure to Pushgateway as a Prometheus metric.
+- Two alerts: verification *failed* (immediate, severity critical) and verification *stale* (no successful verify in 26h, severity warning).
+- The metric is on the existing PostgreSQL dashboard alongside the pg_dump-stale and basebackup-stale panels — three operational signals on one screen.
+
+*Runbook:*
+- Four-scenario runbook (`docs/runbooks/postgres-recovery.md`): fresh PVC reset, full restore from `pg_dump`, partial restore (single database), point-in-time recovery to a specific timestamp.
+
+**Links** (3 ADRs + 1 runbook, button row):
+- "Read the data-integrity ADR →" `docs/adr/infrastructure/2026-04-24-postgres-data-integrity.md`
+- "Read the WAL/PITR ADR →" `docs/adr/database/wal-archiving-pitr.md`
+- "Read the backup-verification ADR →" `docs/adr/database/backup-verification.md` (path follows the convention used by the WAL/PITR ADR; confirm exact filename when implementing — backup-verification PR #175 settles it)
+- "Read the recovery runbook →" `docs/runbooks/postgres-recovery.md`
+
+### Pillar 4: Migration Safety — `migration-lint` (unchanged content, repositioned)
+
+**Anchor:** `migrations` (unchanged)
+
+No copy changes. Section moves up (was position 3, now position 4 — neutral, and the *relative* shape vs. its neighbours is still "between Reliability and Schema").
+
+### Pillar 5: Schema Design — Partitioning & Materialized Views (unchanged content, repositioned)
+
+**Anchor:** `schema` (unchanged)
+
+No copy changes. Section moves to last (was position 2). It's the deepest content and the narrowest audience — the bottom is the right place.
+
+## TOC update
+
+Sticky TOC (both desktop sidebar and mobile chip row) is regenerated from the new ordering:
+
+```ts
+const tocItems: StickyTocItem[] = [
+  { id: "optimization",  label: "Query Optimization" },
+  { id: "observability", label: "Query Observability" },
+  { id: "reliability",   label: "Reliability & Backups" },
+  { id: "migrations",    label: "Migration Safety" },
+  { id: "schema",        label: "Schema Design" },
+];
+```
+
+`StickyToc.tsx` is unchanged — it already takes `items` as a prop. The `IntersectionObserver` re-binds to whichever sections render.
+
+## Bio paragraph touch-up
+
+The `<p>` directly under `<h1>` on `/database` currently reads:
+
+> "Production-grade PostgreSQL is one of the load-bearing skills behind this portfolio: real-database benchmarks, range partitioning with materialized views, a custom AST-based migration linter, and an operational track with backups and recovery runbooks."
+
+Replace with:
+
+> "Production-grade PostgreSQL: real-database benchmarks (with measured 3.5× wins), slow-query observability via `pg_stat_statements` + `auto_explain`, point-in-time recovery with verified backups, a custom AST-based migration linter, and range partitioning with materialized views for reporting."
+
+The lead changes from depth signal ("load-bearing skills") to capability list (5 specifics). The "with measured 3.5× wins" is the same number that appears in the optimization pillar's table — recruiter scans see it twice without it feeling repetitive.
+
+## Component impact
+
+| File | Change |
+|---|---|
+| `frontend/src/components/database/PostgresTab.tsx` | Reorder existing four `PillarSection`s, add a fifth (Observability), expand the Reliability section's narrative + bullets + links, update `tocItems`. |
+| `frontend/src/app/database/page.tsx` | Update bio paragraph copy. |
+| `frontend/src/components/go/tabs/MicroservicesTab.tsx` | Replace the `{/* Database Optimization */}` `<section>` (~118 lines) with a one-line breadcrumb. |
+| `frontend/e2e/database.spec.ts` | Add anchor assertions for `#observability` and the new TOC ordering. Existing anchor assertions for `#optimization`, `#migrations`, `#reliability`, `#schema` stay. |
+
+No new files, no new components, no router changes.
+
+## Testing
+
+- **Playwright smoke** (`frontend/e2e/database.spec.ts` — extend existing test):
+  - The TOC labels render in the new order: "Query Optimization", "Query Observability", "Reliability & Backups", "Migration Safety", "Schema Design".
+  - All five `<h2>` anchors exist with the IDs above.
+  - Clicking the new "Query Observability" TOC chip scrolls the matching `<h2>` into view.
+  - The optimization pillar contains a `<table>` with at least one `<td>` containing the text "3.5x" or "3.5×" (proves the moved benchmark table is present).
+  - On `/go`, the breadcrumb to `/database#optimization` is present where the old "Database Optimization" `<section>` was.
+- **Type/lint** — `npm run typecheck` and `npm run lint` (already in `make preflight-frontend`).
+- **Visual** — manual: load locally, scroll the new pillar, verify the `IntersectionObserver` highlights "Query Observability" when its `<h2>` enters the viewport, verify the moved table renders correctly, verify the `/go` breadcrumb link navigates correctly.
+
+## Rollout
+
+This is a single PR — no staged steps. Roughly:
+
+1. Author the new Observability `PillarSection` content + the expanded Reliability section in `PostgresTab.tsx`.
+2. Reorder pillars + update `tocItems`.
+3. Move the benchmark table from `/go` MicroservicesTab into the optimization pillar.
+4. Replace the old `/go` section with the breadcrumb.
+5. Update the bio paragraph.
+6. Update the Playwright spec.
+7. `make preflight-frontend` (must pass) → `make preflight-e2e` (must pass).
+8. PR to `qa`.
+
+Sequence dependency: the Playwright assertion that the new "Query Observability" chip exists must not be added before the implementation, or `qa`'s smoke suite goes red on the same commit. Bundle them in the same PR (TDD-style: failing test → implementation → green) so this stays green commit-by-commit.
+
+## Open questions
+
+- **Backup-verification ADR exact filename.** PR #175 will settle it. Confirm at implementation time and update the link if needed (currently assumed `docs/adr/database/backup-verification.md`).
+- **Whether the optimization-pillar table goes inside the existing `narrative` prop or as a new optional `extras` prop on `PillarSection`.** Implementation-time call. Both work; the simpler path is to render the table as part of `narrative` (which already accepts `ReactNode`), avoiding a component prop change.
+
+## Consequences
+
+**Positive:**
+- The five pillars on `/database` now match the actual depth of database work in the portfolio. A recruiter or hiring manager scanning the page sees PostgreSQL operational depth that wasn't visible before.
+- The pillar order leads with the section most likely to be relevant to any PostgreSQL role; narrower content lives at the bottom.
+- `/go` and `/database` stop competing for the same content. SQL-engineering keywords are concentrated where the keyword search expects them.
+- Cross-linking between `/database` and `/observability` makes the duplication intentional and prevents future drift.
+
+**Trade-offs:**
+- The page gets longer. The sticky TOC is the mitigation; it already exists and handles the longer page without restructuring.
+- `/go` MicroservicesTab loses a table that demonstrated database wins. The breadcrumb keeps the link discoverable; the depth lives one click away on `/database`.
+- The Reliability pillar bullet list grows from ~5 to ~13 bullets. That's the right shape for this content (three operational primitives, each with 3-5 bullets) — a denser pillar at the page midpoint. If it reads as too long during implementation, splitting "verified backups" into its own pillar is a reversible change.

--- a/go/auth-service/cmd/server/config.go
+++ b/go/auth-service/cmd/server/config.go
@@ -114,7 +114,7 @@ func connectPostgres(ctx context.Context, databaseURL string) *pgxpool.Pool {
 	if err != nil {
 		log.Fatalf("failed to parse database config: %v", err)
 	}
-	poolConfig.MaxConns = 10
+	poolConfig.MaxConns = 8
 	poolConfig.MinConns = 2
 	poolConfig.MaxConnIdleTime = 5 * time.Minute
 	poolConfig.MaxConnLifetime = 30 * time.Minute

--- a/go/k8s/configmaps/auth-service-config.yml
+++ b/go/k8s/configmaps/auth-service-config.yml
@@ -4,7 +4,7 @@ metadata:
   name: auth-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service
+  DATABASE_URL: postgres://taskuser:taskpass@pgbouncer.java-tasks.svc.cluster.local:6432/authdb?sslmode=disable&application_name=auth-service
   DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service-migrate
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
   PORT: "8091"

--- a/go/k8s/configmaps/auth-service-config.yml
+++ b/go/k8s/configmaps/auth-service-config.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: go-ecommerce
 data:
   DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service
+  DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service-migrate
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
   PORT: "8091"
   OTEL_EXPORTER_OTLP_ENDPOINT: "jaeger.monitoring.svc.cluster.local:4317"

--- a/go/k8s/configmaps/cart-service-config.yml
+++ b/go/k8s/configmaps/cart-service-config.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: go-ecommerce
 data:
   DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb?sslmode=disable&application_name=cart-service
+  DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb?sslmode=disable&application_name=cart-service-migrate
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   KAFKA_BROKERS: "kafka.go-ecommerce.svc.cluster.local:9092"
   PRODUCT_GRPC_ADDR: "go-product-service.go-ecommerce.svc.cluster.local:9095"

--- a/go/k8s/configmaps/order-projector-config.yml
+++ b/go/k8s/configmaps/order-projector-config.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: go-ecommerce
 data:
   DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb?sslmode=disable&application_name=order-projector"
+  DATABASE_URL_DIRECT: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb?sslmode=disable&application_name=order-projector-migrate"
   KAFKA_BROKERS: "kafka.go-ecommerce.svc.cluster.local:9092"
   PORT: "8097"
   ALLOWED_ORIGINS: "http://localhost:3000,https://kylebradshaw.dev"

--- a/go/k8s/configmaps/order-service-config.yml
+++ b/go/k8s/configmaps/order-service-config.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: go-ecommerce
 data:
   DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable&application_name=order-service
+  DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable&application_name=order-service-migrate
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   RABBITMQ_URL: amqp://guest:guest@rabbitmq.java-tasks.svc.cluster.local:5672
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev

--- a/go/k8s/configmaps/payment-service-config.yml
+++ b/go/k8s/configmaps/payment-service-config.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: go-ecommerce
 data:
   DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb?sslmode=disable&application_name=payment-service"
+  DATABASE_URL_DIRECT: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb?sslmode=disable&application_name=payment-service-migrate"
   PORT: "8098"
   GRPC_PORT: "9098"
   RABBITMQ_URL: "amqp://guest:guest@rabbitmq.java-tasks.svc.cluster.local:5672"

--- a/go/k8s/configmaps/product-service-config.yml
+++ b/go/k8s/configmaps/product-service-config.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: go-ecommerce
 data:
   DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb?sslmode=disable&application_name=product-service
+  DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb?sslmode=disable&application_name=product-service-migrate
   REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
   PORT: "8095"

--- a/go/k8s/jobs/auth-service-migrate.yml
+++ b/go/k8s/jobs/auth-service-migrate.yml
@@ -30,7 +30,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: auth-service-config
-                  key: DATABASE_URL
+                  key: DATABASE_URL_DIRECT
           resources:
             requests:
               memory: "32Mi"

--- a/go/k8s/jobs/cart-service-migrate.yml
+++ b/go/k8s/jobs/cart-service-migrate.yml
@@ -28,7 +28,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: cart-service-config
-                  key: DATABASE_URL
+                  key: DATABASE_URL_DIRECT
           resources:
             requests:
               memory: "32Mi"

--- a/go/k8s/jobs/order-projector-migrate.yml
+++ b/go/k8s/jobs/order-projector-migrate.yml
@@ -28,7 +28,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: order-projector-config
-                  key: DATABASE_URL
+                  key: DATABASE_URL_DIRECT
           resources:
             requests:
               memory: "32Mi"

--- a/go/k8s/jobs/order-service-migrate.yml
+++ b/go/k8s/jobs/order-service-migrate.yml
@@ -30,7 +30,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: order-service-config
-                  key: DATABASE_URL
+                  key: DATABASE_URL_DIRECT
           resources:
             requests:
               memory: "32Mi"

--- a/go/k8s/jobs/payment-service-migrate.yml
+++ b/go/k8s/jobs/payment-service-migrate.yml
@@ -28,7 +28,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: payment-service-config
-                  key: DATABASE_URL
+                  key: DATABASE_URL_DIRECT
           resources:
             requests:
               memory: "32Mi"

--- a/go/k8s/jobs/product-service-migrate.yml
+++ b/go/k8s/jobs/product-service-migrate.yml
@@ -30,7 +30,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: product-service-config
-                  key: DATABASE_URL
+                  key: DATABASE_URL_DIRECT
           resources:
             requests:
               memory: "32Mi"

--- a/go/pkg/db/pgbouncer_integration_test.go
+++ b/go/pkg/db/pgbouncer_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestPgBouncerPreparedStatementReuse boots Postgres + PgBouncer (transaction
+// mode, max_prepared_statements=200) and verifies pgx's CacheDescribe path
+// works through the pooler and that backend count stays bounded.
+func TestPgBouncerPreparedStatementReuse(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// 1. Start Postgres
+	pgC, err := postgres.Run(ctx, "postgres:16",
+		postgres.WithDatabase("appdb"),
+		postgres.WithUsername("app"),
+		postgres.WithPassword("app"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	defer pgC.Terminate(ctx)
+
+	pgHost, _ := pgC.Host(ctx)
+	pgPort, _ := pgC.MappedPort(ctx, "5432/tcp")
+	pgInternal, _ := pgC.ContainerIP(ctx)
+
+	// 2. Bootstrap pg_stat_statements + pgbouncer auth role on Postgres
+	directURL := fmt.Sprintf("postgres://app:app@%s:%s/appdb?sslmode=disable", pgHost, pgPort.Port())
+	bootstrap, err := pgxpool.New(ctx, directURL)
+	if err != nil {
+		t.Fatalf("bootstrap pool: %v", err)
+	}
+	for _, q := range []string{
+		`CREATE EXTENSION IF NOT EXISTS pg_stat_statements`,
+		`CREATE ROLE pgbouncer_auth LOGIN PASSWORD 'auth'`,
+		`CREATE OR REPLACE FUNCTION public.pgbouncer_get_auth(p_usename TEXT)
+		   RETURNS TABLE(usename TEXT, passwd TEXT)
+		   LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS $$
+		     SELECT usename::TEXT, passwd::TEXT FROM pg_shadow WHERE usename = p_usename;
+		   $$`,
+		`GRANT EXECUTE ON FUNCTION public.pgbouncer_get_auth(TEXT) TO pgbouncer_auth`,
+		`CREATE TABLE widgets (id SERIAL PRIMARY KEY, name TEXT NOT NULL)`,
+		`INSERT INTO widgets(name) SELECT 'w'||g FROM generate_series(1,100) g`,
+	} {
+		if _, err := bootstrap.Exec(ctx, q); err != nil {
+			t.Fatalf("bootstrap %q: %v", q, err)
+		}
+	}
+	bootstrap.Close()
+
+	// 3. Start PgBouncer pointing at Postgres' internal IP
+	pgbConfig := fmt.Sprintf(`
+[databases]
+appdb = host=%s port=5432 dbname=appdb
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 6432
+auth_type = scram-sha-256
+auth_user = pgbouncer_auth
+auth_query = SELECT usename, passwd FROM public.pgbouncer_get_auth($1)
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = transaction
+max_client_conn = 200
+default_pool_size = 5
+max_prepared_statements = 200
+ignore_startup_parameters = extra_float_digits,application_name
+`, pgInternal)
+
+	pgbReq := testcontainers.ContainerRequest{
+		Image:        "edoburu/pgbouncer:1.23.1",
+		ExposedPorts: []string{"6432/tcp"},
+		WaitingFor:   wait.ForListeningPort("6432/tcp"),
+		Files: []testcontainers.ContainerFile{
+			{Reader: stringReader(pgbConfig), ContainerFilePath: "/etc/pgbouncer/pgbouncer.ini", FileMode: 0o644},
+			{Reader: stringReader(`"pgbouncer_auth" "auth"` + "\n"), ContainerFilePath: "/etc/pgbouncer/userlist.txt", FileMode: 0o600},
+		},
+		Cmd: []string{"/etc/pgbouncer/pgbouncer.ini"},
+	}
+	pgbC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: pgbReq, Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start pgbouncer: %v", err)
+	}
+	defer pgbC.Terminate(ctx)
+	pgbHost, _ := pgbC.Host(ctx)
+	pgbPort, _ := pgbC.MappedPort(ctx, "6432/tcp")
+
+	// 4. Open pgxpool through PgBouncer with CacheDescribe
+	pooledURL := fmt.Sprintf("postgres://app:app@%s:%s/appdb?sslmode=disable", pgbHost, pgbPort.Port())
+	cfg, err := pgxpool.ParseConfig(pooledURL)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg.MaxConns = 20
+	cfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeCacheDescribe
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	defer pool.Close()
+
+	// 5. Hammer the same parameterized query from 20 goroutines, 5 queries each = 100 total.
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				var name string
+				err := pool.QueryRow(ctx, "SELECT name FROM widgets WHERE id = $1", (i*5+j)%100+1).Scan(&name)
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("query error: %v", err)
+	}
+
+	// 6. Assert: queryid is stable in pg_stat_statements (prepared-statement reuse).
+	verify, _ := pgxpool.New(ctx, directURL)
+	defer verify.Close()
+	var calls int64
+	err = verify.QueryRow(ctx, `
+		SELECT calls FROM pg_stat_statements
+		WHERE query LIKE 'SELECT name FROM widgets WHERE id = $%' LIMIT 1`).Scan(&calls)
+	if err != nil {
+		t.Fatalf("pg_stat_statements lookup: %v", err)
+	}
+	if calls < 100 {
+		t.Errorf("expected calls >= 100, got %d (prepared statements may not be reused across pool)", calls)
+	}
+
+	// 7. Assert: backend count stayed bounded (default_pool_size = 5).
+	var backends int
+	err = verify.QueryRow(ctx, `
+		SELECT count(*) FROM pg_stat_activity
+		WHERE datname = 'appdb' AND application_name LIKE 'pgbouncer%'`).Scan(&backends)
+	if err != nil {
+		t.Fatalf("pg_stat_activity lookup: %v", err)
+	}
+	if backends > 6 { // pool=5 + small slop
+		t.Errorf("expected ≤6 pgbouncer backends, got %d (fan-in not working)", backends)
+	}
+}
+
+func stringReader(s string) *strings.Reader { return strings.NewReader(s) }

--- a/java/k8s/configmaps/pgbouncer-config.yml
+++ b/java/k8s/configmaps/pgbouncer-config.yml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgbouncer-config
+  namespace: java-tasks
+data:
+  pgbouncer.ini: |
+    [databases]
+    ; Wildcard so any new DB just works. Per-DB overrides can be added later.
+    * = host=postgres.java-tasks.svc.cluster.local port=5432
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = 6432
+
+    ; --- Auth ---
+    auth_type = scram-sha-256
+    auth_user = pgbouncer_auth
+    auth_query = SELECT usename, passwd FROM public.pgbouncer_get_auth($1)
+    ; userlist.txt holds ONLY pgbouncer_auth itself (chicken-and-egg for auth_query).
+    auth_file = /etc/pgbouncer/userlist.txt
+
+    ; --- Pooling ---
+    pool_mode = transaction
+    max_client_conn = 200
+    default_pool_size = 25
+    min_pool_size = 5
+    reserve_pool_size = 5
+    reserve_pool_timeout = 3
+    max_db_connections = 80
+    server_idle_timeout = 600
+    server_lifetime = 3600
+
+    ; --- Prepared statements (PgBouncer 1.21+ transaction-mode support) ---
+    max_prepared_statements = 200
+
+    ; --- Logging / observability ---
+    log_connections = 1
+    log_disconnections = 1
+    log_pooler_errors = 1
+    stats_period = 60
+
+    ; --- Admin / stats access for the exporter ---
+    admin_users = pgbouncer_auth
+    stats_users = pgbouncer_auth
+    ignore_startup_parameters = extra_float_digits,search_path,application_name
+
+  userlist.txt: |
+    ; Only pgbouncer_auth lives here in plaintext-equivalent form.
+    ; Real password substituted at runtime via initContainer (see deployment).
+    "pgbouncer_auth" "PLACEHOLDER_REPLACED_BY_INITCONTAINER"

--- a/java/k8s/deployments/pgbouncer.yml
+++ b/java/k8s/deployments/pgbouncer.yml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer
+  namespace: java-tasks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgbouncer
+  strategy:
+    type: Recreate  # single replica, port 6432 must not double-bind
+  template:
+    metadata:
+      labels:
+        app: pgbouncer
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9127"
+        prometheus.io/path: "/metrics"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: pgbouncer-config
+        - name: rendered
+          emptyDir: {}
+      initContainers:
+        - name: render-userlist
+          image: busybox:1.36
+          env:
+            - name: PGBOUNCER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: pgbouncer-auth-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # Substitute the real password into userlist.txt. SCRAM-SHA-256 hash
+              # is what auth_query returns; the file only needs auth_user creds in
+              # md5/scram form. We use plaintext here because pgbouncer accepts
+              # plaintext entries when auth_type=scram-sha-256 — pgbouncer itself
+              # will negotiate scram against postgres on the back end.
+              sed "s|PLACEHOLDER_REPLACED_BY_INITCONTAINER|${PGBOUNCER_AUTH_PASSWORD}|" \
+                /config/userlist.txt > /rendered/userlist.txt
+              cp /config/pgbouncer.ini /rendered/pgbouncer.ini
+              chmod 600 /rendered/userlist.txt
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: rendered
+              mountPath: /rendered
+      containers:
+        - name: pgbouncer
+          image: edoburu/pgbouncer:1.23.1
+          args:
+            - /rendered/pgbouncer.ini
+          ports:
+            - containerPort: 6432
+              name: pgbouncer
+          volumeMounts:
+            - name: rendered
+              mountPath: /rendered
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 70  # pgbouncer in edoburu image
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+        - name: exporter
+          image: prometheuscommunity/pgbouncer-exporter:v0.10.2
+          args:
+            - --pgBouncer.connectionString=postgres://pgbouncer_auth:$(PGBOUNCER_AUTH_PASSWORD)@127.0.0.1:6432/pgbouncer?sslmode=disable
+            - --web.listen-address=:9127
+          env:
+            - name: PGBOUNCER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: pgbouncer-auth-password
+          ports:
+            - containerPort: 9127
+              name: metrics
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "20m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9127
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/java/k8s/jobs/pgbouncer-auth-bootstrap.yml
+++ b/java/k8s/jobs/pgbouncer-auth-bootstrap.yml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pgbouncer-auth-bootstrap
+  namespace: java-tasks
+  annotations:
+    description: "Creates pgbouncer_auth role + SECURITY DEFINER wrapper for auth_query. Idempotent."
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: postgres:16
+          env:
+            - name: PGHOST
+              value: postgres.java-tasks.svc.cluster.local
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: taskuser
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: postgres-password
+            - name: PGBOUNCER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: java-secrets
+                  key: pgbouncer-auth-password
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+              # Run against every database PgBouncer will pool. Function is per-DB.
+              for db in postgres authdb productdb orderdb cartdb paymentdb projectordb taskdb \
+                        authdb_qa productdb_qa orderdb_qa cartdb_qa paymentdb_qa projectordb_qa taskdb_qa; do
+                echo "Bootstrapping pgbouncer_auth in $db..."
+                psql -d "$db" -v ON_ERROR_STOP=1 -v pw="$PGBOUNCER_AUTH_PASSWORD" <<'SQL'
+                  DO $$
+                  BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'pgbouncer_auth') THEN
+                      EXECUTE format('CREATE ROLE pgbouncer_auth LOGIN PASSWORD %L', :'pw');
+                    ELSE
+                      EXECUTE format('ALTER ROLE pgbouncer_auth WITH PASSWORD %L', :'pw');
+                    END IF;
+                  END
+                  $$;
+
+                  CREATE OR REPLACE FUNCTION public.pgbouncer_get_auth(p_usename TEXT)
+                  RETURNS TABLE(usename TEXT, passwd TEXT)
+                  LANGUAGE sql SECURITY DEFINER SET search_path = pg_catalog AS $func$
+                    SELECT usename::TEXT, passwd::TEXT FROM pg_shadow WHERE usename = p_usename;
+                  $func$;
+
+                  REVOKE ALL ON FUNCTION public.pgbouncer_get_auth(TEXT) FROM PUBLIC;
+                  GRANT EXECUTE ON FUNCTION public.pgbouncer_get_auth(TEXT) TO pgbouncer_auth;
+              SQL
+              done
+              echo "pgbouncer_auth bootstrap complete."

--- a/java/k8s/kustomization.yaml
+++ b/java/k8s/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - deployments/rabbitmq.yml
   - deployments/redis.yml
   - deployments/task-service.yml
+  - deployments/pgbouncer.yml
   - services/activity-service.yml
   - services/gateway-service.yml
   - services/mongodb.yml
@@ -29,6 +30,7 @@ resources:
   - services/rabbitmq.yml
   - services/redis.yml
   - services/task-service.yml
+  - services/pgbouncer.yml
   - volumes/postgres-pvc.yml
   - volumes/postgres-backup-pv.yml
   - volumes/postgres-backup-readonly-pv.yml
@@ -42,6 +44,7 @@ resources:
   - jobs/pgbouncer-auth-bootstrap.yml
   - cronjobs/postgres-basebackup.yml
   - pdb/postgres-pdb.yml
+  - pdb/pgbouncer-pdb.yml
   - ingress.yml
   - ingress-rabbitmq.yml
   - network-policy.yml

--- a/java/k8s/kustomization.yaml
+++ b/java/k8s/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - configmaps/rabbitmq-definitions.yml
   - configmaps/task-service-config.yml
   - configmaps/postgres-verify-scripts.yml
+  - configmaps/pgbouncer-config.yml
   - deployments/activity-service.yml
   - deployments/gateway-service.yml
   - deployments/mongodb.yml

--- a/java/k8s/kustomization.yaml
+++ b/java/k8s/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
   - jobs/postgres-grafana-reader.yml
   - jobs/postgres-backup-verify.yml
   - jobs/postgres-replicator-bootstrap.yml
+  - jobs/pgbouncer-auth-bootstrap.yml
   - cronjobs/postgres-basebackup.yml
   - pdb/postgres-pdb.yml
   - ingress.yml

--- a/java/k8s/pdb/pgbouncer-pdb.yml
+++ b/java/k8s/pdb/pgbouncer-pdb.yml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pgbouncer-pdb
+  namespace: java-tasks
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pgbouncer

--- a/java/k8s/secrets/java-secrets.yml.template
+++ b/java/k8s/secrets/java-secrets.yml.template
@@ -15,3 +15,6 @@ data:
   grafana-reader-password: Z3JhZmFuYS1yZWFkZXItc2VjcmV0   # grafana-reader-secret
   # replicator role created by jobs/postgres-replicator-bootstrap.yml using this key
   replicator-password: cmVwbGljYXRvci1zZWNyZXQ=           # replicator-secret
+  # pgbouncer_auth role created by jobs/pgbouncer-auth-bootstrap.yml using this key (added 2026-04-28)
+  # used by pgbouncer to authenticate to postgres for auth_query
+  pgbouncer-auth-password: cGdib3VuY2VyLWF1dGgtc2VjcmV0   # pgbouncer-auth-secret

--- a/java/k8s/services/pgbouncer.yml
+++ b/java/k8s/services/pgbouncer.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgbouncer
+  namespace: java-tasks
+  labels:
+    app: pgbouncer
+spec:
+  type: ClusterIP
+  selector:
+    app: pgbouncer
+  ports:
+    - name: pgbouncer
+      port: 6432
+      targetPort: 6432
+      protocol: TCP
+    - name: metrics
+      port: 9127
+      targetPort: 9127
+      protocol: TCP

--- a/k8s/monitoring/configmaps/grafana-alerting.yml
+++ b/k8s/monitoring/configmaps/grafana-alerting.yml
@@ -1905,3 +1905,119 @@ data:
               severity: critical
             annotations:
               summary: "No successful postgres-basebackup CronJob in 8+ days — PITR baseline may have aged out"
+
+      - orgId: 1
+        name: PgBouncer
+        folder: Infrastructure Alerts
+        interval: 1m
+        rules:
+          - uid: pgbouncer-pool-wait-time-high
+            title: PgBouncer Pool Wait Time High
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: pgbouncer_stats_avg_wait_time_seconds
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0.1] }
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "PgBouncer pool {{ $labels.database }} wait time high"
+              description: "Avg wait time >100ms for 5m on {{ $labels.database }}. Pool may be undersized or Postgres slow."
+
+          - uid: pgbouncer-clients-waiting
+            title: PgBouncer Clients Waiting
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: pgbouncer_pools_client_waiting_connections
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0] }
+                  refId: C
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              summary: "PgBouncer pool {{ $labels.database }} has waiting clients for 10m"
+              description: "{{ $values.B }} client(s) waiting on {{ $labels.database }}. Consider raising default_pool_size."
+
+          - uid: pgbouncer-server-connection-failures
+            title: PgBouncer Cannot Reach Postgres
+            noDataState: OK
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: PBFA97CFB590B2093
+                model:
+                  expr: >-
+                    (sum by (database) (pgbouncer_pools_client_active_connections) > 0)
+                    and on(database)
+                    (sum by (database) (rate(pgbouncer_stats_total_xact_count[5m])) == 0)
+                  instant: true
+                  refId: A
+              - refId: B
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                relativeTimeRange: { from: 300, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0] }
+                  refId: C
+            for: 3m
+            labels:
+              severity: critical
+            annotations:
+              summary: "PgBouncer cannot reach Postgres for {{ $labels.database }}"
+              description: "Clients connected but no transactions completing. PgBouncer→Postgres path likely broken."

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -3802,3 +3802,115 @@ data:
         }
       ]
     }
+  pgbouncer.json: |
+    {
+      "annotations": { "list": [] },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "uid": "pgbouncer-overview",
+      "title": "PgBouncer Overview",
+      "tags": ["pgbouncer", "postgres", "infrastructure"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": { "from": "now-1h", "to": "now" },
+      "panels": [
+        {
+          "title": "Total Postgres backends (headline)",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+          "id": 1,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "sum(pg_stat_database_numbackends)", "legendFormat": "backends", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 60 },
+                  { "color": "red", "value": 80 }
+                ]
+              }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "Top pools by waiting clients",
+          "type": "bargauge",
+          "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+          "id": 2,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "topk(5, pgbouncer_pools_client_waiting_connections)", "legendFormat": "{{database}}", "refId": "A" }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            },
+            "overrides": []
+          }
+        },
+        {
+          "title": "Avg wait time per pool (ms)",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+          "id": 3,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "pgbouncer_stats_avg_wait_time_seconds * 1000", "legendFormat": "{{database}}", "refId": "A" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] }
+        },
+        {
+          "title": "Avg query time per pool (ms)",
+          "type": "timeseries",
+          "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+          "id": 4,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "pgbouncer_stats_avg_query_time_seconds * 1000", "legendFormat": "{{database}}", "refId": "A" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] }
+        },
+        {
+          "title": "Client connections (active vs waiting)",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+          "id": 5,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "sum by (database) (pgbouncer_pools_client_active_connections)", "legendFormat": "active — {{database}}", "refId": "A" },
+            { "expr": "sum by (database) (pgbouncer_pools_client_waiting_connections)", "legendFormat": "waiting — {{database}}", "refId": "B" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "stacking": { "mode": "normal" } } }, "overrides": [] }
+        },
+        {
+          "title": "Server connection usage",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+          "id": 6,
+          "datasource": { "type": "prometheus", "uid": "" },
+          "targets": [
+            { "expr": "sum by (database) (pgbouncer_pools_server_active_connections)", "legendFormat": "active — {{database}}", "refId": "A" },
+            { "expr": "sum by (database) (pgbouncer_pools_server_idle_connections)", "legendFormat": "idle — {{database}}", "refId": "B" },
+            { "expr": "sum by (database) (pgbouncer_pools_server_used_connections)", "legendFormat": "used — {{database}}", "refId": "C" }
+          ],
+          "fieldConfig": { "defaults": { "unit": "short", "custom": { "stacking": { "mode": "normal" } } }, "overrides": [] }
+        }
+      ]
+    }

--- a/k8s/overlays/qa-go/kustomization.yaml
+++ b/k8s/overlays/qa-go/kustomization.yaml
@@ -17,7 +17,10 @@ patches:
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb_qa?sslmode=disable&application_name=auth-service"
+        value: "postgres://taskuser:taskpass@pgbouncer.java-tasks-qa.svc.cluster.local:6432/authdb_qa?sslmode=disable&application_name=auth-service"
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb_qa?sslmode=disable&application_name=auth-service-migrate"
       - op: add
         path: /data/GRPC_PORT
         value: "9091"
@@ -34,6 +37,9 @@ patches:
       - op: replace
         path: /data/DATABASE_URL
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb_qa?sslmode=disable&application_name=order-service"
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb_qa?sslmode=disable&application_name=order-service-migrate"
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
@@ -116,6 +122,9 @@ patches:
       - op: replace
         path: /data/DATABASE_URL
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb_qa?sslmode=disable&application_name=product-service"
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/productdb_qa?sslmode=disable&application_name=product-service-migrate"
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
@@ -129,6 +138,9 @@ patches:
       - op: replace
         path: /data/DATABASE_URL
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb_qa?sslmode=disable&application_name=cart-service"
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/cartdb_qa?sslmode=disable&application_name=cart-service-migrate"
       - op: replace
         path: /data/REDIS_URL
         value: "redis://redis.java-tasks.svc.cluster.local:6379/1"
@@ -154,6 +166,9 @@ patches:
       - op: replace
         path: /data/DATABASE_URL
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb_qa?sslmode=disable&application_name=payment-service"
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/paymentdb_qa?sslmode=disable&application_name=payment-service-migrate"
       - op: replace
         path: /data/KAFKA_BROKERS
         value: "kafka.go-ecommerce-qa.svc.cluster.local:9092"
@@ -170,6 +185,9 @@ patches:
       - op: replace
         path: /data/DATABASE_URL
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb_qa?sslmode=disable&application_name=order-projector"
+      - op: add
+        path: /data/DATABASE_URL_DIRECT
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb_qa?sslmode=disable&application_name=order-projector-migrate"
       - op: replace
         path: /data/KAFKA_BROKERS
         value: "kafka.go-ecommerce-qa.svc.cluster.local:9092"

--- a/k8s/overlays/qa-java/kustomization.yaml
+++ b/k8s/overlays/qa-java/kustomization.yaml
@@ -150,6 +150,43 @@ patches:
         value:
           type: ExternalName
           externalName: rabbitmq.java-tasks.svc.cluster.local
+  - target:
+      kind: Service
+      name: pgbouncer
+    patch: |
+      - op: replace
+        path: /spec
+        value:
+          type: ExternalName
+          externalName: pgbouncer.java-tasks.svc.cluster.local
+  # --- Remove pgbouncer deployment + bootstrap job (shared with prod) ---
+  - target:
+      kind: Deployment
+      name: pgbouncer
+    patch: |
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: pgbouncer
+  - target:
+      kind: Job
+      name: pgbouncer-auth-bootstrap
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: pgbouncer-auth-bootstrap
+  - target:
+      kind: PodDisruptionBudget
+      name: pgbouncer-pdb
+    patch: |
+      $patch: delete
+      apiVersion: policy/v1
+      kind: PodDisruptionBudget
+      metadata:
+        name: pgbouncer-pdb
   # --- Remove PVC (no local storage needed) ---
   - target:
       kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary
- Lands single-replica PgBouncer in `java-tasks` namespace (transaction mode, `max_prepared_statements=200`, `auth_query`-based auth via `pgbouncer_get_auth` SECURITY DEFINER wrapper)
- Cuts **auth-service only** over to PgBouncer in QA + prod (smallest blast-radius first; remaining 5 Go services + Java task-service in a follow-up PR after QA observation)
- Adds `DATABASE_URL_DIRECT` to every Go ConfigMap so migration Jobs keep session-level access (advisory locks, transaction wrapping)
- Grafana dashboard + 3 alerts: pool wait time, waiting clients, server-connection failures
- testcontainers integration test (build-tagged) verifying prepared-statement reuse + backend fan-in
- ADR + CLAUDE.md migration-bypass rule

Spec: `docs/superpowers/specs/2026-04-27-pgbouncer-design.md`
Plan: `docs/superpowers/plans/2026-04-28-pgbouncer.md`
Closes part of #160 (bulk Go/Java cutover follows in a separate PR per spec rollout strategy).

## Why scoped to auth-service
The spec explicitly says "Cut services over one at a time in QA (auth-service first), observe, then batch the rest. Don't ship as one PR if it can be split." This PR is the infrastructure + auth-service cutover. After QA observation, a follow-up PR retunes `MaxConns` and flips `DATABASE_URL` for product, order, cart, payment, order-projector, and Java task-service.

## Test plan
- [ ] CI green (lint + go test + kustomize render)
- [ ] In QA, exec into auth-service pod and confirm `psql $DATABASE_URL -c '\\conninfo'` shows port 6432
- [ ] In QA, watch `pgbouncer-overview` Grafana dashboard for ~1h post-deploy (waiting clients = 0, avg wait < 100ms)
- [ ] Verify `pgbouncer-auth-bootstrap` Job completes (`kubectl get job -n java-tasks-qa pgbouncer-auth-bootstrap`)
- [ ] Confirm migration Jobs still pass against direct port (`kubectl get job -n go-ecommerce-qa | grep migrate`)
- [ ] Total Postgres backends panel shows the fan-in effect after auth-service cutover

## Notes for review
- Integration test was committed but not run locally — testcontainers + Colima had a known reaper-mount issue on the dev machine. Will be exercised on Linux CI.
- `pgbouncer-auth-password` is a new required key in `java-secrets` — added to the `.template`. The bootstrap Job is idempotent (safe to re-run).
- QA shares prod's pgbouncer instance via an ExternalName Service, mirroring the existing pattern for `postgres`. The qa-java overlay `\$patch: delete`s the new pgbouncer Deployment/Job/PDB so QA doesn't try to spin up its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)