### PR TITLE
feat(ci): R3 — fail on credential URLs in ConfigMap data (Phase 5)

### DIFF
--- a/scripts/k8s-policy-check.sh
+++ b/scripts/k8s-policy-check.sh
@@ -9,10 +9,42 @@
 #   R2. Any ConfigMap data key ending in DATABASE_URL whose value starts with
 #       postgres:// MUST include sslmode=disable. Rationale: the Go pq driver
 #       defaults to sslmode=require against a non-SSL postgres.
+#   R3. ConfigMap data values MUST NOT contain credential URLs of the form
+#       <scheme>://<user>:<pass>@<host>. Rationale: ConfigMaps are unencrypted
+#       and broadly readable; credentials belong in (Sealed) Secrets. The
+#       application should assemble the DSN at startup from a host/port/db
+#       ConfigMap and a user/password Secret. The migration to that shape is
+#       Phase 4 of docs/superpowers/specs/2026-04-28-secrets-management-design.md;
+#       files still carrying the old shape are listed in R3_ALLOWLIST below
+#       and entries should be removed as each service migrates.
 #
 # Usage: scripts/k8s-policy-check.sh [dir ...]
 # Exits 0 on success, 1 on any violation. Prints each violation to stderr.
 set -euo pipefail
+
+# R3 allowlist — ConfigMap files that contain credential URLs today and are
+# scheduled for the DSN-component split in Phase 4. Remove an entry once the
+# corresponding service stops shipping a user:pass@host string in its
+# ConfigMap. New ConfigMaps must NOT be added here.
+R3_ALLOWLIST=(
+  "go/k8s/configmaps/auth-service-config.yml"
+  "go/k8s/configmaps/cart-service-config.yml"
+  "go/k8s/configmaps/order-projector-config.yml"
+  "go/k8s/configmaps/order-service-config.yml"
+  "go/k8s/configmaps/payment-service-config.yml"
+  "go/k8s/configmaps/product-service-config.yml"
+)
+
+is_r3_allowlisted() {
+  local needle="$1"
+  local entry
+  for entry in "${R3_ALLOWLIST[@]}"; do
+    if [ "$entry" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 if ! command -v yq >/dev/null 2>&1; then
   echo "k8s-policy-check.sh: yq is required (v4, Go rewrite)" >&2
@@ -46,6 +78,9 @@ check_file() {
     if [ "$kind" = "Deployment" ]; then
       local n_containers
       n_containers=$(yq "select(di == $i) | .spec.template.spec.containers | length" "$file")
+      if [ "$n_containers" -le 0 ]; then
+        continue
+      fi
       local c
       for c in $(seq 0 $((n_containers - 1))); do
         local image probe
@@ -67,10 +102,11 @@ check_file() {
       local key
       while IFS= read -r key; do
         [ -z "$key" ] && continue
+        local value
+        value=$(yq "select(di == $i) | .data[\"$key\"]" "$file")
+
         case "$key" in
           *DATABASE_URL)
-            local value
-            value=$(yq "select(di == $i) | .data[\"$key\"]" "$file")
             if echo "$value" | grep -q '^postgres://'; then
               if ! echo "$value" | grep -q 'sslmode=disable'; then
                 local name
@@ -80,6 +116,20 @@ check_file() {
             fi
             ;;
         esac
+
+        # R3: scheme://user:pass@host pattern. Match a scheme of one or more
+        # lowercase letters (optionally with `+letters`, e.g. mongodb+srv),
+        # then `://`, then a userinfo run with no `/`, no `:`, no whitespace,
+        # then `:`, then a password run with no `/`, no `@`, no whitespace,
+        # then `@`. The trailing `@` is what distinguishes credentials from
+        # `host:port`.
+        if echo "$value" | grep -Eq '[a-z][a-z0-9+]*://[^/:[:space:]]+:[^/@[:space:]]+@'; then
+          if ! is_r3_allowlisted "$file"; then
+            local name
+            name=$(yq "select(di == $i) | .metadata.name" "$file")
+            report "$file: ConfigMap/$name key '$key' embeds credentials in a URL (R3 — split into ConfigMap host/port + Secret user/password)"
+          fi
+        fi
       done <<< "$keys"
     fi
   done

--- a/scripts/test-k8s-policy-check.sh
+++ b/scripts/test-k8s-policy-check.sh
@@ -60,7 +60,7 @@ kind: ConfigMap
 metadata:
   name: bad
 data:
-  DATABASE_URL: postgres://user:pass@host:5432/db
+  DATABASE_URL: postgres://host:5432/db
 EOF
 if "$POLICY" "$TMP/case3" >/dev/null 2>&1; then
   fail "case3: postgres URL without sslmode=disable should have failed"
@@ -75,7 +75,7 @@ kind: ConfigMap
 metadata:
   name: good
 data:
-  DATABASE_URL: postgres://user:pass@host:5432/db?sslmode=disable
+  DATABASE_URL: postgres://host:5432/db?sslmode=disable
 EOF
 if ! "$POLICY" "$TMP/case4" >/dev/null 2>&1; then
   fail "case4: postgres URL with sslmode=disable should have passed"
@@ -100,6 +100,53 @@ if ! "$POLICY" "$TMP/case5" >/dev/null 2>&1; then
   fail "case5: unrelated Deployment without probe should have passed"
 fi
 pass "case5: non-stateful Deployment without probe is allowed"
+
+# --- Fixture 6: ConfigMap with creds in non-DATABASE_URL key (R3 fail) ---
+mkdir -p "$TMP/case6"
+cat > "$TMP/case6/cm.yml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bad
+data:
+  RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
+EOF
+if "$POLICY" "$TMP/case6" >/dev/null 2>&1; then
+  fail "case6: amqp:// with embedded credentials should have failed (R3)"
+fi
+pass "case6: credential URL in ConfigMap is detected (R3)"
+
+# --- Fixture 7: ConfigMap with host:port only (no creds) — should pass ---
+mkdir -p "$TMP/case7"
+cat > "$TMP/case7/cm.yml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: good
+data:
+  REDIS_URL: redis://redis.java-tasks.svc.cluster.local:6379
+  POSTGRES_HOST: postgres.java-tasks.svc.cluster.local
+  POSTGRES_PORT: "5432"
+EOF
+if ! "$POLICY" "$TMP/case7" >/dev/null 2>&1; then
+  fail "case7: credential-free URLs should have passed"
+fi
+pass "case7: host:port URLs without credentials pass (R3)"
+
+# --- Fixture 8: ConfigMap with mongodb+srv credentials — should fail (R3) ---
+mkdir -p "$TMP/case8"
+cat > "$TMP/case8/cm.yml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bad
+data:
+  MONGO_URL: mongodb+srv://user:secret@cluster.example.net/db
+EOF
+if "$POLICY" "$TMP/case8" >/dev/null 2>&1; then
+  fail "case8: mongodb+srv credentials should have failed (R3)"
+fi
+pass "case8: mongodb+srv credentials detected (R3)"
 
 echo
 echo "All policy check tests passed."


### PR DESCRIPTION
## Summary

Phase 5 of the [secrets-management migration](docs/superpowers/specs/2026-04-28-secrets-management-design.md). Adds rule **R3** to `scripts/k8s-policy-check.sh`: ConfigMap `data` values must not contain `scheme://user:pass@host` URLs. CI already runs this script on every PR/push, so the rule is enforced without further wiring.

The rule matches what CLAUDE.md and the secrets-and-config-practices ADR already say in prose; this PR is just the executable enforcement so a regression can't sneak in once Phase 4 starts migrating Go services off embedded-credential DSNs.

## Allowlist

Six Go-service ConfigMaps carry credential URLs today and are listed in `R3_ALLOWLIST`:

- `auth-service-config.yml`
- `cart-service-config.yml`
- `order-projector-config.yml`
- `order-service-config.yml`
- `payment-service-config.yml`
- `product-service-config.yml`

Each entry should be removed in the Phase 4 PR that migrates the corresponding service. The allowlist must not grow.

## Drive-by

Pre-existing latent bug in R1's container-loop on macOS: `seq 0 -1` produces `0\n-1` under BSD seq (whereas GNU seq yields nothing), and `yq` then errors on `containers[-1]`. CI runs on Ubuntu so this never broke there, but it made running the policy script locally fail. Added a `n_containers > 0` guard.

## Test plan

- [x] `bash scripts/test-k8s-policy-check.sh` — 8/8 cases pass (3 new for R3).
- [x] `bash scripts/k8s-policy-check.sh` against the full repo — passes; the six allowlisted files are tolerated, no other ConfigMap carries credentials.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)