### PR TITLE
feat(database): add Redis tab to /database

### DIFF
--- a/docs/superpowers/specs/2026-04-28-redis-database-tab-design.md
+++ b/docs/superpowers/specs/2026-04-28-redis-database-tab-design.md
@@ -1,0 +1,140 @@
+# Redis tab on /database
+
+## Context
+
+The `/database` portfolio page currently has three tabs — PostgreSQL, NoSQL, Vector. The NoSQL tab is a one-paragraph stub for MongoDB that already references Redis as a side note. Redis is actually used in eight distinct patterns across the codebase (caching, rate limiting, idempotency, JWT denylist, analytics windowing, Spring `@Cacheable`, etc.) and deserves first-class treatment alongside the other database technologies. This spec adds a Redis tab and tightens up the surrounding tab structure.
+
+## Goals
+
+1. Add a first-class **Redis** tab to `/database`, positioned between PostgreSQL and the document-store tab.
+2. Rename the existing **NoSQL** tab to **MongoDB**, since the content has only ever covered MongoDB.
+3. Tell the full Redis story across five pillars: caching, rate limiting, HTTP idempotency, JWT denylist, time-windowed analytics — plus a closing operational-discipline paragraph that ties them together.
+4. Keep the new tab visually and structurally consistent with the existing PostgresTab (sticky TOC, `PillarSection` components, ADR/spec links).
+
+## Non-goals
+
+- New backend code. This is a frontend documentation change against an existing architecture.
+- Changes to MongoDB/Vector tab content (beyond the rename).
+- Benchmarks or performance numbers — none currently exist for the Redis flows, and we're not going to fabricate them.
+
+## Architecture
+
+Frontend-only. Edits scoped to:
+
+- `frontend/src/components/database/tabs.ts` — extend `DatabaseTab` type, reorder/rename entries.
+- `frontend/src/app/database/page.tsx` — add a render branch for the new tab key.
+- `frontend/src/components/database/NoSqlTab.tsx` → `MongoDbTab.tsx` — rename file + component + `data-testid`. Content-light; just a name and prose touch-up to remove the "Redis as a side note" sentence (Redis now has its own tab).
+- `frontend/src/components/database/RedisTab.tsx` — **new** component, modeled after `PostgresTab.tsx` (TOC items, `PillarSection`s, mobile chip / desktop sidebar layout).
+- `frontend/e2e/mocked/database-page.spec.ts` — update tab-label assertions; add Redis tab activation + pillar/anchor coverage.
+
+The Redis tab follows the same shape as `PostgresTab`: a TOC list at the top of the file, a `<div data-testid="redis-tab">` with mobile chips, a `space-y-16` column of `PillarSection`s, and a sticky sidebar for desktop.
+
+## Tab structure
+
+Final tab order: **PostgreSQL · Redis · MongoDB · Vector** (`postgres → redis → mongodb → vector`).
+
+`DatabaseTab` becomes `"postgres" | "redis" | "mongodb" | "vector"`. The `databaseTabs` array reorders to match. The MongoDB tab keeps the same "stub points at /java" shape it has today; only the visible label and `data-testid` change.
+
+## Pillars (RedisTab)
+
+Sticky TOC items, in order:
+
+```
+caching → rate-limiting → idempotency → denylist → analytics
+```
+
+### 1. `id="caching"` — Read-Side Caching
+
+Narrative: caching layered on top of a healthy primary store, never as a load-bearing dependency. Two languages, two styles.
+
+Bullets:
+
+- Go `Cache` interface (`go/ai-service/internal/cache/cache.go`): bytes in, bytes out — callers handle their own serialization, so the cache stays transport-agnostic. `RedisCache` for prod, `NopCache` for dev / when Redis is unavailable.
+- Per-prefix namespacing (e.g., `ai:tools:<tool>:<args-hash>`, `product:catalog:<id>`); makes key inspection in `redis-cli` trivial and bounds blast radius if a prefix needs invalidation.
+- AI tool-result cache (`go/ai-service/internal/tools/cached.go`) memoizes deterministic tool calls so an agent loop doesn't pay Redis latency on identical sub-queries.
+- Product catalog cache (`go/product-service/internal/service/product.go`) — short-TTL read-through for hot product reads.
+- Java: Spring `@Cacheable` on `project-stats` and `project-velocity` queries in `task-service` (`AnalyticsService.java`). Declarative, swappable via `CacheConfig`. Same Redis instance backs Spring's cache abstraction.
+- Cross-cutting: every Redis call goes through a circuit breaker (`gobreaker`); on trip, calls fail open (cache miss for reads, skip-write for writes). OTel Redis spans (`tracing.RedisSpan`) capture every operation for end-to-end traces.
+
+### 2. `id="rate-limiting"` — Per-IP Rate Limiting
+
+Narrative: a fixed-window limiter is the simplest correct thing. `INCR` + `EXPIRE` per IP per window — no token bucket, no Lua, no surprises. Used wherever the gateway-level CDN rules don't reach (auth, ecommerce, AI agent).
+
+Bullets:
+
+- Implementation: `go/ai-service/internal/guardrails/ratelimit.go` (canonical) and per-service middleware in `auth`, `order`, `cart`.
+- Pattern: `INCR key`; if value is 1, `EXPIRE key window`; reject when value exceeds `max`. Returns `Retry-After: <seconds-until-window-end>`.
+- Per-service prefixes (`ai:ratelimit:<ip>`, `auth:ratelimit:<ip>`, etc.) so a single Redis instance serves multiple services without collision.
+- Fail-open: if the Redis breaker is open, the limiter allows traffic. Better to skip rate limiting briefly than to 503 every request — the upstream load balancer + the Postgres connection pool ceiling are the next-layer brakes.
+- Trade-off note: fixed-window has a known burst-at-boundary edge case. Documented in the file; acceptable given the protection profile.
+
+### 3. `id="idempotency"` — HTTP Idempotency-Key
+
+Narrative: POST `/orders` and POST `/cart` need to be retry-safe — flaky networks, saga compensations, and the user smashing the buy button shouldn't create duplicate orders. RFC-style `Idempotency-Key` middleware backs both.
+
+Bullets:
+
+- Middleware: `go/order-service/internal/middleware/idempotency.go`, mirrored in `cart-service`.
+- Two-phase Redis entry per key:
+  - **In-flight marker** (`PROCESSING`, 30 s TTL) set on the first request — concurrent duplicates with the same key get a 409 instead of racing.
+  - **Completed-response cache** (status code + body, 24 h TTL) written when the handler returns — subsequent retries with the same key replay the original response byte-for-byte.
+- Key shape: `idempotency:<route>:<idempotency-key-header>` keyed under a per-route prefix so accidental key reuse across routes can't replay the wrong response.
+- `responseCapture` wraps `gin.ResponseWriter` so the handler's body is buffered for caching without changing the handler signature.
+- Why this matters in this portfolio specifically: the saga orchestrator retries on transient gRPC failures, and idempotency is the only thing standing between a network blip and a duplicate charge.
+
+### 4. `id="denylist"` — JWT Token Denylist
+
+Narrative: stateless JWTs are great for read-side performance but terrible at "the user just clicked logout." A small Redis denylist closes the gap without sacrificing the stateless-verification win — verification adds one `EXISTS` check, revocation is one `SET … EX <remaining-ttl>`.
+
+Bullets:
+
+- Implementation: `go/auth-service/internal/service/token_denylist.go`.
+- Key shape: `auth:denied:<sha256-of-token>` with TTL matching the token's remaining lifetime. Hashing avoids leaking the token; aligned TTL avoids unbounded growth.
+- Logout flow: handler calls `denylist.Revoke(token, ttl)`; subsequent requests presenting the same token hit the deny check first and 401.
+- Graceful degradation: a `nil` Redis client is a valid construction — revocation becomes a no-op and tokens expire naturally. Used in dev / unit tests.
+- Trade-off note: introduces a per-request Redis hop on every authenticated call. Acceptable for the use case; a future optimization is a bloom filter in front of the denylist if RPS climbs.
+
+### 5. `id="analytics"` — Time-Windowed Analytics
+
+Narrative: the analytics service runs a Kafka consumer over `ecommerce.orders` / `ecommerce.cart` / `ecommerce.views` and writes time-bucketed counters into Redis. Each metric has an explicit TTL — no unbounded growth, no hand-rolled cleanup cron.
+
+Bullets:
+
+- Store: `go/analytics-service/internal/store/redis.go`.
+- Three metrics, three retention windows:
+  - **Revenue** (`analytics:revenue:<hour>`) — 48 h TTL, hourly granularity.
+  - **Trending products** (`analytics:trending:<hour>`) — 2 h TTL, sorted-set scored by view/order signals.
+  - **Cart abandonment** (`analytics:abandonment:<hour>` + `analytics:abandonment:users:<user>`) — 24 h TTL, hash + per-user marker for dedup.
+- Hourly bucket keys (`2006-01-02T15` Go time layout) make range queries a simple key sweep over the last N hours; no SCAN cursor or sorted-set range needed for the common case.
+- Trade-off note: sub-hour granularity isn't supported; deliberate choice to keep keys legible and the dashboard math obvious. If finer resolution is needed later, the bucket layout is a one-line change.
+- Operational signals: standard Redis breaker / OTel span / fail-open story applies — analytics is best-effort, never blocks the write path.
+
+## Closing operational note
+
+A short paragraph at the bottom of the tab (under the last pillar, no separate `PillarSection`) ties the patterns together:
+
+> Every Redis call in this portfolio is wrapped in a circuit breaker that fails open, every key is namespaced and TTL'd, and every operation gets an OpenTelemetry span via `tracing.RedisSpan` so a single trace shows the cache hit between the HTTP handler and the Postgres query. The discipline isn't visible in any single use case — it's the reason none of them have ever taken down the request path.
+
+## Testing
+
+- `npx tsc --noEmit` clean.
+- `npx eslint src/` — no new errors (existing warnings allowed).
+- `npx next build` — succeeds.
+- E2E (`frontend/e2e/mocked/database-page.spec.ts`):
+  - Tab labels: PostgreSQL · Redis · MongoDB · Vector.
+  - Click "Redis" → `[data-testid="redis-tab"]` visible; pillar headings render; anchor IDs `caching`, `rate-limiting`, `idempotency`, `denylist`, `analytics` are present; sidebar TOC labels are in order.
+  - Click "MongoDB" → existing `[data-testid="mongodb-tab"]` (renamed) visible, `/java` link still points correctly.
+- Manual: load `/database` in the dev server, click through all four tabs, verify TOC chip + sidebar render correctly on the Redis tab.
+
+## Delivery
+
+- Branch: `agent/feat-redis-database-tab`, off `qa` (not `main` — recent merges including the Redis-using infrastructure docs are not yet on main and this PR is intentionally not main-bound until other blockers clear).
+- Worktree: `.claude/worktrees/agent-feat-redis-database-tab/`.
+- Single PR to `qa`. Frontend-only diff; small enough for a one-shot review.
+- No Vercel env-var changes — no new `NEXT_PUBLIC_*` vars introduced.
+
+## Risks & mitigations
+
+- **MongoDB tab rename surface area.** Tab key change ripples through the renderer, the test IDs, and the Playwright spec. Mitigation: do all three in the same commit; verify with `grep` for any other consumer of `"nosql"` before pushing.
+- **Pillar copy drift.** The bullets reference specific file paths (`cached.go`, `idempotency.go`, etc.). Mitigation: every reference is verified against the worktree at write time, and links use stable file paths rather than line ranges.
+- **Tab strip overflow.** Four tabs at typical viewport widths still fit comfortably (the existing tab buttons are short). Mitigation: visual check during dev-server testing; the existing tab-bar component is responsive.

--- a/frontend/e2e/mocked/database-page.spec.ts
+++ b/frontend/e2e/mocked/database-page.spec.ts
@@ -8,24 +8,33 @@ test.describe("/database page", () => {
     ).toBeVisible();
   });
 
-  test("renders all three tab labels", async ({ page }) => {
+  test("renders all four tab labels", async ({ page }) => {
     await page.goto("/database");
     await expect(page.getByRole("button", { name: "PostgreSQL", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "NoSQL", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Redis", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "MongoDB", exact: true })).toBeVisible();
     await expect(page.getByRole("button", { name: "Vector", exact: true })).toBeVisible();
   });
 
   test("PostgreSQL tab is active by default", async ({ page }) => {
     await page.goto("/database");
     await expect(page.getByTestId("postgres-tab")).toBeVisible();
-    await expect(page.getByTestId("nosql-tab")).not.toBeVisible();
+    await expect(page.getByTestId("redis-tab")).not.toBeVisible();
+    await expect(page.getByTestId("mongodb-tab")).not.toBeVisible();
     await expect(page.getByTestId("vector-tab")).not.toBeVisible();
   });
 
-  test("clicking NoSQL switches to the NoSQL tab", async ({ page }) => {
+  test("clicking Redis switches to the Redis tab", async ({ page }) => {
     await page.goto("/database");
-    await page.getByRole("button", { name: "NoSQL", exact: true }).click();
-    await expect(page.getByTestId("nosql-tab")).toBeVisible();
+    await page.getByRole("button", { name: "Redis", exact: true }).click();
+    await expect(page.getByTestId("redis-tab")).toBeVisible();
+    await expect(page.getByTestId("postgres-tab")).not.toBeVisible();
+  });
+
+  test("clicking MongoDB switches to the MongoDB tab", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "MongoDB", exact: true }).click();
+    await expect(page.getByTestId("mongodb-tab")).toBeVisible();
     await expect(page.getByTestId("postgres-tab")).not.toBeVisible();
   });
 
@@ -35,12 +44,55 @@ test.describe("/database page", () => {
     await expect(page.getByTestId("vector-tab")).toBeVisible();
   });
 
-  test("NoSQL stub points to /java", async ({ page }) => {
+  test("MongoDB stub points to /java", async ({ page }) => {
     await page.goto("/database");
-    await page.getByRole("button", { name: "NoSQL", exact: true }).click();
+    await page.getByRole("button", { name: "MongoDB", exact: true }).click();
     await expect(page.getByText("MongoDB powers the activity feed", { exact: false })).toBeVisible();
     const link = page.getByRole("link", { name: /View MongoDB usage in \/java/ });
     await expect(link).toHaveAttribute("href", "/java");
+  });
+
+  test("Redis tab renders all five pillar headings", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Redis", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: /Read-Side Caching/, level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Per-IP Rate Limiting/, level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /HTTP Idempotency-Key/, level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /JWT Token Denylist/, level: 2 }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Time-Windowed Analytics/, level: 2 }),
+    ).toBeVisible();
+  });
+
+  test("Redis tab pillars have stable anchor ids", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Redis", exact: true }).click();
+    for (const id of ["caching", "rate-limiting", "idempotency", "denylist", "analytics"]) {
+      await expect(page.locator(`#${id}`)).toBeVisible();
+    }
+  });
+
+  test("Redis tab TOC labels render in order", async ({ page }) => {
+    await page.goto("/database");
+    await page.getByRole("button", { name: "Redis", exact: true }).click();
+    const sidebarLabels = await page
+      .locator('[data-testid="sticky-toc-sidebar"] a')
+      .allTextContents();
+    expect(sidebarLabels.map((s) => s.trim())).toEqual([
+      "Read-Side Caching",
+      "Rate Limiting",
+      "HTTP Idempotency",
+      "JWT Denylist",
+      "Time-Windowed Analytics",
+    ]);
   });
 
   test("Vector stub points to /ai", async ({ page }) => {

--- a/frontend/src/app/database/page.tsx
+++ b/frontend/src/app/database/page.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { databaseTabs, type DatabaseTab } from "@/components/database/tabs";
 import { PostgresTab } from "@/components/database/PostgresTab";
-import { NoSqlTab } from "@/components/database/NoSqlTab";
+import { RedisTab } from "@/components/database/RedisTab";
+import { MongoDbTab } from "@/components/database/MongoDbTab";
 import { VectorTab } from "@/components/database/VectorTab";
 
 export default function DatabasePage() {
@@ -21,8 +22,10 @@ export default function DatabasePage() {
           <code>pg_stat_statements</code> + <code>auto_explain</code>,
           point-in-time recovery with verified backups, a custom AST-based
           migration linter, and range partitioning with materialized views for
-          reporting. MongoDB and Qdrant are also in use elsewhere in the
-          portfolio — dedicated tabs for each are coming.
+          reporting. Redis underpins caching, rate limiting, HTTP idempotency,
+          JWT revocation, and time-windowed analytics across the Go stack and
+          Spring <code>@Cacheable</code> in the Java stack. MongoDB and Qdrant
+          are also in use elsewhere — dedicated tabs for each are coming.
         </p>
       </section>
 
@@ -50,7 +53,8 @@ export default function DatabasePage() {
         {/* Tab Content */}
         <div className="mt-8">
           {activeTab === "postgres" && <PostgresTab />}
-          {activeTab === "nosql" && <NoSqlTab />}
+          {activeTab === "redis" && <RedisTab />}
+          {activeTab === "mongodb" && <MongoDbTab />}
           {activeTab === "vector" && <VectorTab />}
         </div>
       </section>

--- a/frontend/src/components/database/MongoDbTab.tsx
+++ b/frontend/src/components/database/MongoDbTab.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 
-export function NoSqlTab() {
+export function MongoDbTab() {
   return (
-    <div data-testid="nosql-tab" className="space-y-6">
+    <div data-testid="mongodb-tab" className="space-y-6">
       <p className="text-muted-foreground leading-relaxed">
         MongoDB powers the activity feed and analytics aggregations in the
-        Java task-management portfolio — document-shaped activity events,
-        time-bucketed aggregations, and a Redis read-cache layered on top.
-        A dedicated NoSQL section is on the way; for now, the running code
+        Java task-management portfolio — document-shaped activity events
+        and time-bucketed aggregations served back through GraphQL. A
+        dedicated MongoDB section is on the way; for now, the running code
         and its supporting docs live on the Java page.
       </p>
       <div>

--- a/frontend/src/components/database/RedisTab.tsx
+++ b/frontend/src/components/database/RedisTab.tsx
@@ -1,0 +1,371 @@
+import { PillarSection } from "@/components/database/PillarSection";
+import {
+  StickyTocChips,
+  StickyTocSidebar,
+  type StickyTocItem,
+} from "@/components/database/StickyToc";
+
+const REPO = "https://github.com/kabradshaw1/portfolio";
+
+const tocItems: StickyTocItem[] = [
+  { id: "caching", label: "Read-Side Caching" },
+  { id: "rate-limiting", label: "Rate Limiting" },
+  { id: "idempotency", label: "HTTP Idempotency" },
+  { id: "denylist", label: "JWT Denylist" },
+  { id: "analytics", label: "Time-Windowed Analytics" },
+];
+
+export function RedisTab() {
+  return (
+    <div data-testid="redis-tab" className="md:grid md:grid-cols-[1fr_220px] md:gap-10">
+      {/* Mobile chip TOC: top of tab content, hidden at md+. */}
+      <div className="md:hidden">
+        <StickyTocChips items={tocItems} />
+      </div>
+
+      <div className="space-y-16 min-w-0">
+        <PillarSection
+          id="caching"
+          title="Read-Side Caching — Two Languages, One Discipline"
+          narrative={
+            <>
+              <p>
+                Caching is layered on top of a healthy primary store, never as a
+                load-bearing dependency. Both the Go services and the Java
+                <code> task-service</code> talk to the same Redis instance, but
+                they reach it through idiomatic abstractions in each language —
+                a small Go interface that keeps the cache transport-agnostic,
+                and Spring&apos;s <code>@Cacheable</code> for declarative
+                method-level caching.
+              </p>
+              <p>
+                The shared rule across both sides: every cache call goes
+                through a circuit breaker that fails open. When Redis is
+                unavailable, reads become misses and writes become no-ops —
+                the request path keeps working.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Go <code>Cache</code> interface (<code>go/ai-service/internal/cache/cache.go</code>):
+              bytes in, bytes out. Callers handle their own serialization, so
+              the cache stays transport-agnostic. <code>RedisCache</code> for
+              prod, <code>NopCache</code> for dev or when Redis is disabled.
+            </>,
+            <>
+              Per-prefix namespacing (e.g.{" "}
+              <code>ai:tools:&lt;tool&gt;:&lt;args-hash&gt;</code>,{" "}
+              <code>product:catalog:&lt;id&gt;</code>) — key inspection in{" "}
+              <code>redis-cli</code> stays trivial and a single prefix can be
+              invalidated without affecting unrelated entries.
+            </>,
+            <>
+              AI tool-result cache (<code>go/ai-service/internal/tools/cached.go</code>)
+              memoizes deterministic tool calls so an agent loop doesn&apos;t
+              pay repeated Redis or upstream latency on identical sub-queries
+              within the same conversation.
+            </>,
+            <>
+              Product catalog cache (<code>go/product-service/internal/service/product.go</code>):
+              short-TTL read-through for hot product reads — keeps Postgres
+              free for writes during catalog browsing spikes.
+            </>,
+            <>
+              Java: Spring <code>@Cacheable</code> on <code>project-stats</code>{" "}
+              and <code>project-velocity</code> in{" "}
+              <code>task-service/AnalyticsService.java</code>. Declarative,
+              swappable via <code>CacheConfig</code>; the same Redis instance
+              backs Spring&apos;s cache abstraction.
+            </>,
+            <>
+              Cross-cutting: every Redis call wrapped in{" "}
+              <code>gobreaker</code>; on trip, reads fail open (cache miss),
+              writes are skipped. OpenTelemetry Redis spans via{" "}
+              <code>tracing.RedisSpan</code> render the cache hit/miss in
+              Jaeger between the HTTP handler and the Postgres query.
+            </>,
+          ]}
+          links={[
+            {
+              label: "Go Cache interface",
+              href: `${REPO}/blob/main/go/ai-service/internal/cache/cache.go`,
+            },
+            {
+              label: "Spring CacheConfig",
+              href: `${REPO}/blob/main/java/task-service/src/main/java/dev/kylebradshaw/task/config/CacheConfig.java`,
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="rate-limiting"
+          title="Per-IP Rate Limiting — Fixed Window, Fail-Open"
+          narrative={
+            <>
+              <p>
+                A fixed-window limiter is the simplest correct thing: <code>INCR</code>
+                {" "}plus <code>EXPIRE</code>, one Redis round-trip per request,
+                no Lua, no token bucket, no surprises. The same pattern lives
+                in <code>auth-service</code>, <code>order-service</code>,{" "}
+                <code>cart-service</code>, and <code>ai-service</code> — each
+                with its own key prefix so a single Redis instance can serve
+                all four without collision.
+              </p>
+              <p>
+                The trade-off is documented in the file: fixed windows have a
+                known burst-at-boundary edge (a client could double-spend at
+                the second a window flips). For the protection profile here —
+                abuse blunting, not strict QoS — that&apos;s acceptable.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Canonical implementation:{" "}
+              <code>go/ai-service/internal/guardrails/ratelimit.go</code>;
+              mirrored as middleware in <code>auth</code>, <code>order</code>,
+              and <code>cart</code>.
+            </>,
+            <>
+              Pattern: <code>INCR key</code>; if value is 1,{" "}
+              <code>EXPIRE key window</code>; reject when value exceeds{" "}
+              <code>max</code>. Returns{" "}
+              <code>Retry-After: &lt;seconds-until-window-end&gt;</code> so
+              well-behaved clients back off cleanly.
+            </>,
+            <>
+              Per-service prefixes (<code>ai:ratelimit:&lt;ip&gt;</code>,{" "}
+              <code>auth:ratelimit:&lt;ip&gt;</code>, etc.) — one Redis serves
+              every service without key collision or accidental cross-service
+              throttling.
+            </>,
+            <>
+              Fail-open: if the Redis breaker is open, the limiter allows
+              traffic. Skipping rate limiting briefly is better than 503&apos;ing
+              every request — the upstream load balancer and the Postgres
+              connection pool ceiling are the next-layer brakes.
+            </>,
+            <>
+              Per-route ceilings tuned per service (e.g.{" "}
+              <code>POST /agent/chat</code> is much tighter than{" "}
+              <code>GET /products</code>) so expensive endpoints can&apos;t be
+              spammed even when the cheap ones aren&apos;t.
+            </>,
+          ]}
+          links={[
+            {
+              label: "AI rate limiter",
+              href: `${REPO}/blob/main/go/ai-service/internal/guardrails/ratelimit.go`,
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="idempotency"
+          title="HTTP Idempotency-Key — Safe Retries"
+          narrative={
+            <>
+              <p>
+                <code>POST /orders</code> and <code>POST /cart/checkout</code>
+                {" "}have to be retry-safe. Flaky networks, saga compensations,
+                and the user smashing the buy button shouldn&apos;t create
+                duplicate orders. RFC-style{" "}
+                <code>Idempotency-Key</code> middleware backs both endpoints,
+                using a two-phase Redis entry per key.
+              </p>
+              <p>
+                Why this matters in this portfolio specifically: the saga
+                orchestrator retries on transient gRPC failures, and idempotency
+                is the only thing standing between a network blip and a
+                duplicate charge.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Middleware:{" "}
+              <code>go/order-service/internal/middleware/idempotency.go</code>,
+              mirrored in <code>cart-service</code>.
+            </>,
+            <>
+              <strong>Phase 1 — in-flight marker:</strong> when a key first
+              arrives, write <code>PROCESSING</code> with a 30 s TTL.
+              Concurrent duplicates with the same key get a 409 instead of
+              racing to write the same order twice.
+            </>,
+            <>
+              <strong>Phase 2 — completed-response cache:</strong> when the
+              handler returns, write the captured status code + body with a
+              24 h TTL. Subsequent retries with the same key replay the
+              original response byte-for-byte — no &ldquo;was that order
+              actually created?&rdquo; round-trip back to Postgres.
+            </>,
+            <>
+              Key shape:{" "}
+              <code>idempotency:&lt;route&gt;:&lt;idempotency-key-header&gt;</code>
+              . The per-route prefix prevents accidental key reuse across
+              endpoints from replaying the wrong response.
+            </>,
+            <>
+              <code>responseCapture</code> wraps <code>gin.ResponseWriter</code>{" "}
+              so the handler&apos;s body is buffered for caching without
+              changing handler signatures or duplicating serialization logic.
+            </>,
+            <>
+              Fail-open: if Redis is unavailable, the middleware logs and lets
+              the request through. The downstream guard is Postgres&apos; own
+              uniqueness constraints (idempotency keys are also persisted on
+              the order row), so retries can&apos;t create duplicates even with
+              the cache disabled.
+            </>,
+          ]}
+          links={[
+            {
+              label: "order-service idempotency",
+              href: `${REPO}/blob/main/go/order-service/internal/middleware/idempotency.go`,
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="denylist"
+          title="JWT Token Denylist — Cheap Revocation Without Sessions"
+          narrative={
+            <>
+              <p>
+                Stateless JWTs are great for read-side performance but terrible
+                at &ldquo;the user just clicked logout.&rdquo; A small Redis
+                denylist closes the gap without sacrificing the
+                stateless-verification win — verification adds one{" "}
+                <code>EXISTS</code> check; revocation is a single{" "}
+                <code>SET … EX &lt;remaining-ttl&gt;</code>.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Implementation:{" "}
+              <code>go/auth-service/internal/service/token_denylist.go</code>.
+            </>,
+            <>
+              Key shape: <code>auth:denied:&lt;sha256-of-token&gt;</code>.
+              Hashing avoids leaking the token in Redis itself or in any logs
+              that capture key names.
+            </>,
+            <>
+              TTL aligned to the token&apos;s remaining lifetime — once the
+              token would have expired anyway, the denylist entry self-cleans.
+              Avoids unbounded denylist growth without a sweep job.
+            </>,
+            <>
+              Logout handler calls <code>denylist.Revoke(token, ttl)</code>;
+              every authenticated request hits the deny check before the
+              handler runs.
+            </>,
+            <>
+              Graceful degradation: a <code>nil</code> Redis client is a valid
+              construction. Revocation becomes a no-op and tokens expire
+              naturally — used in dev environments and unit tests.
+            </>,
+            <>
+              Trade-off note: introduces a per-request Redis hop on every
+              authenticated call. Acceptable for current RPS; a future
+              optimization would be a bloom filter in front of the denylist if
+              throughput climbs.
+            </>,
+          ]}
+          links={[
+            {
+              label: "Token denylist",
+              href: `${REPO}/blob/main/go/auth-service/internal/service/token_denylist.go`,
+            },
+          ]}
+        />
+
+        <PillarSection
+          id="analytics"
+          title="Time-Windowed Analytics — Bucketed Counters with TTLs"
+          narrative={
+            <>
+              <p>
+                The analytics service runs a Kafka consumer over{" "}
+                <code>ecommerce.orders</code>, <code>ecommerce.cart</code>, and{" "}
+                <code>ecommerce.views</code>, then writes time-bucketed counters
+                into Redis. Each metric has an explicit retention window — no
+                unbounded growth, no hand-rolled cleanup cron, just per-key TTLs
+                that match the dashboard query window.
+              </p>
+            </>
+          }
+          bullets={[
+            <>
+              Store: <code>go/analytics-service/internal/store/redis.go</code>.
+            </>,
+            <>
+              <strong>Revenue</strong> (
+              <code>analytics:revenue:&lt;hour&gt;</code>) — 48 h TTL, hourly
+              granularity. Daily revenue charts read 24 keys, weekly reads 168.
+            </>,
+            <>
+              <strong>Trending products</strong> (
+              <code>analytics:trending:&lt;hour&gt;</code>) — 2 h TTL,
+              sorted-set scored by view/order signals. The short window is
+              deliberate: trending is a near-real-time concept, stale data is
+              worse than no data.
+            </>,
+            <>
+              <strong>Cart abandonment</strong> (
+              <code>analytics:abandonment:&lt;hour&gt;</code> +
+              {" "}<code>analytics:abandonment:users:&lt;user&gt;</code>) — 24 h
+              TTL. Hash for aggregate counters, per-user marker for dedup so a
+              single abandoned cart counts once.
+            </>,
+            <>
+              Hourly bucket keys use the Go time layout{" "}
+              <code>2006-01-02T15</code> — range queries become a deterministic
+              key sweep over the last N hours, no <code>SCAN</code> cursor or
+              sorted-set range needed for the common case.
+            </>,
+            <>
+              Sub-hour granularity isn&apos;t supported; deliberate choice to
+              keep keys legible and dashboard math obvious. If finer resolution
+              is needed later, the bucket layout is a one-line change.
+            </>,
+            <>
+              Standard Redis breaker / OTel span / fail-open story applies —
+              analytics is best-effort and never blocks the write path.
+            </>,
+          ]}
+          links={[
+            {
+              label: "Analytics Redis store",
+              href: `${REPO}/blob/main/go/analytics-service/internal/store/redis.go`,
+            },
+          ]}
+        />
+
+        {/* Closing operational note */}
+        <section className="rounded-lg border border-foreground/10 bg-card p-6">
+          <h3 className="text-base font-semibold">
+            Operational discipline (the boring part that keeps it boring)
+          </h3>
+          <p className="mt-3 text-sm text-muted-foreground leading-relaxed">
+            Every Redis call in this portfolio is wrapped in a circuit breaker
+            that fails open, every key is namespaced and TTL&apos;d, and every
+            operation gets an OpenTelemetry span via{" "}
+            <code>tracing.RedisSpan</code> so a single trace shows the cache
+            hit between the HTTP handler and the Postgres query. The
+            discipline isn&apos;t visible in any single use case — it&apos;s the
+            reason none of them have ever taken down the request path.
+          </p>
+        </section>
+      </div>
+
+      {/* Desktop sidebar TOC: right column at md+. */}
+      <aside className="hidden md:block">
+        <StickyTocSidebar items={tocItems} />
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/database/tabs.ts
+++ b/frontend/src/components/database/tabs.ts
@@ -1,7 +1,8 @@
-export type DatabaseTab = "postgres" | "nosql" | "vector";
+export type DatabaseTab = "postgres" | "redis" | "mongodb" | "vector";
 
 export const databaseTabs: { key: DatabaseTab; label: string }[] = [
   { key: "postgres", label: "PostgreSQL" },
-  { key: "nosql", label: "NoSQL" },
+  { key: "redis", label: "Redis" },
+  { key: "mongodb", label: "MongoDB" },
   { key: "vector", label: "Vector" },
 ];


### PR DESCRIPTION
## Summary

Adds a first-class **Redis** tab to \`/database\`, positioned between PostgreSQL and the document-store tab. Renames the existing **NoSQL** tab to **MongoDB** so the label matches the content.

Final tab order: PostgreSQL · Redis · MongoDB · Vector.

## Five Redis pillars

1. **Read-Side Caching** — Go \`Cache\` interface + Spring \`@Cacheable\`, both circuit-breaker-protected and fail-open.
2. **Per-IP Rate Limiting** — fixed-window \`INCR\`/\`EXPIRE\` shared across auth/order/cart/ai middleware.
3. **HTTP Idempotency-Key** — in-flight marker (30s) + completed-response cache (24h) on order/cart writes.
4. **JWT Token Denylist** — SHA256-hashed keys, TTL aligned to remaining token lifetime, graceful degradation when Redis is nil.
5. **Time-Windowed Analytics** — revenue (48h), trending (2h), abandonment (24h), hourly bucket keys fed by the Kafka consumer.

A closing operational note ties together the cross-cutting discipline (circuit breakers + fail-open, key prefixing + TTLs, OTel Redis spans).

## Spec

\`docs/superpowers/specs/2026-04-28-redis-database-tab-design.md\`

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint src/\` — no new errors
- [x] \`npx next build\` — succeeds
- [x] \`npx playwright test e2e/mocked/database-page.spec.ts\` — 19/19 pass (includes new Redis tab activation, pillar headings, anchor ids, TOC ordering)
- [ ] Manual on QA: load \`/database\`, click through all four tabs, verify the Redis tab renders pillars and the sticky TOC chips/sidebar work

🤖 Generated with [Claude Code](https://claude.com/claude-code)