### PR TITLE
feat(secrets): Sealed Secrets controller install (Phase 1 of 6)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"77fbd95d-f36b-4cdb-9f92-9b13487fc1e1","pid":31050,"acquiredAt":1777361509950}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,11 +588,15 @@ jobs:
         run: |
           # Apply every manifest directory recursively. --dry-run=server
           # exercises the real API server's validation and admission.
-          # Skip overlays/, kustomization.yaml, and cert-manager/ (CRDs not in kind cluster).
+          # Skip overlays/, kustomization.yaml, cert-manager/ (CRDs not in
+          # kind cluster), and sealed-secrets/ (controller is fetched from
+          # upstream URL; the in-repo dir is just a README today, but the
+          # exclusion future-proofs against committing the controller YAML).
           for dir in k8s java/k8s go/k8s; do
             find "$dir" -type f \( -name '*.yml' -o -name '*.yaml' \) \
               -not -path '*/overlays/*' \
               -not -path '*/cert-manager/*' \
+              -not -path '*/sealed-secrets/*' \
               -not -name 'kustomization.yaml' \
               -print0 | xargs -0 -I{} kubectl apply --dry-run=server -f {}
           done
@@ -1378,6 +1382,13 @@ jobs:
           cat k8s/cert-manager/cluster-issuer.yml | $SSH "kubectl apply -f -"
           cat k8s/cert-manager/qa-certificates.yml | $SSH "kubectl apply -f -"
 
+          # Install Sealed Secrets controller (idempotent — kubectl apply
+          # against the pinned upstream manifest). Version pin documented
+          # in k8s/sealed-secrets/README.md; refresh by bumping here +
+          # the prod block below + the deploy.sh script.
+          $SSH "kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/controller.yaml 2>/dev/null || true"
+          $SSH "kubectl wait --for=condition=available --timeout=120s deployment/sealed-secrets-controller -n kube-system 2>/dev/null || true"
+
           # Apply Go overlay, excluding Jobs (they must run sequentially below).
           # Split multi-doc YAML on '---', drop any document containing 'kind: Job'.
           kubectl kustomize k8s/overlays/qa-go/ \
@@ -1570,6 +1581,12 @@ jobs:
           cat k8s/cert-manager/ca-certificate.yml | $SSH "kubectl apply -f -"
           cat k8s/cert-manager/issuer.yml | $SSH "kubectl apply -f -"
           cat k8s/cert-manager/certificates.yml | $SSH "kubectl apply -f -"
+
+          # Install Sealed Secrets controller. Version pin documented in
+          # k8s/sealed-secrets/README.md; keep this in sync with the QA
+          # block and k8s/deploy.sh.
+          $SSH "kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/controller.yaml 2>/dev/null || true"
+          $SSH "kubectl wait --for=condition=available --timeout=120s deployment/sealed-secrets-controller -n kube-system 2>/dev/null || true"
 
           for f in $(find go/k8s -name '*.yml' -not -name 'namespace.yml' -not -path '*/secrets/*' -not -path '*/jobs/*'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
 

--- a/docs/brainstorm/CLAUDE.md
+++ b/docs/brainstorm/CLAUDE.md
@@ -1,1 +1,0 @@
-Your job is to help me brainstorm.  I want to give you an idea or a project, and I want to you think of as many questions as you can, to help me think through it.  When you get an answer, please create a .txt file with fallow up questions.  When passed a text file, please ask those questions

--- a/docs/superpowers/plans/2026-04-28-sealed-secrets-phase1.md
+++ b/docs/superpowers/plans/2026-04-28-sealed-secrets-phase1.md
@@ -1,0 +1,57 @@
+# Plan: Sealed Secrets — Phase 1 (controller install + bootstrap runbook)
+
+Spec: `docs/superpowers/specs/2026-04-28-secrets-management-design.md`
+Branch: `agent/feat-sealed-secrets-phase1`
+
+Phase 1 lands the tool only. No existing manifests change; no live secrets are migrated yet (that's Phase 2). After this PR:
+
+- The Sealed Secrets controller runs in the cluster.
+- `kubeseal` install + sealing-key backup procedure is documented.
+- The deploy pipeline knows how to keep the controller up to date.
+
+## Step 1 — Repo home for Sealed Secrets artifacts
+
+- Create `k8s/sealed-secrets/` directory.
+- `k8s/sealed-secrets/README.md` — describes the controller version pin, install procedure, sealing-key backup procedure, kubeseal CLI install, and forward-references where Phase 2 will land committed `*.sealed.yml` resources.
+
+The directory mirrors `k8s/cert-manager/`: a small home for the cluster-level concern, with the actual heavy install applied from a pinned remote URL (so we don't vendor a 2000-line third-party manifest into the repo).
+
+## Step 2 — Pipeline integration (`.github/workflows/ci.yml`)
+
+Mirror the existing cert-manager pattern:
+
+- **Deploy QA** job: after Tailscale, before applying the QA overlays, apply Sealed Secrets controller and wait for it to be Ready.
+- **Deploy Production** job: same.
+
+Pinned version: `v0.36.6` (latest stable as of 2026-04-28). Refresh procedure documented in the README.
+
+K8s Manifest Validation: add `-not -path '*/sealed-secrets/*'` to the `find` skip list (the directory only contains a README today, but the exclusion is consistent with cert-manager and future-proofs against committing the controller YAML).
+
+## Step 3 — Local deploy script (`k8s/deploy.sh`)
+
+Same pattern: install Sealed Secrets controller in the `minikube`, `qa`, and `aws` paths before applying overlays. Best-effort (`|| true`) so a re-run doesn't fail when the controller is already installed.
+
+## Step 4 — Verification (post-deploy, not in CI)
+
+The PR description's test plan asks the operator to confirm end-to-end:
+
+1. Controller pod is Running in `kube-system` (the default namespace for the bitnami install).
+2. `kubeseal --fetch-cert` returns a public certificate.
+3. Seal a trivial test secret, apply it, confirm the controller materializes a real Secret.
+
+This isn't part of the PR's CI gates because it requires the live cluster; it's the operator handoff at merge time.
+
+## Out of scope for Phase 1
+
+- Migrating any existing live Secret. Phase 2.
+- Closing the template-vs-live drift (replicator-password, etc.). Phase 3.
+- DSN component split. Phase 4.
+- CI guardrail. Phase 5.
+- Java services. Phase 6.
+
+## Test plan
+
+- `K8s Manifest Validation` CI job passes (the new directory is excluded but the find still terminates cleanly).
+- After merge to qa: `Deploy QA` succeeds; `kubectl get deploy -n kube-system | grep sealed-secrets-controller` shows the controller available.
+- After merge to main: same in prod.
+- Operator confirms `kubeseal --fetch-cert` returns a key against both QA and prod.

--- a/docs/superpowers/specs/2026-04-28-secrets-management-design.md
+++ b/docs/superpowers/specs/2026-04-28-secrets-management-design.md
@@ -1,0 +1,323 @@
+# Design: Secrets Management — Sealed Secrets + DSN Component Split
+
+- **Date:** 2026-04-28
+- **Status:** Draft — pending approval
+- **Roadmap:** Standalone infra/security item (not part of `db-roadmap`)
+- **GitHub issue:** TBD
+
+## Context
+
+The repo's current credential story is a mix of patterns that drifted as
+features landed. Auditing the live Minikube cluster (kyle@debian, 2026-04-28)
+against the manifests in `main` shows:
+
+### What's in the live cluster
+
+| Namespace | Secret | Keys |
+|---|---|---|
+| `java-tasks` | `java-secrets` | `google-client-id`, `google-client-secret`, `jwt-secret`, `postgres-password` |
+| `go-ecommerce` | `go-secrets` | `google-client-id`, `google-client-secret`, `jwt-secret` |
+| `go-ecommerce` | `stripe-secrets` | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` |
+| `monitoring` | `telegram-bot` | `bot-token` |
+| (per service) | `*-grpc-tls` | mTLS cert/key (managed by cert-manager — already proper) |
+
+### What the manifests claim
+
+- `java/k8s/secrets/java-secrets.yml.template` — 7 keys, including
+  `replicator-password`, `grafana-reader-password`,
+  `pgbouncer-auth-password`. None of those three are in the live Secret.
+- `go/k8s/secrets/go-secrets.yml.template` — structural reference for
+  `go-secrets`.
+- Neither template is applied by CI; both are pure documentation
+  artifacts shipped with placeholder base64 values that look like
+  credentials.
+
+### Concrete gaps this audit surfaces
+
+1. **Drift between template and live.** Three secret keys are in the
+   committed template but missing from the live cluster. Jobs that
+   reference them (`postgres-grafana-reader.yml`,
+   `postgres-replicator-bootstrap.yml`,
+   `pgbouncer-auth-bootstrap.yml`) declare `secretKeyRef` lookups that
+   would fail at admission time. Either the Jobs failed silently (and
+   nothing notices because no downstream depends on those roles yet) or
+   they were never applied to that namespace. We do not know which —
+   that uncertainty is itself a bug.
+
+2. **Credentials inside ConfigMaps, not Secrets.** Twelve occurrences of
+   `taskuser:taskpass` baked into `DATABASE_URL` strings across every
+   Go service ConfigMap and the QA overlay; six occurrences of
+   `guest:guest` in `RABBITMQ_URL` strings. ConfigMaps are not encrypted
+   at rest in etcd and are not access-controlled the way Secrets are.
+
+3. **Templates that look like real Secrets.** The `*.template.yml`
+   files have `kind: Secret` and base64-encoded "placeholder" values.
+   At a glance — and on a `kubectl apply -f` mis-targeting — they are
+   indistinguishable from a real Secret. A reviewer would reasonably
+   ask whether the placeholder is the prod value (it isn't, but
+   nothing says so loudly).
+
+4. **No bootstrap runbook.** "What does a fresh cluster need to come
+   online?" is implicit. Today it lives in the operator's head.
+
+5. **No CI guardrail for credentials in ConfigMaps.** `gitleaks` runs,
+   but `taskuser:taskpass` doesn't match any of its patterns — it
+   doesn't look like an API key. Future copy-paste would slip past.
+
+## Goals
+
+- Move all live Secret data under a tool that lets us commit the
+  encrypted form to git, so the cluster's secret state is reproducible
+  from `main`.
+- Split DSN strings so credentials live in Secrets and the rest
+  (host/port/db/options) lives in ConfigMaps.
+- Document the bootstrap path: a runbook that takes a fresh Minikube
+  cluster and produces a working set of Secrets without manual
+  copy-paste of base64 strings.
+- Add a CI guardrail that catches plaintext credentials inside
+  ConfigMap data fields.
+- Eliminate the drift between `*.template.yml` and the live cluster by
+  removing the templates as a credential-source artifact.
+
+## Non-goals
+
+- A cloud KMS-backed solution (External Secrets Operator with AWS/GCP
+  Secrets Manager). The portfolio runs on Minikube; introducing a
+  cloud dependency just to manage local development credentials is
+  the wrong trade-off.
+- Rotating the actual credential values. This work is about *how*
+  secrets are stored, not *which* secrets are valid. Rotation is its
+  own follow-up.
+- Re-architecting cert-manager. Per-service mTLS certs are already
+  managed properly via `Certificate` resources; out of scope.
+- Migrating GitHub Actions secrets (Tailscale authkey, GHCR creds,
+  etc.). Those live in GitHub's encrypted store, which is a different
+  problem domain.
+
+## Decision
+
+**Adopt [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)**
+as the in-cluster secrets management tool, and **split DSN strings**
+into ConfigMap (non-credential parts) + Secret (credentials), with the
+application building the connection string at startup.
+
+### Why Sealed Secrets
+
+| Option | Fit | Verdict |
+|---|---|---|
+| **Sealed Secrets** | Bitnami controller in cluster; `kubeseal` CLI encrypts a `Secret` against the controller's public key; the encrypted `SealedSecret` is safe to commit to git. Controller decrypts back into a real Secret on apply. Single-cluster simple. | **Choose.** Matches the Minikube + GitOps-ish pattern already in use. Zero cloud dependency. The encrypted form is committable, which closes the "what's in prod?" gap. |
+| External Secrets Operator | Pulls from cloud KMS / Vault / Secrets Manager. Best when secrets already live in a cloud provider. | Overkill — we don't have a cloud provider in scope. |
+| SOPS | Encrypts files; works with kustomize's `sops` plugin. No controller. | Decent, but the kustomize integration is fiddly and there's no central rotation story. Sealed Secrets' controller model is cleaner. |
+| HashiCorp Vault | Heavy. Operator + storage + auth. | Overkill for portfolio scale. |
+| Stay with manual `kubectl create secret` | Status quo. | Doesn't solve drift, doesn't solve bootstrap docs. Reject. |
+
+### Why split DSNs
+
+Today every Go service's ConfigMap looks like:
+
+```yaml
+DATABASE_URL: postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/orderdb?sslmode=disable
+```
+
+A ConfigMap is the wrong place for a password. The right shape:
+
+```yaml
+# ConfigMap (non-secret, freely committable)
+DB_HOST: postgres.java-tasks.svc.cluster.local
+DB_PORT: "5432"
+DB_NAME: orderdb
+DB_OPTIONS: sslmode=disable
+
+# Secret (sealed)
+DB_USER: taskuser
+DB_PASSWORD: <strong>
+```
+
+The application builds the DSN at startup. This is how 12-factor /
+production teams structure connection config — credentials never enter
+the ConfigMap surface.
+
+## Architecture
+
+```
+sealed-secrets-system namespace
+├── sealed-secrets-controller Deployment (bitnami/sealed-secrets-controller)
+│   └── Generates a cluster-wide public/private keypair on first start;
+│       private key never leaves the cluster.
+└── sealing-key Secret (managed by controller; backed up out-of-band)
+
+Repo
+├── secrets/
+│   ├── java-tasks/
+│   │   └── java-secrets.sealed.yml          (committable; encrypted)
+│   ├── go-ecommerce/
+│   │   ├── go-secrets.sealed.yml
+│   │   └── stripe-secrets.sealed.yml
+│   ├── monitoring/
+│   │   └── telegram-bot.sealed.yml
+│   └── README.md                            (bootstrap runbook)
+└── (delete) java/k8s/secrets/, go/k8s/secrets/
+
+Application code
+├── go/<service>/cmd/server/config.go
+│   └── Build DATABASE_URL from DB_HOST/DB_PORT/DB_NAME/DB_OPTIONS (ConfigMap)
+│       + DB_USER/DB_PASSWORD (Secret).
+│       Same pattern for RABBITMQ_URL, REDIS_URL.
+└── (no change to imports / framework code)
+
+Kubernetes manifests
+├── go/k8s/configmaps/<service>-config.yml
+│   └── DATABASE_URL removed; DB_HOST/DB_PORT/DB_NAME/DB_OPTIONS added
+├── go/k8s/deployments/<service>.yml
+│   └── envFrom: { configMapRef: <service>-config, secretRef: <service>-db }
+└── k8s/overlays/qa-go/kustomization.yaml
+    └── DB_NAME patched to *_qa; everything else inherits
+```
+
+## Implementation phases
+
+### Phase 1 — Land Sealed Secrets controller + bootstrap runbook
+
+Goal: the tool is installed, encrypted secrets are committable, but no
+existing manifests change yet.
+
+- Add `k8s/sealed-secrets/` with the controller install manifest
+  (single YAML pinned to a release tag).
+- Update `k8s/deploy.sh` and CI to apply it.
+- Document `kubeseal` install + sealing-key backup in
+  `secrets/README.md`. The sealing key backup is the load-bearing
+  operational artifact: lose it and *all* sealed secrets in the repo
+  become un-decryptable.
+- Verify by sealing one trivial secret end-to-end and confirming the
+  controller decrypts it.
+
+### Phase 2 — Migrate the four live Secrets into the repo as `SealedSecret` resources
+
+For each of `java-secrets`, `go-secrets`, `stripe-secrets`,
+`telegram-bot`:
+
+1. Read the live values from the cluster (out-of-band — operator's
+   responsibility, not the agent's).
+2. Run `kubeseal` to produce the encrypted YAML.
+3. Commit it under `secrets/<namespace>/<name>.sealed.yml`.
+4. Reference from the appropriate kustomization.
+5. Delete the corresponding `*.template.yml` from the repo.
+
+The ordering matters: we apply the new `SealedSecret`, the controller
+materializes a `Secret` with the same name, the app sees no change.
+Then we delete the template.
+
+### Phase 3 — Add the missing keys
+
+For each key that the manifests reference but the live cluster doesn't
+have (`replicator-password`, `grafana-reader-password`,
+`pgbouncer-auth-password`):
+
+1. Generate a strong random value (operator runs `openssl rand`).
+2. Seal it; commit.
+3. Re-run the corresponding bootstrap Job
+   (`postgres-replicator-bootstrap`, etc.); confirm it succeeds.
+
+This phase closes the live-vs-manifest drift.
+
+### Phase 4 — Split DSNs (Go services first)
+
+Per Go service:
+
+1. Add `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_OPTIONS` to the ConfigMap;
+   remove `DATABASE_URL`. Keep `DATABASE_URL_DIRECT` for migration
+   Jobs (or split it the same way — same fields, different `DB_NAME`
+   modes). Decision in the implementation plan.
+2. Add `DB_USER`, `DB_PASSWORD` to a per-service `<service>-db` Secret
+   (sealed).
+3. In `cmd/server/config.go`, build the DSN at startup. Existing
+   `pgxpool` consumers don't change.
+4. Repeat for `RABBITMQ_URL` (`MQ_HOST`, `MQ_PORT`, `MQ_VHOST` in
+   ConfigMap; `MQ_USER`, `MQ_PASSWORD` in Secret).
+5. `REDIS_URL` follows the same pattern when it grows a password (it
+   doesn't today; defer).
+
+Order services from least-to-most central — auth-service is most
+central, do it last. Roll out one service per merge so a rollback is
+narrow.
+
+### Phase 5 — CI guardrail
+
+Add a CI check that fails when a ConfigMap `data` field contains
+`://[^@]*@` (a password-bearing URL) or matches a small set of
+known-bad patterns (`password=`, `:taskpass`, `guest:guest`).
+
+Implementation: a small Go or shell script in `.github/scripts/` plus
+a workflow step. Tests against fixtures that exercise both the
+positive and negative cases.
+
+### Phase 6 — Java services + monitoring
+
+The Java services use Spring's environment-variable substitution; the
+DSN-split pattern is the same shape but with different config wiring.
+Defer to its own phase to keep individual PRs reviewable.
+
+## Bootstrap runbook (deliverable)
+
+`secrets/README.md` will document the fresh-cluster bootstrap:
+
+1. Install Sealed Secrets controller: `kubectl apply -f k8s/sealed-secrets/`.
+2. Wait for the controller; export the public cert (`kubeseal --fetch-cert`).
+3. Apply all `secrets/**/*.sealed.yml`.
+4. Confirm Secrets materialize: `kubectl get secrets -A`.
+5. Sealing-key backup procedure (out-of-band; operator's encrypted
+   personal vault). Without this, a `minikube delete` is unrecoverable.
+
+## Trade-offs
+
+**Positive:**
+- The cluster's secret state becomes reproducible from `main` (modulo
+  the sealing key, which is the one out-of-band artifact).
+- Drift between manifests and live cluster is closed and stays closed.
+- ConfigMaps stop carrying credentials, which is the structurally
+  correct shape and a recognizable pattern at code review time.
+- A real bootstrap runbook exists.
+- A CI guardrail catches the regression class going forward.
+
+**Trade-offs / costs:**
+- One more controller in the cluster (modest — Sealed Secrets is small).
+- The sealing key is a load-bearing artifact: lose it and committed
+  sealed secrets become useless. The mitigation is documenting and
+  honoring the backup procedure.
+- Existing app code grows a small DSN-builder helper. Net effect on
+  readability is positive (config struct fields read like a 12-factor
+  app), but it is a code change.
+- Migration is touchy: each service migration is a coordinated
+  ConfigMap + Secret + Deployment change. Ordering matters; do one
+  service per PR.
+
+**Phase-2-and-beyond ideas (not now):**
+- Cloud KMS-backed secrets via External Secrets Operator if the
+  portfolio grows a cloud target.
+- Automated rotation (separate concern, separate spec).
+- A `make seal` developer command that wraps `kubeseal` for the
+  common case.
+
+## Companion ADR
+
+`docs/adr/security/secrets-management.md` covering:
+
+- Why Sealed Secrets over External Secrets / SOPS / Vault for this
+  context.
+- Why DSN split rather than "store the whole connection string in a
+  Secret."
+- The sealing-key custody decision and its operational implications.
+- Why the migration is multi-phase (per-service) rather than a single
+  big-bang PR.
+
+## Open questions
+
+- **Stripe & Google OAuth keys** — these are real (non-portfolio)
+  credentials. The migration must not log or echo them. Operator-only
+  step; agent should not handle their values.
+- **Sealing key backup destination** — operator's call. The runbook
+  will state requirements, not prescribe a destination.
+- **Where to put `secrets/` in the repo** — top-level or under
+  `k8s/secrets/`? Slight preference for top-level because it's a
+  cross-cutting concern (touches every namespace), but happy to defer
+  to convention.

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -48,6 +48,11 @@ if [ "$ENV" = "qa" ]; then
   kubectl apply -f "$SCRIPT_DIR/cert-manager/cluster-issuer.yml"
   kubectl apply -f "$SCRIPT_DIR/cert-manager/qa-certificates.yml"
 
+  echo "==> Installing Sealed Secrets controller (if not already present)..."
+  # Version pin documented in k8s/sealed-secrets/README.md.
+  kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/controller.yaml 2>/dev/null || true
+  kubectl wait --for=condition=available --timeout=120s deployment/sealed-secrets-controller -n kube-system 2>/dev/null || true
+
   echo "==> Deploying go-ecommerce-qa..."
   kubectl apply -k "$SCRIPT_DIR/overlays/qa-go"
 
@@ -131,6 +136,11 @@ kubectl apply -f "$SCRIPT_DIR/cert-manager/cluster-issuer.yml"
 kubectl apply -f "$SCRIPT_DIR/cert-manager/ca-certificate.yml"
 kubectl apply -f "$SCRIPT_DIR/cert-manager/issuer.yml"
 kubectl apply -f "$SCRIPT_DIR/cert-manager/certificates.yml"
+
+echo "==> Installing Sealed Secrets controller (if not already present)..."
+# Version pin documented in k8s/sealed-secrets/README.md.
+kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/controller.yaml 2>/dev/null || true
+kubectl wait --for=condition=available --timeout=120s deployment/sealed-secrets-controller -n kube-system 2>/dev/null || true
 
 kubectl apply -k "$REPO_DIR/go/k8s/overlays/$ENV"
 

--- a/k8s/sealed-secrets/README.md
+++ b/k8s/sealed-secrets/README.md
@@ -1,0 +1,114 @@
+# Sealed Secrets
+
+This directory is the cluster-level home for [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) — the secrets-management tool the project uses to commit encrypted Secret values to git safely.
+
+The actual controller install is fetched from a pinned upstream release (mirrors how `k8s/cert-manager/` works). Committed `*.sealed.yml` resources for individual Secrets land in `k8s/secrets/` in Phase 2 of the secrets-management migration; this directory holds the controller-level concerns only.
+
+> **Status:** Phase 1 of the migration plan in
+> `docs/superpowers/specs/2026-04-28-secrets-management-design.md`. The
+> controller is installed but no Secrets are sealed yet. Existing
+> `*.template.yml` files remain in place until Phase 2.
+
+## Version pin
+
+| Component | Version | Released | Source |
+|---|---|---|---|
+| `bitnami-labs/sealed-secrets` controller | `v0.36.6` | 2026-02 | <https://github.com/bitnami-labs/sealed-secrets/releases> |
+
+Refresh procedure when bumping:
+
+1. Check the [release notes](https://github.com/bitnami-labs/sealed-secrets/releases) for breaking changes — controller upgrades have historically been backwards-compatible, but read before assuming.
+2. Update the version pin in three places: this README, `k8s/deploy.sh`, and `.github/workflows/ci.yml` (Deploy QA + Deploy Production jobs).
+3. Open a small PR. The controller is hot-reloadable; no application restart is required.
+
+## Install (operator runbook)
+
+The CI deploy job and `k8s/deploy.sh` apply this automatically. The manual steps below are for fresh-cluster bootstrap.
+
+```bash
+# 1. Apply the controller (creates kube-system/sealed-secrets-controller).
+kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.36.6/controller.yaml
+
+# 2. Wait for the controller to be Ready.
+kubectl wait --for=condition=available --timeout=120s deployment/sealed-secrets-controller -n kube-system
+
+# 3. Verify the controller has minted a sealing keypair.
+kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealing-key=active
+```
+
+## kubeseal CLI install
+
+`kubeseal` is the client-side tool that encrypts a normal `Secret` into a `SealedSecret` against the cluster's public key. Install once on the operator's workstation:
+
+```bash
+# macOS
+brew install kubeseal
+
+# Verify against the live cluster
+kubeseal --fetch-cert --controller-namespace=kube-system
+```
+
+If `kubeseal --fetch-cert` returns a PEM block, the controller is reachable and the local CLI is wired up.
+
+## Sealing-key custody
+
+**The single load-bearing operational artifact in this whole system is the cluster's sealing keypair.** It lives as a Secret labeled `sealedsecrets.bitnami.com/sealing-key=active` in `kube-system`. If the cluster is destroyed and the sealing key is not restored, every committed `*.sealed.yml` in this repo becomes un-decryptable.
+
+### Backup procedure
+
+Run after the controller is first deployed, and again any time the controller rotates the key (it doesn't rotate by default — rotation is opt-in):
+
+```bash
+# Export the active sealing key(s) to a local file.
+kubectl get secret -n kube-system \
+  -l sealedsecrets.bitnami.com/sealing-key=active \
+  -o yaml > sealing-key-backup-$(date +%Y%m%d).yaml
+```
+
+Store the exported file in the operator's encrypted personal vault (1Password, age-encrypted file in a separate repo, etc.). **Do not commit it.**
+
+### Restore procedure (after `minikube delete` or cluster rebuild)
+
+```bash
+# Apply the backed-up key BEFORE the controller starts for the first time
+# (or restart the controller after applying so it adopts the existing key).
+kubectl apply -f sealing-key-backup-YYYYMMDD.yaml
+kubectl rollout restart deployment/sealed-secrets-controller -n kube-system
+```
+
+The controller will adopt the restored key, and all committed `*.sealed.yml` in the repo will decrypt against it.
+
+## Sealing a Secret (forward reference, Phase 2)
+
+The full migration uses this pattern. Documented here for completeness; not yet exercised in this phase.
+
+```bash
+# 1. Build a regular Secret manifest (do not commit this file).
+cat <<EOF > /tmp/example-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+  namespace: default
+type: Opaque
+stringData:
+  api-key: super-secret-value
+EOF
+
+# 2. Encrypt it against the cluster's public key.
+kubeseal \
+  --controller-namespace=kube-system \
+  --format=yaml \
+  < /tmp/example-secret.yaml \
+  > k8s/secrets/default/example-secret.sealed.yml
+
+# 3. Commit the .sealed.yml. The controller materializes a real
+#    Secret with the same name when applied.
+rm /tmp/example-secret.yaml
+```
+
+## What's NOT here
+
+- The controller manifest YAML itself (~2000 lines). Fetched from the upstream release URL at deploy time, like cert-manager.
+- Committed `*.sealed.yml` resources. Those land in `k8s/secrets/<namespace>/` in Phase 2.
+- The sealing-key backup file. Out-of-band, by design.


### PR DESCRIPTION
## Summary

Phase 1 of the secrets-management migration plan in `docs/superpowers/specs/2026-04-28-secrets-management-design.md`. Lands the [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) controller only — no existing manifests change, no live Secrets are migrated yet (that's Phase 2).

The migration's full shape is in the spec; the short version is: the repo's credential surface today has known gaps (drift between `*.template.yml` and the live cluster, plaintext passwords inside ConfigMap DSN strings, no bootstrap runbook). Sealed Secrets + a DSN component split is the planned fix. This PR is just the tool install.

## What this PR does

- **`k8s/sealed-secrets/README.md`** — version pin (v0.36.6), `kubeseal` CLI install for the operator, the sealing-key custody and backup procedure (the one load-bearing artifact), and the pattern Phase 2 will use to seal individual Secrets.
- **`.github/workflows/ci.yml`** — `Deploy QA` and `Deploy Production` jobs install the controller from the pinned upstream URL and wait for it to be Ready. Same pattern as cert-manager.
- **`k8s/deploy.sh`** — local `minikube`/`aws`/`qa` paths install the controller too.
- **K8s Manifest Validation** — skips `*/sealed-secrets/*` (consistent with `*/cert-manager/*`).

## What this PR does NOT do

- Migrate any existing live Secret. Four Secrets (`java-secrets`, `go-secrets`, `stripe-secrets`, `telegram-bot`) stay exactly as they are. Phase 2.
- Close the template-vs-live drift. Phase 3.
- Split DSN strings into ConfigMap + Secret components. Phase 4.
- Add a CI guardrail for plaintext credentials in ConfigMaps. Phase 5.

## Test plan

- [ ] CI: `K8s Manifest Validation` job passes with the new skip.
- [ ] After merge to qa: `Deploy QA` succeeds; `kubectl get deploy sealed-secrets-controller -n kube-system` shows Available.
- [ ] After merge to main: same in prod.
- [ ] Operator: install `kubeseal` locally (`brew install kubeseal`) and confirm `kubeseal --fetch-cert --controller-namespace=kube-system` returns a PEM block from both QA and prod.
- [ ] Operator: take and store the sealing-key backup per the README before doing anything destructive (this is the prerequisite for Phase 2 being safe).