### PR TITLE
Add summarize_orders sub-LLM timing

### DIFF
--- a/frontend/e2e/mocked/async-page.spec.ts
+++ b/frontend/e2e/mocked/async-page.spec.ts
@@ -36,7 +36,7 @@ test.describe("/async page", () => {
       "href",
       "/go/admin",
     );
-    await expect(page.getByRole("link", { name: "Grafana" })).toHaveAttribute(
+    await expect(page.getByRole("link", { name: "Grafana" }).last()).toHaveAttribute(
       "href",
       /grafana\.kylebradshaw\.dev/,
     );

--- a/go/ai-service/cmd/server/main.go
+++ b/go/ai-service/cmd/server/main.go
@@ -121,7 +121,7 @@ func runServe() {
 	registry.Register(tools.Cached(tools.NewCheckInventoryTool(ecomClient), toolCache, 10*time.Second))
 	registry.Register(tools.Cached(tools.NewListOrdersTool(ecomClient), toolCache, 10*time.Second))
 	registry.Register(tools.Cached(tools.NewGetOrderTool(ecomClient), toolCache, 10*time.Second))
-	registry.Register(tools.NewSummarizeOrdersTool(ecomClient, llmc))
+	registry.Register(tools.NewSummarizeOrdersToolWithRecorder(ecomClient, llmc, metrics.PromRecorder{}))
 	registry.Register(tools.NewViewCartTool(ecomClient))
 	registry.Register(tools.NewAddToCartTool(ecomClient))
 	registry.Register(tools.NewInitiateReturnTool(ecomClient))

--- a/go/ai-service/internal/metrics/metrics.go
+++ b/go/ai-service/internal/metrics/metrics.go
@@ -36,6 +36,12 @@ var (
 		Buckets: prometheus.DefBuckets,
 	}, []string{"name"})
 
+	ToolSubLLMDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "ai_tool_sub_llm_duration_seconds",
+		Help:    "Nested LLM call latency within AI tools.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"tool"})
+
 	CacheEvents = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "ai_cache_events_total",
 		Help: "Cache events by cache and event type.",
@@ -111,6 +117,7 @@ func (ChatAdmissionObserver) ObserveReleased() {}
 type Recorder interface {
 	RecordTurn(outcome string, steps int, dur time.Duration)
 	RecordTool(name, outcome string, dur time.Duration)
+	RecordToolSubLLM(tool string, dur time.Duration)
 	RecordOllamaCall(model, operation string, dur time.Duration, promptTokens, completionTokens int, evalDurNs int)
 }
 
@@ -126,6 +133,10 @@ func (PromRecorder) RecordTurn(outcome string, steps int, dur time.Duration) {
 func (PromRecorder) RecordTool(name, outcome string, dur time.Duration) {
 	ToolCallsTotal.WithLabelValues(name, outcome).Inc()
 	ToolDuration.WithLabelValues(name).Observe(dur.Seconds())
+}
+
+func (PromRecorder) RecordToolSubLLM(tool string, dur time.Duration) {
+	ToolSubLLMDuration.WithLabelValues(tool).Observe(dur.Seconds())
 }
 
 func (PromRecorder) RecordOllamaCall(model, operation string, dur time.Duration, promptTokens, completionTokens int, evalDurNs int) {
@@ -147,4 +158,5 @@ type NopRecorder struct{}
 
 func (NopRecorder) RecordTurn(string, int, time.Duration)                         {}
 func (NopRecorder) RecordTool(string, string, time.Duration)                      {}
+func (NopRecorder) RecordToolSubLLM(string, time.Duration)                        {}
 func (NopRecorder) RecordOllamaCall(string, string, time.Duration, int, int, int) {}

--- a/go/ai-service/internal/metrics/metrics.go
+++ b/go/ai-service/internal/metrics/metrics.go
@@ -39,7 +39,7 @@ var (
 	ToolSubLLMDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "ai_tool_sub_llm_duration_seconds",
 		Help:    "Nested LLM call latency within AI tools.",
-		Buckets: prometheus.DefBuckets,
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 12),
 	}, []string{"tool"})
 
 	CacheEvents = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/go/ai-service/internal/metrics/metrics_test.go
+++ b/go/ai-service/internal/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -42,5 +43,8 @@ func TestPromRecorder_RecordToolSubLLM(t *testing.T) {
 	}
 	if got := dtoMetric.GetHistogram().GetSampleCount(); got != 1 {
 		t.Errorf("sub-LLM histogram count = %d", got)
+	}
+	if got := dtoMetric.GetHistogram().GetSampleSum(); math.Abs(got-0.25) > 0.000001 {
+		t.Errorf("sub-LLM histogram sum = %f", got)
 	}
 }

--- a/go/ai-service/internal/metrics/metrics_test.go
+++ b/go/ai-service/internal/metrics/metrics_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func TestPromRecorder_RecordTurn(t *testing.T) {
@@ -22,5 +24,23 @@ func TestPromRecorder_RecordTool(t *testing.T) {
 	r.RecordTool("search_products", "success", 10*time.Millisecond)
 	if got := testutil.ToFloat64(ToolCallsTotal.WithLabelValues("search_products", "success")); got != 1 {
 		t.Errorf("tool counter = %v", got)
+	}
+}
+
+func TestPromRecorder_RecordToolSubLLM(t *testing.T) {
+	ToolSubLLMDuration.Reset()
+	r := PromRecorder{}
+	r.RecordToolSubLLM("summarize_orders", 250*time.Millisecond)
+	observer := ToolSubLLMDuration.WithLabelValues("summarize_orders")
+	metric, ok := observer.(prometheus.Metric)
+	if !ok {
+		t.Fatalf("histogram observer does not implement prometheus.Metric")
+	}
+	dtoMetric := &dto.Metric{}
+	if err := metric.Write(dtoMetric); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	if got := dtoMetric.GetHistogram().GetSampleCount(); got != 1 {
+		t.Errorf("sub-LLM histogram count = %d", got)
 	}
 }

--- a/go/ai-service/internal/tools/orders.go
+++ b/go/ai-service/internal/tools/orders.go
@@ -141,13 +141,22 @@ func (t *getOrderTool) Call(ctx context.Context, args json.RawMessage, userID st
 type summarizeOrdersTool struct {
 	api ordersAPI
 	llm llm.Client
+	rec toolSubLLMRecorder
+}
+
+type toolSubLLMRecorder interface {
+	RecordToolSubLLM(tool string, dur time.Duration)
 }
 
 // NewSummarizeOrdersTool builds a tool that lists the user's recent orders and
 // asks a small sub-LLM call to summarize them. It reuses the parent turn's
 // context so the agent's wall-clock timeout still covers the sub-call.
 func NewSummarizeOrdersTool(api ordersAPI, llmc llm.Client) Tool {
-	return &summarizeOrdersTool{api: api, llm: llmc}
+	return NewSummarizeOrdersToolWithRecorder(api, llmc, nil)
+}
+
+func NewSummarizeOrdersToolWithRecorder(api ordersAPI, llmc llm.Client, rec toolSubLLMRecorder) Tool {
+	return &summarizeOrdersTool{api: api, llm: llmc, rec: rec}
 }
 
 func (t *summarizeOrdersTool) Name() string { return "summarize_orders" }
@@ -195,14 +204,19 @@ func (t *summarizeOrdersTool) Call(ctx context.Context, args json.RawMessage, us
 		len(orders), a.Period, string(orderJSON),
 	)
 
+	subLLMStart := time.Now()
 	resp, err := t.llm.Chat(ctx, []llm.Message{
 		{Role: llm.RoleUser, Content: prompt},
 	}, nil)
+	subLLMDuration := time.Since(subLLMStart)
+	if t.rec != nil {
+		t.rec.RecordToolSubLLM("summarize_orders", subLLMDuration)
+	}
 	if err != nil {
-		slog.WarnContext(ctx, "tool error", "tool", "summarize_orders", "error", err.Error())
+		slog.WarnContext(ctx, "tool error", "tool", "summarize_orders", "error", err.Error(), "sub_llm_duration_ms", subLLMDuration.Milliseconds())
 		return Result{}, fmt.Errorf("summarize_orders: sub-llm: %w", err)
 	}
-	slog.InfoContext(ctx, "tool result", "tool", "summarize_orders", "order_count", len(orders), "duration_ms", time.Since(start).Milliseconds())
+	slog.InfoContext(ctx, "tool result", "tool", "summarize_orders", "order_count", len(orders), "duration_ms", time.Since(start).Milliseconds(), "sub_llm_duration_ms", subLLMDuration.Milliseconds())
 	out := map[string]any{"summary": resp.Content, "order_count": len(orders)}
 	return Result{Content: out, Display: out}, nil
 }

--- a/go/ai-service/internal/tools/orders_test.go
+++ b/go/ai-service/internal/tools/orders_test.go
@@ -3,6 +3,10 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -105,14 +109,97 @@ type summarizerLLM struct {
 	reply   string
 	err     error
 	seenMsg []llm.Message
+	delay   time.Duration
 }
 
 func (f *summarizerLLM) Chat(ctx context.Context, msgs []llm.Message, tools []llm.ToolSchema) (llm.ChatResponse, error) {
 	f.seenMsg = msgs
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
 	if f.err != nil {
 		return llm.ChatResponse{}, f.err
 	}
 	return llm.ChatResponse{Content: f.reply}, nil
+}
+
+type recordedSubLLMCall struct {
+	tool string
+	dur  time.Duration
+}
+
+type fakeSubLLMRecorder struct {
+	calls []recordedSubLLMCall
+}
+
+func (f *fakeSubLLMRecorder) RecordToolSubLLM(tool string, dur time.Duration) {
+	f.calls = append(f.calls, recordedSubLLMCall{tool: tool, dur: dur})
+}
+
+type capturedLog struct {
+	message string
+	attrs   map[string]slog.Value
+}
+
+type captureSlogHandler struct {
+	mu      sync.Mutex
+	records []capturedLog
+}
+
+func (h *captureSlogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return true
+}
+
+func (h *captureSlogHandler) Handle(ctx context.Context, r slog.Record) error {
+	attrs := make(map[string]slog.Value, r.NumAttrs())
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, capturedLog{message: r.Message, attrs: attrs})
+	return nil
+}
+
+func (h *captureSlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *captureSlogHandler) WithGroup(name string) slog.Handler {
+	return h
+}
+
+func captureSlog(t *testing.T) *captureSlogHandler {
+	t.Helper()
+	handler := &captureSlogHandler{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	return handler
+}
+
+func (h *captureSlogHandler) findMessage(message string) (capturedLog, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, record := range h.records {
+		if record.message == message {
+			return record, true
+		}
+	}
+	return capturedLog{}, false
+}
+
+func requireLogAttr(t *testing.T, record capturedLog, key string) slog.Value {
+	t.Helper()
+	value, ok := record.attrs[key]
+	if !ok {
+		t.Fatalf("expected log attr %q in %+v", key, record.attrs)
+	}
+	return value
 }
 
 func TestSummarizeOrdersTool_Success(t *testing.T) {
@@ -120,8 +207,10 @@ func TestSummarizeOrdersTool_Success(t *testing.T) {
 		{ID: "o1", Status: "paid", Total: 12999, CreatedAt: time.Now().Add(-48 * time.Hour)},
 		{ID: "o2", Status: "paid", Total: 8900, CreatedAt: time.Now().Add(-24 * time.Hour)},
 	}}
-	fakeLLM := &summarizerLLM{reply: "You placed 2 orders totaling $218.99."}
-	tool := NewSummarizeOrdersTool(fakeAPI, fakeLLM)
+	fakeLLM := &summarizerLLM{reply: "You placed 2 orders totaling $218.99.", delay: time.Millisecond}
+	recorder := &fakeSubLLMRecorder{}
+	logs := captureSlog(t)
+	tool := NewSummarizeOrdersToolWithRecorder(fakeAPI, fakeLLM, recorder)
 
 	res, err := tool.Call(ctxWithJWT("tok"), json.RawMessage(`{}`), "user-1")
 	if err != nil {
@@ -134,6 +223,54 @@ func TestSummarizeOrdersTool_Success(t *testing.T) {
 	if len(fakeLLM.seenMsg) == 0 {
 		t.Error("expected at least one message sent to sub-LLM")
 	}
+	if len(recorder.calls) != 1 {
+		t.Fatalf("metric calls = %d, want 1", len(recorder.calls))
+	}
+	if recorder.calls[0].tool != "summarize_orders" {
+		t.Errorf("metric tool = %q", recorder.calls[0].tool)
+	}
+	if recorder.calls[0].dur <= 0 {
+		t.Errorf("metric duration = %s, want positive", recorder.calls[0].dur)
+	}
+	record, ok := logs.findMessage("tool result")
+	if !ok {
+		t.Fatal("expected tool result log")
+	}
+	requireLogAttr(t, record, "duration_ms")
+	requireLogAttr(t, record, "sub_llm_duration_ms")
+}
+
+func TestSummarizeOrdersTool_SubLLMErrorRecordsDuration(t *testing.T) {
+	fakeAPI := &fakeOrdersAPI{listOut: []clients.Order{
+		{ID: "o1", Status: "paid", Total: 12999, CreatedAt: time.Now().Add(-48 * time.Hour)},
+	}}
+	fakeLLM := &summarizerLLM{err: errors.New("ollama timeout"), delay: time.Millisecond}
+	recorder := &fakeSubLLMRecorder{}
+	logs := captureSlog(t)
+	tool := NewSummarizeOrdersToolWithRecorder(fakeAPI, fakeLLM, recorder)
+
+	_, err := tool.Call(ctxWithJWT("tok"), json.RawMessage(`{}`), "user-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "summarize_orders: sub-llm: ollama timeout") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if len(recorder.calls) != 1 {
+		t.Fatalf("metric calls = %d, want 1", len(recorder.calls))
+	}
+	if recorder.calls[0].tool != "summarize_orders" {
+		t.Errorf("metric tool = %q", recorder.calls[0].tool)
+	}
+	if recorder.calls[0].dur <= 0 {
+		t.Errorf("metric duration = %s, want positive", recorder.calls[0].dur)
+	}
+	record, ok := logs.findMessage("tool error")
+	if !ok {
+		t.Fatal("expected tool error log")
+	}
+	requireLogAttr(t, record, "error")
+	requireLogAttr(t, record, "sub_llm_duration_ms")
 }
 
 func TestSummarizeOrdersTool_NoOrders(t *testing.T) {
@@ -151,6 +288,30 @@ func TestSummarizeOrdersTool_NoOrders(t *testing.T) {
 	}
 	if fakeLLM.seenMsg != nil {
 		t.Error("expected sub-LLM to be skipped on empty order list")
+	}
+}
+
+func TestSummarizeOrdersTool_NoOrdersSkipsSubLLMMetric(t *testing.T) {
+	fakeAPI := &fakeOrdersAPI{listOut: nil}
+	fakeLLM := &summarizerLLM{reply: "should not be called"}
+	recorder := &fakeSubLLMRecorder{}
+	logs := captureSlog(t)
+	tool := NewSummarizeOrdersToolWithRecorder(fakeAPI, fakeLLM, recorder)
+
+	_, err := tool.Call(ctxWithJWT("tok"), json.RawMessage(`{}`), "user-1")
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if fakeLLM.seenMsg != nil {
+		t.Error("expected sub-LLM to be skipped on empty order list")
+	}
+	if len(recorder.calls) != 0 {
+		t.Fatalf("metric calls = %d, want 0", len(recorder.calls))
+	}
+	if record, ok := logs.findMessage("tool result"); ok {
+		if _, exists := record.attrs["sub_llm_duration_ms"]; exists {
+			t.Fatalf("empty-order log included sub_llm_duration_ms: %+v", record.attrs)
+		}
 	}
 }
 

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -644,12 +644,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+              "expr": "histogram_quantile(0.5, sum by (le) (rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m])))",
               "legendFormat": "sub-LLM p50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m])))",
               "legendFormat": "sub-LLM p95",
               "refId": "B"
             }

--- a/k8s/monitoring/configmaps/grafana-dashboards.yml
+++ b/k8s/monitoring/configmaps/grafana-dashboards.yml
@@ -629,13 +629,61 @@ data:
           }
         },
         {
-          "title": "Agent Steps/Turn",
+          "title": "summarize_orders Sub-LLM Latency",
           "type": "timeseries",
           "gridPos": {
             "h": 6,
             "w": 8,
             "x": 16,
             "y": 28
+          },
+          "id": 18,
+          "datasource": {
+            "type": "prometheus",
+            "uid": ""
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+              "legendFormat": "sub-LLM p50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+              "legendFormat": "sub-LLM p95",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "title": "Agent Steps/Turn",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 34
           },
           "id": 17,
           "datasource": {

--- a/monitoring/grafana/dashboards/ai-pipeline.json
+++ b/monitoring/grafana/dashboards/ai-pipeline.json
@@ -637,12 +637,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m])))",
           "legendFormat": "sub-LLM p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m])))",
           "legendFormat": "sub-LLM p95",
           "refId": "B"
         }

--- a/monitoring/grafana/dashboards/ai-pipeline.json
+++ b/monitoring/grafana/dashboards/ai-pipeline.json
@@ -622,13 +622,61 @@
       }
     },
     {
-      "title": "Agent Steps/Turn",
+      "title": "summarize_orders Sub-LLM Latency",
       "type": "timeseries",
       "gridPos": {
         "h": 6,
         "w": 8,
         "x": 16,
         "y": 28
+      },
+      "id": 18,
+      "datasource": {
+        "type": "prometheus",
+        "uid": ""
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+          "legendFormat": "sub-LLM p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(ai_tool_sub_llm_duration_seconds_bucket{tool=\"summarize_orders\"}[5m]))",
+          "legendFormat": "sub-LLM p95",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "title": "Agent Steps/Turn",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 34
       },
       "id": 17,
       "datasource": {


### PR DESCRIPTION
## Summary
- add a targeted `ai_tool_sub_llm_duration_seconds` histogram for `summarize_orders`
- log `sub_llm_duration_ms` on nested LLM success and failure
- add an AI Pipeline panel for aggregated sub-LLM p50/p95 latency

## Test Plan
- [x] `make preflight-go`
- [x] `make grafana-sync-check`