### PR TITLE
feat(secrets): DSN component split — order-projector (Phase 4)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-dsn-split-order-projector.md
+++ b/docs/superpowers/plans/2026-04-28-dsn-split-order-projector.md
@@ -1,0 +1,153 @@
+# Phase 4 — DSN component split: order-projector (first Go service)
+
+Spec: [`docs/superpowers/specs/2026-04-28-secrets-management-design.md`](../specs/2026-04-28-secrets-management-design.md), Phase 4.
+
+## Why order-projector first
+
+Spec says "least-to-most central, auth-service last." Order-projector is the read-side projector consuming Kafka events into a separate `projectordb` — if anything is wrong with the new DSN-assembly pattern, the only user-visible effect is "the projection lags," not "the saga breaks" or "users can't log in." Best place to land the pattern, then repeat it five more times.
+
+## The pattern this PR establishes
+
+For each Go service:
+
+1. **ConfigMap holds connection geometry only.** Replace `DATABASE_URL` and `DATABASE_URL_DIRECT` with:
+   - `DB_HOST` — pgbouncer host
+   - `DB_PORT` — pgbouncer port (`6432`)
+   - `DB_NAME` — application database
+   - `DB_OPTIONS` — `sslmode=disable&application_name=<service>` and any other URL-query options
+   - `DB_HOST_DIRECT` — postgres host (PgBouncer bypass)
+   - `DB_PORT_DIRECT` — postgres port (`5432`)
+   - `DB_OPTIONS_DIRECT` — same shape with `application_name=<service>-migrate`
+2. **Per-service `<service>-db` SealedSecret carries credentials.** Two keys: `DB_USER`, `DB_PASSWORD`. Same Sealed Secrets workflow as Phase 2/3 — patch live, annotate `managed: true`, run `seal-from-cluster.sh`, commit.
+3. **App config builds the DSN at startup** from the components. Existing `pgxpool.ParseConfig` consumer doesn't change; it just gets a DSN string assembled from component pieces instead of read whole.
+4. **Migration Job builds the DSN in its shell command** from the same components, using the `_DIRECT` ones for PgBouncer bypass.
+5. **QA overlay overrides only `DB_NAME`** (e.g., `projectordb` → `projectordb_qa`). Every other component is shared with prod (we use the same Postgres). Credentials live in QA's own per-service Secret in `go-ecommerce-qa`.
+6. **R3 allowlist shrinks** as each service migrates — remove the file from `scripts/k8s-policy-check.sh`'s `R3_ALLOWLIST`.
+
+Subsequent Phase 4 PRs (cart, order, payment, product, then auth-service last) re-run this recipe.
+
+## Out of scope
+
+- Per-service Postgres roles (least-privilege). All services still authenticate as `taskuser`. The component split is what unblocks per-user creds later — once `DB_USER`/`DB_PASSWORD` come from a per-service Secret, swapping in `projector_user` is a one-Secret change.
+- RabbitMQ DSN split (`MQ_HOST`, `MQ_USER`, etc.). Separate roll-up; the spec mentions it but order-projector doesn't use RabbitMQ today (it consumes Kafka).
+- Redis DSN split. Redis has no password today; defer until it grows one.
+
+## Implementation steps
+
+### 1. Bring up a per-service live Secret (operator workstation)
+
+```bash
+# prod
+ssh debian "kubectl create secret generic order-projector-db -n go-ecommerce \
+  --from-literal=DB_USER=taskuser \
+  --from-literal=DB_PASSWORD=taskpass \
+  --dry-run=client -o yaml | kubectl apply -f -"
+ssh debian "kubectl annotate secret order-projector-db -n go-ecommerce sealedsecrets.bitnami.com/managed=true --overwrite"
+
+# qa (separate sealed file because Strict scope)
+ssh debian "kubectl create secret generic order-projector-db -n go-ecommerce-qa \
+  --from-literal=DB_USER=taskuser \
+  --from-literal=DB_PASSWORD=taskpass \
+  --dry-run=client -o yaml | kubectl apply -f -"
+ssh debian "kubectl annotate secret order-projector-db -n go-ecommerce-qa sealedsecrets.bitnami.com/managed=true --overwrite"
+```
+
+### 2. Add to seal script + seal both
+
+```
+SECRETS+=(
+  "go-ecommerce/order-projector-db"
+  "go-ecommerce-qa/order-projector-db"
+)
+scripts/seal-from-cluster.sh order-projector-db
+```
+
+This writes:
+- `k8s/secrets/go-ecommerce/order-projector-db.sealed.yml`
+- `k8s/secrets/go-ecommerce-qa/order-projector-db.sealed.yml`
+
+If `k8s/secrets/go-ecommerce-qa/` doesn't exist yet, add a `kustomization.yaml` for it and add `go-ecommerce-qa` to `k8s/secrets/kustomization.yaml`'s `resources`. (Phase 3 already did the `java-tasks-qa` analogue — same shape.)
+
+### 3. Replace ConfigMap DSN with components
+
+`go/k8s/configmaps/order-projector-config.yml`:
+
+```yaml
+data:
+  DB_HOST: pgbouncer.java-tasks.svc.cluster.local
+  DB_PORT: "6432"
+  DB_NAME: projectordb
+  DB_OPTIONS: sslmode=disable&application_name=order-projector
+  DB_HOST_DIRECT: postgres.java-tasks.svc.cluster.local
+  DB_PORT_DIRECT: "5432"
+  DB_OPTIONS_DIRECT: sslmode=disable&application_name=order-projector-migrate
+  KAFKA_BROKERS: kafka.go-ecommerce.svc.cluster.local:9092
+  PORT: "8097"
+  ALLOWED_ORIGINS: http://localhost:3000,https://kylebradshaw.dev
+  OTEL_EXPORTER_OTLP_ENDPOINT: jaeger.monitoring.svc.cluster.local:4317
+```
+
+### 4. Assemble DSN in `cmd/server/config.go`
+
+Read the six components, `fmt.Sprintf` the `postgres://...` string, return it through the existing `Config.DatabaseURL` field so `main.go`'s `pgxpool.ParseConfig` consumer doesn't change.
+
+`url.QueryEscape` the user/password to be safe — base64 passwords don't have URL-special characters today, but the assembly should be defensive.
+
+### 5. Update Deployment env
+
+`go/k8s/deployments/order-projector.yml`:
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: order-projector-config
+  - secretRef:
+      name: order-projector-db
+```
+
+`envFrom` exposes every ConfigMap key (DB_HOST, DB_PORT, etc.) and Secret key (DB_USER, DB_PASSWORD) as individual env vars. Cleaner than enumerating each.
+
+### 6. Update Migration Job
+
+`go/k8s/jobs/order-projector-migrate.yml`:
+
+```yaml
+envFrom:
+  - configMapRef:
+      name: order-projector-config
+  - secretRef:
+      name: order-projector-db
+command:
+  - /bin/sh
+  - -c
+args:
+  - |
+    set -e
+    DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST_DIRECT}:${DB_PORT_DIRECT}/${DB_NAME}?${DB_OPTIONS_DIRECT}"
+    echo "Running order-projector migrations..."
+    /usr/local/bin/migrate -path=/migrations -database="${DATABASE_URL}&x-migrations-table=projector_schema_migrations" up
+    echo "Done."
+```
+
+### 7. Update QA overlay
+
+In `k8s/overlays/qa-go/kustomization.yaml`, replace the `DATABASE_URL` / `DATABASE_URL_DIRECT` patches for `order-projector-config` with one `replace` op on `/data/DB_NAME` → `projectordb_qa`. Other component paths are shared with prod and stay untouched.
+
+### 8. Remove from R3 allowlist
+
+`scripts/k8s-policy-check.sh`: drop `go/k8s/configmaps/order-projector-config.yml` from `R3_ALLOWLIST`. Run `bash scripts/k8s-policy-check.sh` to confirm the remaining allowlist still tolerates the other five services.
+
+## Verification
+
+- `make preflight-go` (lint + tests).
+- `bash scripts/test-k8s-policy-check.sh` (the 8 fixture tests still pass).
+- `bash scripts/k8s-policy-check.sh` (R3 reports no new violations; the projector ConfigMap is now policy-clean).
+- Apply the new SealedSecret(s) directly to the cluster (the controller picks up the new resources without a full deploy).
+- After PR merges to qa: confirm the migration Job runs to Complete on the next deploy, and `kubectl logs deploy/order-projector` shows a clean startup with `pgxpool` connecting.
+
+## Risks
+
+- **DSN with special-char password.** `taskpass` is alphanumeric, but the assembly should use `url.QueryEscape` so a future password rotation with `+/=` works without breaking parsing. Done in step 4.
+- **Forgot `_DIRECT` for migration Job.** Bypassing PgBouncer is required for golang-migrate's session-level features (CLAUDE.md note). The migration Job manifest in step 6 explicitly uses `DB_HOST_DIRECT`/`DB_PORT_DIRECT`/`DB_OPTIONS_DIRECT`.
+- **Strict-scope SealedSecret applied to wrong namespace.** Each ns has its own sealed file. Don't kustomize-rewrite the namespace on a sealed secret — it will refuse to decrypt.
+- **QA pointing at prod's DB_NAME.** The single QA overlay patch on `/data/DB_NAME` is the load-bearing line; if it's missing or typo'd, QA writes into prod's `projectordb`. Mitigated by a manual `kubectl describe configmap order-projector-config -n go-ecommerce-qa` after the QA deploy.

--- a/go/k8s/configmaps/order-projector-config.yml
+++ b/go/k8s/configmaps/order-projector-config.yml
@@ -4,8 +4,19 @@ metadata:
   name: order-projector-config
   namespace: go-ecommerce
 data:
-  DATABASE_URL: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb?sslmode=disable&application_name=order-projector"
-  DATABASE_URL_DIRECT: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb?sslmode=disable&application_name=order-projector-migrate"
+  # DSN component split (Phase 4 of the secrets-management migration).
+  # The app reads these DB_* keys plus DB_USER/DB_PASSWORD from the
+  # order-projector-db SealedSecret and assembles the postgres:// DSN
+  # at startup in cmd/server/config.go. The migration Job assembles
+  # the same DSN in shell using the *_DIRECT variants (PgBouncer
+  # bypass — see CLAUDE.md "Go migration Jobs bypass PgBouncer").
+  DB_HOST: "pgbouncer.java-tasks.svc.cluster.local"
+  DB_PORT: "6432"
+  DB_NAME: "projectordb"
+  DB_OPTIONS: "sslmode=disable&application_name=order-projector"
+  DB_HOST_DIRECT: "postgres.java-tasks.svc.cluster.local"
+  DB_PORT_DIRECT: "5432"
+  DB_OPTIONS_DIRECT: "sslmode=disable&application_name=order-projector-migrate"
   KAFKA_BROKERS: "kafka.go-ecommerce.svc.cluster.local:9092"
   PORT: "8097"
   ALLOWED_ORIGINS: "http://localhost:3000,https://kylebradshaw.dev"

--- a/go/k8s/deployments/order-projector.yml
+++ b/go/k8s/deployments/order-projector.yml
@@ -29,6 +29,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: order-projector-config
+            - secretRef:
+                name: order-projector-db
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001

--- a/go/k8s/jobs/order-projector-migrate.yml
+++ b/go/k8s/jobs/order-projector-migrate.yml
@@ -19,16 +19,21 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              set -e
+              set -eu
+              # Assemble the migrate-target DSN from component env vars.
+              # The *_DIRECT host/port/options bypass PgBouncer because
+              # golang-migrate uses session-level features (advisory locks,
+              # transaction wrapping) that PgBouncer's transaction-pool
+              # mode doesn't preserve. See CLAUDE.md.
+              DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST_DIRECT}:${DB_PORT_DIRECT}/${DB_NAME}?${DB_OPTIONS_DIRECT}"
               echo "Running order-projector migrations..."
               /usr/local/bin/migrate -path=/migrations -database="${DATABASE_URL}&x-migrations-table=projector_schema_migrations" up
               echo "Done."
-          env:
-            - name: DATABASE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: order-projector-config
-                  key: DATABASE_URL_DIRECT
+          envFrom:
+            - configMapRef:
+                name: order-projector-config
+            - secretRef:
+                name: order-projector-db
           resources:
             requests:
               memory: "32Mi"

--- a/go/order-projector/cmd/server/config.go
+++ b/go/order-projector/cmd/server/config.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/url"
 	"os"
 )
 
@@ -14,12 +16,15 @@ type Config struct {
 	OTELEndpoint   string
 }
 
-// loadConfig reads configuration from environment variables.
-// It fatals if DATABASE_URL or KAFKA_BROKERS is not set.
+// loadConfig reads configuration from environment variables. It fatals if
+// any required value is missing. The Postgres DSN is assembled from
+// component env vars (Phase 4 of the secrets-management migration) — the
+// ConfigMap supplies host/port/db/options, the per-service Secret supplies
+// user/password.
 func loadConfig() Config {
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		log.Fatal("DATABASE_URL is required")
+	databaseURL, err := buildDatabaseURL()
+	if err != nil {
+		log.Fatalf("config: %v", err)
 	}
 
 	kafkaBrokers := os.Getenv("KAFKA_BROKERS")
@@ -34,6 +39,36 @@ func loadConfig() Config {
 		AllowedOrigins: getenv("ALLOWED_ORIGINS", "http://localhost:3000"),
 		OTELEndpoint:   os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
 	}
+}
+
+// buildDatabaseURL assembles a postgres:// DSN from the DB_* component env
+// vars. Userinfo is URL-escaped so a future password rotation containing
+// URL-reserved characters doesn't break parsing.
+func buildDatabaseURL() (string, error) {
+	host := os.Getenv("DB_HOST")
+	port := os.Getenv("DB_PORT")
+	name := os.Getenv("DB_NAME")
+	user := os.Getenv("DB_USER")
+	password := os.Getenv("DB_PASSWORD")
+
+	for _, kv := range [][2]string{
+		{"DB_HOST", host},
+		{"DB_PORT", port},
+		{"DB_NAME", name},
+		{"DB_USER", user},
+		{"DB_PASSWORD", password},
+	} {
+		if kv[1] == "" {
+			return "", fmt.Errorf("%s is required", kv[0])
+		}
+	}
+
+	userinfo := url.QueryEscape(user) + ":" + url.QueryEscape(password)
+	dsn := fmt.Sprintf("postgres://%s@%s:%s/%s", userinfo, host, port, name)
+	if opts := os.Getenv("DB_OPTIONS"); opts != "" {
+		dsn += "?" + opts
+	}
+	return dsn, nil
 }
 
 func getenv(key, def string) string {

--- a/go/order-projector/cmd/server/config_test.go
+++ b/go/order-projector/cmd/server/config_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "all components present, options included",
+			env: map[string]string{
+				"DB_HOST":     "pgbouncer.java-tasks.svc.cluster.local",
+				"DB_PORT":     "6432",
+				"DB_NAME":     "projectordb",
+				"DB_USER":     "taskuser",
+				"DB_PASSWORD": "taskpass",
+				"DB_OPTIONS":  "sslmode=disable&application_name=order-projector",
+			},
+			want: "postgres://taskuser:taskpass@pgbouncer.java-tasks.svc.cluster.local:6432/projectordb?sslmode=disable&application_name=order-projector",
+		},
+		{
+			name: "options omitted when DB_OPTIONS empty",
+			env: map[string]string{
+				"DB_HOST":     "host",
+				"DB_PORT":     "5432",
+				"DB_NAME":     "db",
+				"DB_USER":     "u",
+				"DB_PASSWORD": "p",
+			},
+			want: "postgres://u:p@host:5432/db",
+		},
+		{
+			name: "URL-special characters in password are escaped",
+			env: map[string]string{
+				"DB_HOST":     "host",
+				"DB_PORT":     "5432",
+				"DB_NAME":     "db",
+				"DB_USER":     "user",
+				"DB_PASSWORD": "p@ss/word+1=",
+			},
+			// QueryEscape encodes @ as %40, / as %2F, + as %2B, = as %3D.
+			want: "postgres://user:p%40ss%2Fword%2B1%3D@host:5432/db",
+		},
+		{
+			name: "missing DB_PASSWORD reports the missing key",
+			env: map[string]string{
+				"DB_HOST": "host",
+				"DB_PORT": "5432",
+				"DB_NAME": "db",
+				"DB_USER": "u",
+			},
+			wantErr: "DB_PASSWORD",
+		},
+		{
+			name:    "empty environment reports the first missing key",
+			env:     map[string]string{},
+			wantErr: "DB_HOST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear any inherited values from the test process.
+			for _, k := range []string{"DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD", "DB_OPTIONS"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			got, err := buildDatabaseURL()
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil; result=%q", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("buildDatabaseURL\n got: %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/k8s/overlays/qa-go/kustomization.yaml
+++ b/k8s/overlays/qa-go/kustomization.yaml
@@ -189,12 +189,13 @@ patches:
       - op: replace
         path: /data/ALLOWED_ORIGINS
         value: "https://qa.kylebradshaw.dev,http://localhost:3000"
+      # DSN component split (Phase 4): host/port/options are shared with prod
+      # (same Postgres reached by ExternalName), so QA only overrides the
+      # database name. DB_USER/DB_PASSWORD come from the go-ecommerce-qa
+      # namespace's order-projector-db SealedSecret.
       - op: replace
-        path: /data/DATABASE_URL
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb_qa?sslmode=disable&application_name=order-projector"
-      - op: add
-        path: /data/DATABASE_URL_DIRECT
-        value: "postgres://taskuser:taskpass@postgres.java-tasks.svc.cluster.local:5432/projectordb_qa?sslmode=disable&application_name=order-projector-migrate"
+        path: /data/DB_NAME
+        value: "projectordb_qa"
       - op: replace
         path: /data/KAFKA_BROKERS
         value: "kafka.go-ecommerce-qa.svc.cluster.local:9092"

--- a/k8s/secrets/go-ecommerce-qa/kustomization.yaml
+++ b/k8s/secrets/go-ecommerce-qa/kustomization.yaml
@@ -1,9 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: go-ecommerce
+namespace: go-ecommerce-qa
 
 resources:
-  - go-secrets.sealed.yml
-  - stripe-secrets.sealed.yml
   - order-projector-db.sealed.yml

--- a/k8s/secrets/go-ecommerce-qa/order-projector-db.sealed.yml
+++ b/k8s/secrets/go-ecommerce-qa/order-projector-db.sealed.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: order-projector-db
+  namespace: go-ecommerce-qa
+spec:
+  encryptedData:
+    DB_PASSWORD: AgC6TAEJNItxeRl/GH/ZYJhYT7jTrMEocj4I0OzjbnMJrHEcN/Lj0EFeWLkmCBS9A3y6LILRIIv/Cp+wG+2URiU2XOBBaiG8LYuphopatKTzAQuTZZGGVEFWrJ6FNrAxHhD3MWs8e7fvVBiZCBM7zVqA1uxjggtMj4KR3Nqdcxh8Qu+mpLb/5Z4RRnvva9dyP9h1y12H1fQnBQI4dZb1cGy6NNJ+ketJkhXy6x9+GitNuu+QwHEjtwRABzDNWkGQECCUcjX2cJpl5Iqkv9oENFrrgXOpYEUbwJFv3iMkVbz+zrK8E9nZ2J/96y4pH/p0X8OenBmBjRwfO57tSYmON9PMShm+UvfhucCIGXe1o5NMbPBrMoKVj62vM8DUZuKEYMNpaJnRhH4lzebrsSAkEkDK/I81KOfzprzLD2qOU+6yHjSk/SV9WJvgeso5Jyi8tLfiknsLrrfQquB1Oc5zQG2YG/Xp/FpewddleVglxe0TNyMZBrLLtDdjnTyczInxfY3jp7hY3dVo6fZAv2JvtkD2CPNj1Kbm3TwKa1eBFbdPHoCB3XwGe9rOCsP0Kzg93Vb5FKEPzapPW/3A4BjOzq9w0nmiV26xuUOzncz4sHEzGd7BY3zIDQR6+jF56BfVd7HlmORCEBVRHRKEuw3dSzyAHv0iVNLRMMpM7F/WnYsQHHZGVuZH49SbNb3rBZlKEKjvItgV28cUtw==
+    DB_USER: AgAF+qMDzEJyDlo27f7JnekzV1iqy7HH+lgMYECF7Gb6Q28iS+2ERHpozpZQ95z07GGkZ2TRrUaERv8hFn4DCm1XiMKpUwcpl8qZfxmbwS2MqeqWbY30HbXj7aEjIQbqctla38l+jCs+BBT7pjFFryXih45ysgiUegWX8yTEJk0ESpeYXs089Psx2Fw9OppXca0Xey4j9zqTJB7SZ8weCVqc1k2TZ0llBFswqmoGPZvXhTVQ77gAyQJtKbzEQSMrW2wGOVW9blXf5BETVJU21HtGBqMhh18Dp2T8eZBmQ37Lv1aa1BBT4+0kChm+4TrnDTcMYoJ0qFVPd54OLE7Dzo6RapJSVEDOrly8mizsnQfnxvP2u3pZMQgQ+zfBiPFs3yA1OD+XpuP8NMxXXqljBJYzQJ0YAWXqNXolXO1GokaaxAwRtIgZJIb2sHPHrtR+GVzYjYzVcCA7rhJddqQ2595ziL6QsXkUyXcJGevfe16oOjHUx6GW2eWk1lbz6Pfk/hAwYVl0gZLINPeuem4qNJUoiqo+csz7Oq8I4zeN752ANiwTz4M+86vAVgL0drFdlE+yE80fZdiE2skFG+DsbZWre1qn3KkB7t0jtJe9naOMoqAau+8DBuoUrzCpoKEBP/o1q3dRkC125I2GkZ9/PGe6VS9/MsKwccuSAtTIWyq1r8OvEffOho6HFL2ZqTTRa0A9PgsS/pen+A==
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/managed: "true"
+      name: order-projector-db
+      namespace: go-ecommerce-qa
+    type: Opaque

--- a/k8s/secrets/go-ecommerce/order-projector-db.sealed.yml
+++ b/k8s/secrets/go-ecommerce/order-projector-db.sealed.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: order-projector-db
+  namespace: go-ecommerce
+spec:
+  encryptedData:
+    DB_PASSWORD: AgAxCSXjbaqjC7WT5sZ37U1PpBkGsNJG9u6Gx1zzgS8Z0YdNHRNV2R8bVrnR7y8EV+d4jZMD9YjpEcP8Y9DJTs6kXMtD55U9VJdS3gtDoMwiM9VTlgDdo7UiDT7JA4r/xWgS0iLp8FeXLdciUPjNqe/NY5WZO9EwUhikbMC5v7sAier9myvzCVWRPxQCkW9Nsk8Qw9+CxfyRihYVGS1pOXJeeJZZrBTMwqFRZq2YFceSeTdeM/5Bex4Zz/8rkJVCPeZdSdyI3P/O2EQKIvqq8FMNcJ1O53dzkZ2gC/GllOQ4nlVI609rYmILNq2vUt1rG6mUqICUkxRikNqTYRBs8IDnrDQ707b78nBsVcFPNxD0j+M5jws4fY8d6oMQw7CK3q1m90JxrEBkJQb0zk/C+D+HAfjiZ7/QE+V1M6seV4JuQDHlOjn+PUcL3gVneKwXjRbkW6NBNpzQ5eM+v5Pjvx+v/Dn+WXl/oOaSu0Gf+OS+goV0t3CyQfQiH8mNKvnb1mndlFy4rSYWo9cJ3NzBvarKjFXF5nGjvDXY13OKlYVxq77ed0t0tSpFc8UN/4Ef0ekeNfhEl1XnUVDnk68w4buNO+QVyIF2Uh8DHB7mSioIGm7y8I+COtTPegmsq+QJgQzwHKE3XI7ToyBC1Q9iaNHJBv6GgTaBxOnLufGowzBPrTBW3HVifOO/XnaqiGFib53bDaJoGoSSZQ==
+    DB_USER: AgAXIh5G4k8oCAjIMkWc+zrC25VTte7zzOxH+9/ePrdv+JTHTuJP0qGAFte880Eii2hQaMZ2SbBM0b0tnmu9sj1NSIlBvWBaS9lC6D0N4QSuw6wbv06yN98WFXFHvPK6cy1oyzztq4QcFYjCgbVivOaS8qpGDjKOSPTm3VSQghbfgUEqZQtwXy35qAtAFuNrSUaWQVew7+u7d1k0jx2jG3w5t9+gkJ+eIOa2SwBOdjXbUrEC3uug2bUju7Rqnh6yWkqeQfxcdkuqayky56fup1CisPQorxaiZUHWPGSRRyZjH6sjHFsdCGEPigswcrShJUlm3fnQb3bHSLvV+OQstsUTcUFcd0QntDl8tf9Rl1cROA6ewAfG1Ayg8iMzZzCmmfDtC+yyr0bNLTtGOPKNdK8AKG6/8BKESyd+B/enpKAbk1oY0Dm9ve4ZgTwbkorkZrmp4L/+cRMTVNCmei+5iPwGIqUnW1L//Fftfrrk+kdCI0zcTrRUOve4iumNDHXAUqYTbiRdRVqw+sVBk8yXxjfP5p4CHAn1s77EAD+jas9GxU5nwxBG2m8MUxBrJ1MikgTgfKDLvvNOGBB9GdDIMJbYYqgZNuydNPEbv6Iqr+DkCFF1nOq/Ps+1NyD7hEAYRepjNYvzjvtAMfUJLkJO1BOdX107QUFHohhbrejCd7EomLTsQLpWcA7t24BqmqNtiz39AlSi7kgnTg==
+  template:
+    metadata:
+      annotations:
+        sealedsecrets.bitnami.com/managed: "true"
+      name: order-projector-db
+      namespace: go-ecommerce
+    type: Opaque

--- a/k8s/secrets/kustomization.yaml
+++ b/k8s/secrets/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - java-tasks
   - java-tasks-qa
   - go-ecommerce
+  - go-ecommerce-qa
   - monitoring

--- a/scripts/k8s-policy-check.sh
+++ b/scripts/k8s-policy-check.sh
@@ -29,7 +29,6 @@ set -euo pipefail
 R3_ALLOWLIST=(
   "go/k8s/configmaps/auth-service-config.yml"
   "go/k8s/configmaps/cart-service-config.yml"
-  "go/k8s/configmaps/order-projector-config.yml"
   "go/k8s/configmaps/order-service-config.yml"
   "go/k8s/configmaps/payment-service-config.yml"
   "go/k8s/configmaps/product-service-config.yml"

--- a/scripts/seal-from-cluster.sh
+++ b/scripts/seal-from-cluster.sh
@@ -28,6 +28,8 @@ SECRETS=(
   "java-tasks-qa/java-secrets"
   "go-ecommerce/go-secrets"
   "go-ecommerce/stripe-secrets"
+  "go-ecommerce/order-projector-db"
+  "go-ecommerce-qa/order-projector-db"
   "monitoring/telegram-bot"
 )
 


### PR DESCRIPTION
## Summary

First Phase 4 PR of the [secrets-management migration](docs/superpowers/specs/2026-04-28-secrets-management-design.md). Picks `order-projector` because it's a downstream read-side projector — if anything is wrong with the DSN-assembly pattern, the worst case is the projection lags, not the saga breaks. Establishes the recipe for the remaining five Go services.

## The pattern this PR establishes

For each Go service:

1. **ConfigMap** holds connection geometry: `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_OPTIONS` plus `*_DIRECT` counterparts for the migration Job's PgBouncer bypass. No credentials.
2. **Per-service `<service>-db` SealedSecret** holds `DB_USER` + `DB_PASSWORD`. Strict-scope means each namespace gets its own sealed file (`k8s/secrets/go-ecommerce/` and `k8s/secrets/go-ecommerce-qa/`).
3. **`cmd/server/config.go`** assembles the `postgres://` DSN at startup via `buildDatabaseURL` — userinfo is `url.QueryEscape`'d so a future password rotation with URL-reserved characters doesn't break parsing. Existing `pgxpool.ParseConfig` consumer doesn't change.
4. **Migration Job** assembles its DSN in shell from the `*_DIRECT` components. golang-migrate uses session-level features (advisory locks, transaction wrapping) that PgBouncer's transaction-pool mode doesn't preserve, so the migrate path bypasses pgbouncer.
5. **QA overlay** collapses to a single `op: replace` on `/data/DB_NAME` (`projectordb` → `projectordb_qa`). Host/port/options are shared with prod because the underlying Postgres is the same instance reached by ExternalName. Credentials live in the `go-ecommerce-qa`-namespace sealed Secret.
6. **R3 allowlist shrinks**: `go/k8s/configmaps/order-projector-config.yml` is removed from `scripts/k8s-policy-check.sh`. As each service migrates, the allowlist trends to empty.

## What's not in this PR

- Per-service Postgres roles (least-privilege). Every Go service still authenticates as `taskuser`. Phase 4 puts the per-service `DB_USER`/`DB_PASSWORD` Secret in place, which is what unblocks swapping in `projector_user` later as a one-Secret change.
- The other five Go services (`auth`, `cart`, `order`, `payment`, `product`). One PR each, in least-to-most-central order. `auth-service` last per the spec.

## Test plan

- [x] `go test -race ./...` for `go/order-projector` passes (new `TestBuildDatabaseURL` covers happy path, missing-key errors, URL-escaping of credentials with special characters).
- [x] `bash scripts/test-k8s-policy-check.sh` — all 8 fixtures pass.
- [x] `bash scripts/k8s-policy-check.sh` — passes (R3 still tolerates the five remaining allowlisted services).
- [x] Both SealedSecrets applied to the live cluster — controller reports `Synced=True`, materialized Secrets contain `DB_USER`/`DB_PASSWORD`.
- [ ] CI green on PR.
- [ ] After merge to qa: `go-projector-migrate` Job completes and `kubectl logs deploy/go-order-projector -n go-ecommerce-qa` shows clean pgxpool startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)