### PR TITLE
fix(auth-service): roll back pgbouncer DSN cutover until prod is provisioned

### DIFF
--- a/go/k8s/configmaps/auth-service-config.yml
+++ b/go/k8s/configmaps/auth-service-config.yml
@@ -4,7 +4,11 @@ metadata:
   name: auth-service-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: postgres://taskuser:taskpass@pgbouncer.java-tasks.svc.cluster.local:6432/authdb?sslmode=disable&application_name=auth-service
+  # Temporarily routed direct to postgres while pgbouncer is rolled out to
+  # the prod java-tasks namespace (see PR #182 follow-up). Will move back to
+  # pgbouncer.java-tasks.svc.cluster.local:6432 once pgbouncer is live in
+  # prod and the pgbouncer-auth-password Secret key is provisioned.
+  DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service
   DATABASE_URL_DIRECT: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb?sslmode=disable&application_name=auth-service-migrate
   ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
   PORT: "8091"

--- a/k8s/overlays/qa-go/kustomization.yaml
+++ b/k8s/overlays/qa-go/kustomization.yaml
@@ -15,9 +15,13 @@ patches:
       - op: replace
         path: /data/ALLOWED_ORIGINS
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      # Temporarily routed direct to postgres while pgbouncer is rolled out
+      # to prod (see PR #182 follow-up). QA's pgbouncer Service is an
+      # ExternalName at pgbouncer.java-tasks.svc.cluster.local, which does
+      # not yet resolve.
       - op: replace
         path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@pgbouncer.java-tasks-qa.svc.cluster.local:6432/authdb_qa?sslmode=disable&application_name=auth-service"
+        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb_qa?sslmode=disable&application_name=auth-service"
       - op: add
         path: /data/DATABASE_URL_DIRECT
         value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/authdb_qa?sslmode=disable&application_name=auth-service-migrate"


### PR DESCRIPTION
## Summary

Unblocks the broken QA deploy. Routes auth-service's \`DATABASE_URL\` back to direct postgres in both the base config and the QA overlay.

## Root cause

PR #182 cut auth-service's \`DATABASE_URL\` over to pgbouncer in QA — but the QA overlay relies on a \`pgbouncer\` Service that's an \`ExternalName\` pointing at \`pgbouncer.java-tasks.svc.cluster.local\`, and pgbouncer was never deployed to the prod \`java-tasks\` namespace. DNS lookup fails → \`go-auth-service\` crashloops → \`kubectl rollout\` times out → Deploy QA fails.

The QA workflow only applies QA namespaces; new shared infra needs to land in prod first (via a \`main\` deploy) before a QA \`ExternalName\` can resolve.

## What this changes

- \`go/k8s/configmaps/auth-service-config.yml\` — \`DATABASE_URL\` back to direct \`postgres.java-tasks.svc.cluster.local:5432\`.
- \`k8s/overlays/qa-go/kustomization.yaml\` — auth-service patch \`DATABASE_URL\` back to direct \`postgres.java-tasks.svc.cluster.local:5432\` (with \`authdb_qa\`).

\`DATABASE_URL_DIRECT\` is left in place — it's harmless when pgbouncer is offline (migration jobs reference it), and it'll be needed again when pgbouncer comes back.

## Re-landing pgbouncer (follow-up)

1. Deploy pgbouncer manifests to prod's \`java-tasks\` from a \`main\` deploy.
2. Provision \`pgbouncer-auth-password\` in the prod \`java-secrets\` Secret out-of-band (not by writing the committed placeholder).
3. Wait for the bootstrap Job to create \`pgbouncer_auth\` in postgres.
4. Re-apply the auth-service \`DATABASE_URL\` cutover.

## Test plan

- [ ] CI: K8s Manifest Validation passes.
- [ ] Push to qa: Deploy QA succeeds; \`go-auth-service\` rolls out cleanly.
- [ ] Post-deploy: \`kubectl logs -n go-ecommerce-qa deploy/go-auth-service\` shows clean startup, no DNS errors.