### PR TITLE
fix(qa-overlay): exclude grafana-reader + extensions-bootstrap Jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1566,6 +1566,11 @@ jobs:
           for f in $(find k8s go/k8s java/k8s -name 'namespace.yml' 2>/dev/null); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
           for f in $(find k8s/ai-services -name '*.yml' -not -name 'namespace.yml'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
           $SSH "minikube ssh 'sudo mkdir -p /backups/postgres && sudo chmod 777 /backups/postgres'"
+          # Bootstrap Jobs have immutable spec.template — a stale Job from a
+          # prior deploy with a different command/env fails the apply below
+          # with `field is immutable`. Delete first; mirrors the pattern used
+          # for Go migrate Jobs further down.
+          $SSH "kubectl delete job -n java-tasks pgbouncer-auth-bootstrap postgres-replicator-bootstrap postgres-grafana-reader postgres-extensions-bootstrap --ignore-not-found --wait=true"
           for f in $(find java/k8s -name '*.yml' -not -name 'namespace.yml' -not -path '*/secrets/*'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
           for f in $(find k8s/monitoring -name '*.yml' -not -name 'namespace.yml'); do echo '---'; cat "$f"; done | $SSH "kubectl apply -f -"
 

--- a/k8s/overlays/qa-java/kustomization.yaml
+++ b/k8s/overlays/qa-java/kustomization.yaml
@@ -247,6 +247,32 @@ patches:
       kind: Job
       metadata:
         name: postgres-replicator-bootstrap
+  # postgres-grafana-reader and postgres-extensions-bootstrap mirror
+  # pgbouncer-auth-bootstrap and postgres-replicator-bootstrap above:
+  # they create global roles or extensions in the SHARED prod postgres
+  # (java-tasks namespace, reached from QA via ExternalName). Letting
+  # them run from the QA overlay re-CREATEs/ALTERs prod-side state with
+  # whatever passwords live in java-tasks-qa/java-secrets, silently
+  # overwriting the prod role passwords on every QA deploy. Prod is the
+  # single source of truth for these bootstrap operations.
+  - target:
+      kind: Job
+      name: postgres-grafana-reader
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: postgres-grafana-reader
+  - target:
+      kind: Job
+      name: postgres-extensions-bootstrap
+    patch: |
+      $patch: delete
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: postgres-extensions-bootstrap
   # --- Remove WAL-archive PVCs (the underlying PVs are claimed by prod) ---
   # Without these deletes, QA's PVCs raced prod's for the only two matching PVs
   # and cross-bound, leaving prod's postgres pod unschedulable.


### PR DESCRIPTION
## Summary

- Add `$patch: delete` exclusions for `postgres-grafana-reader` and `postgres-extensions-bootstrap` in the QA java overlay. These mirror the pre-existing exclusions for `pgbouncer-auth-bootstrap` and `postgres-replicator-bootstrap` — all four bootstrap Jobs CREATE/ALTER global roles or extensions in the **shared** prod postgres (reached from QA via ExternalName), so running them from the QA overlay was silently overwriting prod's role passwords on every QA deploy with whatever lived in `java-tasks-qa/java-secrets`.
- Add `kubectl delete job ... --ignore-not-found --wait=true` for the four bootstrap Jobs before the prod CI bulk apply. Kubernetes Jobs have an immutable `spec.template`; a stale Job from a prior deploy with a different command/env causes the bulk apply to fail with `field is immutable`. The Go migrate Jobs further down already use this pattern.

## Why

PR #191's QA deploy failed twice with `The Job "postgres-grafana-reader" is invalid: spec.template: ... field is immutable`. The stale Job in `java-tasks-qa` (from before the Job-script rewrite, stuck Running for 23h on a missing secret key) had a different `spec.template` than what the deploy was trying to apply. Already cleaned the stale resource manually; this PR keeps it from coming back.

## Out of scope

- **Phase 6**: proper `SealedSecret` for `java-tasks-qa/java-secrets`. Currently QA's Secret is frozen at its pre-Phase-2 state (the `*.template.yml` was deleted; nothing replaces it). After this PR the missing keys in QA's Secret stop blocking deploys, but the broader QA Sealed Secrets work is still pending.
- **`pg_hba.conf`** entry for the read-replica — separate bug from PR #181.

## Test plan

- [ ] CI green on PR.
- [ ] On qa deploy: `kubectl get jobs -n java-tasks-qa` does not include `postgres-grafana-reader` or `postgres-extensions-bootstrap`.
- [ ] Prod deploy step doesn't fail with `field is immutable` when bootstrap Job specs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)