### PR TITLE
Phase 4b: Hybrid search with BM25 and semantic retrieval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   qdrant:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.16.3
     ports:
       - "127.0.0.1:6333:6333"
       - "127.0.0.1:6334:6334"

--- a/docs/superpowers/plans/2026-05-08-hybrid-search.md
+++ b/docs/superpowers/plans/2026-05-08-hybrid-search.md
@@ -1,0 +1,1151 @@
+# Hybrid Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Qdrant-native hybrid retrieval so newly ingested RAG collections use dense semantic vectors plus BM25 sparse vectors, while legacy dense-only collections keep working.
+
+**Architecture:** Ingestion creates named `dense` and `sparse` vectors for new collections and upserts both vectors per chunk. Chat defaults to Qdrant Query API hybrid search with RRF, then falls back to legacy semantic search when a collection is dense-only. Eval captures retrieval metadata so semantic-only and hybrid runs can be compared.
+
+**Tech Stack:** Python 3.11, FastAPI, qdrant-client with FastEmbed extra, Qdrant 1.16.3+, pytest, Docker Compose, Kubernetes manifests.
+
+---
+
+## References
+
+- Design spec: `docs/superpowers/specs/2026-05-08-hybrid-search-design.md`
+- Qdrant hybrid Query API: https://qdrant.tech/documentation/search/hybrid-queries/
+- Qdrant text search and BM25 sparse vectors: https://qdrant.tech/documentation/search/text-search/
+- qdrant-client package: https://pypi.org/project/qdrant-client/
+
+## File Structure
+
+- Modify `services/shared/pyproject.toml`: include a new shared `rag` package and install `qdrant-client[fastembed]==1.17.1`.
+- Create `services/shared/rag/__init__.py`: export sparse vector helpers.
+- Create `services/shared/rag/sparse.py`: normalize FastEmbed BM25 sparse output into Qdrant `SparseVector` models.
+- Create `services/shared/tests/test_sparse.py`: unit tests for sparse vector normalization without loading real ONNX models.
+- Modify `services/ingestion/requirements.txt`: use `qdrant-client[fastembed]==1.17.1`.
+- Modify `services/chat/requirements.txt`: use `qdrant-client[fastembed]==1.17.1`.
+- Modify `docker-compose.yml`: pin Qdrant to `qdrant/qdrant:v1.16.3`.
+- Modify `k8s/ai-services/deployments/qdrant.yml`: pin Qdrant to `qdrant/qdrant:v1.16.3`.
+- Modify `services/ingestion/app/store.py`: create hybrid collection configs and upsert named vectors.
+- Modify `services/ingestion/app/config.py`: add sparse model config.
+- Modify `services/ingestion/app/collection_meta.py`: persist hybrid metadata.
+- Modify `services/ingestion/app/main.py`: generate sparse vectors before Qdrant upsert and record metadata.
+- Modify `services/ingestion/tests/test_store.py`: cover hybrid collection creation and named-vector upserts.
+- Modify `services/ingestion/tests/test_main.py`: cover sparse generation and metadata writes.
+- Modify `services/chat/app/config.py`: add retrieval mode, vector names, sparse model, and hybrid prefetch config.
+- Modify `services/chat/app/retriever.py`: add semantic and hybrid retrieval methods with fallback metadata.
+- Modify `services/chat/app/chain.py`: return chunks plus retrieval metadata to `/chat` callers.
+- Modify `services/chat/app/main.py`: expose retrieval metadata from `/search`, `/chat` JSON, `/chat` SSE, and `/config`.
+- Modify `services/chat/tests/test_retriever.py`: cover Query API hybrid, named semantic, and legacy fallback.
+- Modify `services/chat/tests/test_chain.py`: cover metadata propagation.
+- Modify `services/chat/tests/test_main.py`: cover API response metadata compatibility.
+- Modify `services/eval/app/config_capture.py`: capture chat retrieval config already exposed by `/config`.
+- Modify `services/eval/tests/test_config_capture.py`: assert hybrid retrieval settings are preserved.
+
+## Task 1: Pin Runtime And Client Versions
+
+**Files:**
+- Modify: `services/ingestion/requirements.txt`
+- Modify: `services/chat/requirements.txt`
+- Modify: `services/shared/pyproject.toml`
+- Modify: `docker-compose.yml`
+- Modify: `k8s/ai-services/deployments/qdrant.yml`
+
+- [ ] **Step 1: Update qdrant-client dependencies**
+
+In `services/ingestion/requirements.txt`, replace:
+
+```txt
+qdrant-client==1.9.0
+```
+
+with:
+
+```txt
+qdrant-client[fastembed]==1.17.1
+```
+
+In `services/chat/requirements.txt`, make the same replacement.
+
+In `services/shared/pyproject.toml`, update the package include and dependencies to:
+
+```toml
+dependencies = [
+    "httpx>=0.27",
+    "openai>=1.0",
+    "anthropic>=0.30",
+    "qdrant-client[fastembed]==1.17.1",
+]
+
+[tool.setuptools.packages.find]
+include = ["llm*", "rag*"]
+```
+
+- [ ] **Step 2: Pin Qdrant images**
+
+In `docker-compose.yml`, replace:
+
+```yaml
+image: qdrant/qdrant:latest
+```
+
+with:
+
+```yaml
+image: qdrant/qdrant:v1.16.3
+```
+
+In `k8s/ai-services/deployments/qdrant.yml`, make the same image replacement.
+
+- [ ] **Step 3: Verify dependency text changes**
+
+Run:
+
+```bash
+rg -n "qdrant-client|qdrant/qdrant" services/ingestion/requirements.txt services/chat/requirements.txt services/shared/pyproject.toml docker-compose.yml k8s/ai-services/deployments/qdrant.yml
+```
+
+Expected: chat and ingestion requirements show `qdrant-client[fastembed]==1.17.1`, shared pyproject includes the same dependency, and both Qdrant image references are `qdrant/qdrant:v1.16.3`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/ingestion/requirements.txt services/chat/requirements.txt services/shared/pyproject.toml docker-compose.yml k8s/ai-services/deployments/qdrant.yml
+git commit -m "chore: pin qdrant hybrid search dependencies"
+```
+
+## Task 2: Add Shared BM25 Sparse Vector Encoder
+
+**Files:**
+- Create: `services/shared/rag/__init__.py`
+- Create: `services/shared/rag/sparse.py`
+- Create: `services/shared/tests/test_sparse.py`
+
+- [ ] **Step 1: Write failing sparse encoder tests**
+
+Create `services/shared/tests/test_sparse.py`:
+
+```python
+from types import SimpleNamespace
+
+from qdrant_client.models import SparseVector
+from rag.sparse import SparseVectorEncoder, normalize_sparse_vector
+
+
+def test_normalize_sparse_vector_converts_numpy_like_values():
+    raw = SimpleNamespace(
+        indices=SimpleNamespace(tolist=lambda: [2, 7]),
+        values=SimpleNamespace(tolist=lambda: [0.5, 1.25]),
+    )
+
+    vector = normalize_sparse_vector(raw)
+
+    assert vector == SparseVector(indices=[2, 7], values=[0.5, 1.25])
+
+
+def test_sparse_vector_encoder_returns_one_vector_per_text(monkeypatch):
+    class FakeSparseTextEmbedding:
+        def __init__(self, model_name: str, batch_size: int):
+            self.model_name = model_name
+            self.batch_size = batch_size
+
+        def embed(self, texts):
+            assert texts == ["RFC 7231", "section 4.2"]
+            return [
+                SimpleNamespace(indices=[1], values=[0.7]),
+                SimpleNamespace(indices=[3, 4], values=[0.2, 0.9]),
+            ]
+
+    monkeypatch.setattr("rag.sparse.SparseTextEmbedding", FakeSparseTextEmbedding)
+
+    encoder = SparseVectorEncoder(model_name="Qdrant/bm25", batch_size=16)
+    vectors = encoder.embed(["RFC 7231", "section 4.2"])
+
+    assert vectors == [
+        SparseVector(indices=[1], values=[0.7]),
+        SparseVector(indices=[3, 4], values=[0.2, 0.9]),
+    ]
+
+
+def test_sparse_vector_encoder_returns_empty_list_for_empty_input(monkeypatch):
+    class FailingSparseTextEmbedding:
+        def __init__(self, model_name: str, batch_size: int):
+            raise AssertionError("model should not load for empty input")
+
+    monkeypatch.setattr("rag.sparse.SparseTextEmbedding", FailingSparseTextEmbedding)
+
+    encoder = SparseVectorEncoder(model_name="Qdrant/bm25", batch_size=16)
+
+    assert encoder.embed([]) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services/shared pytest services/shared/tests/test_sparse.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'rag'`.
+
+- [ ] **Step 3: Implement sparse encoder**
+
+Create `services/shared/rag/__init__.py`:
+
+```python
+from rag.sparse import SparseVectorEncoder, normalize_sparse_vector
+
+__all__ = ["SparseVectorEncoder", "normalize_sparse_vector"]
+```
+
+Create `services/shared/rag/sparse.py`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from fastembed import SparseTextEmbedding
+from qdrant_client.models import SparseVector
+
+
+def _as_list(value: Any) -> list:
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+
+def normalize_sparse_vector(raw: Any) -> SparseVector:
+    return SparseVector(
+        indices=[int(index) for index in _as_list(raw.indices)],
+        values=[float(value) for value in _as_list(raw.values)],
+    )
+
+
+class SparseVectorEncoder:
+    def __init__(self, model_name: str = "Qdrant/bm25", batch_size: int = 256):
+        self.model_name = model_name
+        self.batch_size = batch_size
+        self._model: SparseTextEmbedding | None = None
+
+    def _get_model(self) -> SparseTextEmbedding:
+        if self._model is None:
+            self._model = SparseTextEmbedding(
+                model_name=self.model_name,
+                batch_size=self.batch_size,
+            )
+        return self._model
+
+    def embed(self, texts: Sequence[str]) -> list[SparseVector]:
+        if not texts:
+            return []
+        return [
+            normalize_sparse_vector(vector)
+            for vector in self._get_model().embed(list(texts))
+        ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+PYTHONPATH=services/shared pytest services/shared/tests/test_sparse.py -v
+```
+
+Expected: PASS for 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/shared/rag/__init__.py services/shared/rag/sparse.py services/shared/tests/test_sparse.py
+git commit -m "feat: add bm25 sparse vector encoder"
+```
+
+## Task 3: Store Hybrid Vectors During Ingestion
+
+**Files:**
+- Modify: `services/ingestion/app/store.py`
+- Modify: `services/ingestion/tests/test_store.py`
+
+- [ ] **Step 1: Write failing store tests**
+
+Append these tests to `services/ingestion/tests/test_store.py`:
+
+```python
+from qdrant_client.models import SparseVector
+
+
+def test_store_init_creates_hybrid_collection(mock_qdrant_client):
+    mock_qdrant_client.collection_exists.return_value = False
+
+    QdrantStore(host="localhost", port=6333, collection_name="test")
+
+    call_args = mock_qdrant_client.create_collection.call_args
+    assert call_args.kwargs["collection_name"] == "test"
+    assert sorted(call_args.kwargs["vectors_config"].keys()) == ["dense"]
+    assert sorted(call_args.kwargs["sparse_vectors_config"].keys()) == ["sparse"]
+
+
+def test_upsert_writes_named_dense_and_sparse_vectors(mock_qdrant_client):
+    mock_qdrant_client.collection_exists.return_value = True
+    store = QdrantStore(host="localhost", port=6333, collection_name="test")
+
+    chunks = [{"text": "RFC 7231", "page_number": 1, "chunk_index": 0}]
+    dense_vectors = [[0.1] * 768]
+    sparse_vectors = [SparseVector(indices=[10, 11], values=[0.8, 0.4])]
+
+    store.upsert(
+        chunks=chunks,
+        vectors=dense_vectors,
+        sparse_vectors=sparse_vectors,
+        document_id="doc-123",
+        filename="http.pdf",
+    )
+
+    point = mock_qdrant_client.upsert.call_args.kwargs["points"][0]
+    assert point.vector["dense"] == dense_vectors[0]
+    assert point.vector["sparse"] == sparse_vectors[0]
+    assert point.payload["text"] == "RFC 7231"
+```
+
+Update the existing `test_upsert_vectors` call to include:
+
+```python
+sparse_vectors=[
+    SparseVector(indices=[1], values=[0.1]),
+    SparseVector(indices=[2], values=[0.2]),
+],
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services/ingestion/app:services/shared pytest services/ingestion/tests/test_store.py -v
+```
+
+Expected: FAIL because `QdrantStore.upsert()` does not accept `sparse_vectors` and collection creation has no sparse config.
+
+- [ ] **Step 3: Implement hybrid collection and upsert support**
+
+In `services/ingestion/app/store.py`, update imports:
+
+```python
+from qdrant_client.models import (
+    Distance,
+    FieldCondition,
+    Filter,
+    MatchValue,
+    PointStruct,
+    SparseVector,
+    SparseVectorParams,
+    VectorParams,
+)
+```
+
+Add constants near imports:
+
+```python
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
+```
+
+Update `_ensure_collection()`:
+
+```python
+    def _ensure_collection(self):
+        if not self.client.collection_exists(self.collection_name):
+            self.client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config={
+                    DENSE_VECTOR_NAME: VectorParams(
+                        size=768,
+                        distance=Distance.COSINE,
+                    )
+                },
+                sparse_vectors_config={
+                    SPARSE_VECTOR_NAME: SparseVectorParams(),
+                },
+            )
+```
+
+Update `upsert()` signature and point creation:
+
+```python
+    def upsert(
+        self,
+        chunks: list[dict],
+        vectors: list[list[float]],
+        sparse_vectors: list[SparseVector],
+        document_id: str,
+        filename: str,
+    ) -> None:
+        points = [
+            PointStruct(
+                id=str(uuid.uuid4()),
+                vector={
+                    DENSE_VECTOR_NAME: vector,
+                    SPARSE_VECTOR_NAME: sparse_vector,
+                },
+                payload={
+                    "text": chunk["text"],
+                    "page_number": chunk["page_number"],
+                    "chunk_index": chunk["chunk_index"],
+                    "document_id": document_id,
+                    "filename": filename,
+                },
+            )
+            for chunk, vector, sparse_vector in zip(chunks, vectors, sparse_vectors)
+        ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+PYTHONPATH=services/ingestion/app:services/shared pytest services/ingestion/tests/test_store.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/ingestion/app/store.py services/ingestion/tests/test_store.py
+git commit -m "feat: store hybrid qdrant vectors"
+```
+
+## Task 4: Generate Sparse Vectors And Metadata In Ingestion API
+
+**Files:**
+- Modify: `services/ingestion/app/config.py`
+- Modify: `services/ingestion/app/collection_meta.py`
+- Modify: `services/ingestion/app/main.py`
+- Modify: `services/ingestion/tests/test_main.py`
+
+- [ ] **Step 1: Write failing ingestion API test**
+
+In `services/ingestion/tests/test_main.py`, add imports:
+
+```python
+from qdrant_client.models import SparseVector
+```
+
+Add this test near the existing ingest tests:
+
+```python
+@patch("app.main.SparseVectorEncoder")
+@patch("app.main.QdrantStore")
+@patch("app.main.embed_texts", new_callable=AsyncMock)
+@patch("app.main.extract_pages")
+def test_ingest_generates_sparse_vectors_and_records_hybrid_metadata(
+    mock_extract,
+    mock_embed,
+    mock_qdrant_store_cls,
+    mock_sparse_encoder_cls,
+    client,
+):
+    mock_extract.return_value = [{"page_number": 1, "text": "RFC 7231 section 4.2"}]
+    mock_embed.return_value = [[0.1] * 768]
+
+    mock_sparse_encoder = MagicMock()
+    sparse_vectors = [SparseVector(indices=[1, 2], values=[0.7, 0.4])]
+    mock_sparse_encoder.embed.return_value = sparse_vectors
+    mock_sparse_encoder_cls.return_value = mock_sparse_encoder
+
+    mock_store = MagicMock()
+    mock_qdrant_store_cls.return_value = mock_store
+
+    response = client.post(
+        "/ingest",
+        files={"file": ("http.pdf", b"%PDF-1.4 fake", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    mock_sparse_encoder.embed.assert_called_once_with(["RFC 7231 section 4.2"])
+    mock_store.upsert.assert_called_once()
+    assert mock_store.upsert.call_args.kwargs["sparse_vectors"] == sparse_vectors
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=services/ingestion/app:services/shared pytest services/ingestion/tests/test_main.py::test_ingest_generates_sparse_vectors_and_records_hybrid_metadata -v
+```
+
+Expected: FAIL because `app.main.SparseVectorEncoder` does not exist and `store.upsert()` is not called with sparse vectors.
+
+- [ ] **Step 3: Add sparse ingestion config**
+
+In `services/ingestion/app/config.py`, add settings:
+
+```python
+    sparse_model: str = "Qdrant/bm25"
+    sparse_batch_size: int = 256
+    hybrid_enabled: bool = True
+```
+
+- [ ] **Step 4: Extend metadata persistence**
+
+In `services/ingestion/app/collection_meta.py`, extend the stored config dict in `upsert()` so records include:
+
+```python
+"hybrid_enabled": True,
+"dense_vector_name": "dense",
+"sparse_vector_name": "sparse",
+"sparse_model": sparse_model,
+```
+
+Update the `upsert()` method signature to accept:
+
+```python
+sparse_model: str | None = None,
+hybrid_enabled: bool = True,
+```
+
+When serializing, use `sparse_model` as passed from settings.
+
+- [ ] **Step 5: Generate sparse vectors in ingest**
+
+In `services/ingestion/app/main.py`, add imports:
+
+```python
+from rag.sparse import SparseVectorEncoder
+```
+
+Add module global after `_embedding_provider`:
+
+```python
+_sparse_encoder = SparseVectorEncoder(
+    model_name=settings.sparse_model,
+    batch_size=settings.sparse_batch_size,
+)
+```
+
+After dense `vectors = await embed_texts(...)`, add:
+
+```python
+    try:
+        sparse_vectors = _sparse_encoder.embed(texts)
+    except Exception as e:
+        logger.error("sparse_vector_error", error=str(e), exc_info=True)
+        raise HTTPException(status_code=503, detail="Sparse vector generation failed")
+```
+
+Update `store.upsert()`:
+
+```python
+        store.upsert(
+            chunks=chunks,
+            vectors=vectors,
+            sparse_vectors=sparse_vectors,
+            document_id=document_id,
+            filename=file.filename,
+        )
+```
+
+Update metadata write:
+
+```python
+        await meta_db.upsert(
+            collection=target_collection,
+            chunk_size=settings.chunk_size,
+            chunk_overlap=settings.chunk_overlap,
+            embedding_model=settings.embedding_model,
+            sparse_model=settings.sparse_model,
+            hybrid_enabled=settings.hybrid_enabled,
+        )
+```
+
+- [ ] **Step 6: Run targeted ingestion tests**
+
+Run:
+
+```bash
+PYTHONPATH=services/ingestion/app:services/shared pytest services/ingestion/tests/test_main.py services/ingestion/tests/test_store.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/ingestion/app/config.py services/ingestion/app/collection_meta.py services/ingestion/app/main.py services/ingestion/tests/test_main.py
+git commit -m "feat: generate sparse vectors during ingestion"
+```
+
+## Task 5: Add Hybrid And Fallback Retrieval In Chat
+
+**Files:**
+- Modify: `services/chat/app/config.py`
+- Modify: `services/chat/app/retriever.py`
+- Modify: `services/chat/tests/test_retriever.py`
+
+- [ ] **Step 1: Write failing retriever tests**
+
+Replace `services/chat/tests/test_retriever.py` with tests that cover all retrieval modes while preserving old assertions:
+
+```python
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.retriever import QdrantRetriever
+from qdrant_client.models import SparseVector
+
+
+@pytest.fixture
+def mock_qdrant_client():
+    with patch("app.retriever.QdrantClient") as MockClient:
+        client = MagicMock()
+        MockClient.return_value = client
+        yield client
+
+
+def _hit(score=0.95, text="relevant chunk"):
+    return MagicMock(
+        score=score,
+        payload={
+            "text": text,
+            "page_number": 1,
+            "filename": "doc.pdf",
+            "document_id": "abc",
+        },
+    )
+
+
+def test_hybrid_search_uses_prefetch_and_rrf(mock_qdrant_client):
+    mock_qdrant_client.query_points.return_value = MagicMock(points=[_hit()])
+    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
+
+    result = retriever.search_hybrid(
+        query_vector=[0.1] * 768,
+        sparse_vector=SparseVector(indices=[1], values=[0.7]),
+        top_k=5,
+        prefetch_limit=20,
+    )
+
+    assert result.metadata == {
+        "retrieval_mode": "hybrid",
+        "retrieval_fallback": False,
+        "fusion": "rrf",
+    }
+    assert result.chunks[0]["text"] == "relevant chunk"
+    call_args = mock_qdrant_client.query_points.call_args
+    assert call_args.kwargs["collection_name"] == "test"
+    assert call_args.kwargs["limit"] == 5
+    assert len(call_args.kwargs["prefetch"]) == 2
+
+
+def test_semantic_search_uses_named_dense_vector(mock_qdrant_client):
+    mock_qdrant_client.search.return_value = [_hit()]
+    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
+
+    result = retriever.search_semantic(query_vector=[0.1] * 768, top_k=3)
+
+    assert result.metadata["retrieval_mode"] == "semantic"
+    assert result.metadata["retrieval_fallback"] is False
+    assert mock_qdrant_client.search.call_args.kwargs["query_vector"][0] == "dense"
+
+
+def test_legacy_semantic_search_uses_unnamed_vector(mock_qdrant_client):
+    mock_qdrant_client.search.return_value = [_hit()]
+    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
+
+    result = retriever.search_semantic(
+        query_vector=[0.1] * 768,
+        top_k=3,
+        legacy_vector=True,
+        fallback=True,
+    )
+
+    assert result.metadata["retrieval_mode"] == "semantic"
+    assert result.metadata["retrieval_fallback"] is True
+    assert mock_qdrant_client.search.call_args.kwargs["query_vector"] == [0.1] * 768
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services/chat/app:services/shared pytest services/chat/tests/test_retriever.py -v
+```
+
+Expected: FAIL because `search_hybrid`, `search_semantic`, and metadata result objects do not exist.
+
+- [ ] **Step 3: Add chat retrieval settings**
+
+In `services/chat/app/config.py`, add:
+
+```python
+    retrieval_mode: str = "hybrid"
+    dense_vector_name: str = "dense"
+    sparse_vector_name: str = "sparse"
+    sparse_model: str = "Qdrant/bm25"
+    sparse_batch_size: int = 256
+    hybrid_prefetch_limit: int = 20
+```
+
+In `validate()`, add:
+
+```python
+        if self.retrieval_mode not in {"semantic", "hybrid"}:
+            raise ValueError("retrieval_mode must be 'semantic' or 'hybrid'")
+        if self.hybrid_prefetch_limit < self.top_k:
+            raise ValueError("hybrid_prefetch_limit must be >= top_k")
+```
+
+- [ ] **Step 4: Implement retriever result and search methods**
+
+Replace `services/chat/app/retriever.py` with:
+
+```python
+import time
+from dataclasses import dataclass
+
+from qdrant_client import QdrantClient
+from qdrant_client.models import Fusion, FusionQuery, Prefetch, SparseVector
+
+from app.config import settings
+from app.metrics import QDRANT_SEARCH_DURATION, QDRANT_SEARCH_RESULTS
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    chunks: list[dict]
+    metadata: dict
+
+
+class QdrantRetriever:
+    def __init__(self, host: str, port: int, collection_name: str):
+        self.client = QdrantClient(host=host, port=port)
+        self.collection_name = collection_name
+
+    def _format_results(self, results) -> list[dict]:
+        return [
+            {
+                "text": hit.payload["text"],
+                "page_number": hit.payload["page_number"],
+                "filename": hit.payload["filename"],
+                "document_id": hit.payload["document_id"],
+                "score": hit.score,
+            }
+            for hit in results
+        ]
+
+    def search_semantic(
+        self,
+        query_vector: list[float],
+        top_k: int = 5,
+        legacy_vector: bool = False,
+        fallback: bool = False,
+    ) -> RetrievalResult:
+        start = time.perf_counter()
+        vector_selector = (
+            query_vector if legacy_vector else (settings.dense_vector_name, query_vector)
+        )
+        results = self.client.search(
+            collection_name=self.collection_name,
+            query_vector=vector_selector,
+            limit=top_k,
+        )
+        QDRANT_SEARCH_DURATION.labels(collection=self.collection_name).observe(
+            time.perf_counter() - start
+        )
+        QDRANT_SEARCH_RESULTS.labels(collection=self.collection_name).observe(
+            len(results)
+        )
+        return RetrievalResult(
+            chunks=self._format_results(results),
+            metadata={
+                "retrieval_mode": "semantic",
+                "retrieval_fallback": fallback,
+                "fusion": None,
+            },
+        )
+
+    def search_hybrid(
+        self,
+        query_vector: list[float],
+        sparse_vector: SparseVector,
+        top_k: int = 5,
+        prefetch_limit: int = 20,
+    ) -> RetrievalResult:
+        start = time.perf_counter()
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            prefetch=[
+                Prefetch(
+                    query=query_vector,
+                    using=settings.dense_vector_name,
+                    limit=prefetch_limit,
+                ),
+                Prefetch(
+                    query=sparse_vector,
+                    using=settings.sparse_vector_name,
+                    limit=prefetch_limit,
+                ),
+            ],
+            query=FusionQuery(fusion=Fusion.RRF),
+            limit=top_k,
+            with_payload=True,
+        )
+        results = response.points
+        QDRANT_SEARCH_DURATION.labels(collection=self.collection_name).observe(
+            time.perf_counter() - start
+        )
+        QDRANT_SEARCH_RESULTS.labels(collection=self.collection_name).observe(
+            len(results)
+        )
+        return RetrievalResult(
+            chunks=self._format_results(results),
+            metadata={
+                "retrieval_mode": "hybrid",
+                "retrieval_fallback": False,
+                "fusion": "rrf",
+            },
+        )
+
+    def search(self, query_vector: list[float], top_k: int = 5) -> list[dict]:
+        return self.search_semantic(query_vector=query_vector, top_k=top_k).chunks
+```
+
+- [ ] **Step 5: Run retriever tests**
+
+Run:
+
+```bash
+PYTHONPATH=services/chat/app:services/shared pytest services/chat/tests/test_retriever.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/chat/app/config.py services/chat/app/retriever.py services/chat/tests/test_retriever.py
+git commit -m "feat: add qdrant hybrid retriever"
+```
+
+## Task 6: Wire Hybrid Retrieval Through Chat API
+
+**Files:**
+- Modify: `services/chat/app/chain.py`
+- Modify: `services/chat/app/main.py`
+- Modify: `services/chat/tests/test_chain.py`
+- Modify: `services/chat/tests/test_main.py`
+
+- [ ] **Step 1: Write failing chain metadata test**
+
+In `services/chat/tests/test_chain.py`, add:
+
+```python
+from app.retriever import RetrievalResult
+```
+
+Add this test:
+
+```python
+@patch("app.chain.SparseVectorEncoder")
+@patch("app.chain.QdrantRetriever")
+@pytest.mark.asyncio
+async def test_retrieve_chunks_returns_hybrid_metadata(
+    mock_retriever_cls,
+    mock_sparse_encoder_cls,
+):
+    embedding_provider = AsyncMock()
+    embedding_provider.embed.return_value = [[0.1] * 768]
+
+    sparse_vector = MagicMock()
+    mock_sparse_encoder = MagicMock()
+    mock_sparse_encoder.embed.return_value = [sparse_vector]
+    mock_sparse_encoder_cls.return_value = mock_sparse_encoder
+
+    retriever = MagicMock()
+    retriever.search_hybrid.return_value = RetrievalResult(
+        chunks=[{"text": "RFC 7231", "page_number": 1, "filename": "http.pdf", "document_id": "doc", "score": 0.9}],
+        metadata={"retrieval_mode": "hybrid", "retrieval_fallback": False, "fusion": "rrf"},
+    )
+    mock_retriever_cls.return_value = retriever
+
+    result = await retrieve_chunks(
+        question="What is RFC 7231?",
+        embedding_provider=embedding_provider,
+        embedding_model="nomic-embed-text",
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=5,
+    )
+
+    assert result.metadata["retrieval_mode"] == "hybrid"
+    assert result.chunks[0]["text"] == "RFC 7231"
+```
+
+- [ ] **Step 2: Run chain test to verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=services/chat/app:services/shared pytest services/chat/tests/test_chain.py::test_retrieve_chunks_returns_hybrid_metadata -v
+```
+
+Expected: FAIL because `retrieve_chunks()` returns `list[dict]`.
+
+- [ ] **Step 3: Update chain retrieval**
+
+In `services/chat/app/chain.py`, import:
+
+```python
+from rag.sparse import SparseVectorEncoder
+from app.config import settings
+from app.retriever import QdrantRetriever, RetrievalResult
+```
+
+Add module global:
+
+```python
+_sparse_encoder = SparseVectorEncoder(
+    model_name=settings.sparse_model,
+    batch_size=settings.sparse_batch_size,
+)
+```
+
+Update `retrieve_chunks()` return type to `RetrievalResult` and replace retriever call:
+
+```python
+    retriever = QdrantRetriever(
+        host=qdrant_host, port=qdrant_port, collection_name=collection_name
+    )
+    if settings.retrieval_mode == "hybrid":
+        try:
+            sparse_vector = _sparse_encoder.embed([question])[0]
+            result = retriever.search_hybrid(
+                query_vector=query_vector,
+                sparse_vector=sparse_vector,
+                top_k=top_k,
+                prefetch_limit=settings.hybrid_prefetch_limit,
+            )
+        except Exception:
+            result = retriever.search_semantic(
+                query_vector=query_vector,
+                top_k=top_k,
+                legacy_vector=True,
+                fallback=True,
+            )
+    else:
+        result = retriever.search_semantic(query_vector=query_vector, top_k=top_k)
+```
+
+Return `result`.
+
+In `rag_query()`, change:
+
+```python
+    retrieval = await retrieve_chunks(...)
+    chunks = retrieval.chunks
+```
+
+and final event:
+
+```python
+    yield {"done": True, "sources": sources, "retrieval": retrieval.metadata}
+```
+
+- [ ] **Step 4: Update `/search`, `/chat`, and `/config` metadata**
+
+In `services/chat/app/main.py`, update `/config` response:
+
+```python
+        "retrieval_mode": settings.retrieval_mode,
+        "hybrid_prefetch_limit": settings.hybrid_prefetch_limit,
+        "dense_vector_name": settings.dense_vector_name,
+        "sparse_vector_name": settings.sparse_vector_name,
+        "sparse_model": settings.sparse_model,
+        "fusion": "rrf" if settings.retrieval_mode == "hybrid" else None,
+```
+
+In JSON `/chat`, collect final retrieval metadata:
+
+```python
+            retrieval = {}
+            ...
+                if event.get("done"):
+                    sources = event.get("sources", [])
+                    retrieval = event.get("retrieval", {})
+            return {"answer": "".join(tokens), "sources": sources, "retrieval": retrieval}
+```
+
+In `/search`, use the new result object:
+
+```python
+        retrieval = await retrieve_chunks(...)
+```
+
+and return:
+
+```python
+    return {
+        "results": [
+            {
+                "text": c["text"],
+                "filename": c["filename"],
+                "page_number": c["page_number"],
+                "score": c["score"],
+            }
+            for c in retrieval.chunks
+        ],
+        "retrieval": retrieval.metadata,
+    }
+```
+
+- [ ] **Step 5: Run targeted chat tests**
+
+Run:
+
+```bash
+PYTHONPATH=services/chat/app:services/shared pytest services/chat/tests/test_chain.py services/chat/tests/test_main.py -v
+```
+
+Expected: PASS after updating existing tests that mock `retrieve_chunks()` to return `RetrievalResult(chunks=[...], metadata={...})`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/chat/app/chain.py services/chat/app/main.py services/chat/tests/test_chain.py services/chat/tests/test_main.py
+git commit -m "feat: expose hybrid retrieval metadata"
+```
+
+## Task 7: Capture Hybrid Retrieval Settings In Eval
+
+**Files:**
+- Modify: `services/eval/tests/test_config_capture.py`
+- Modify: `services/eval/app/config_capture.py`
+
+- [ ] **Step 1: Write failing config capture assertion**
+
+In `services/eval/tests/test_config_capture.py`, update the fake chat config response to include:
+
+```python
+{
+    "retrieval_mode": "hybrid",
+    "hybrid_prefetch_limit": 20,
+    "dense_vector_name": "dense",
+    "sparse_vector_name": "sparse",
+    "sparse_model": "Qdrant/bm25",
+    "fusion": "rrf",
+}
+```
+
+Add assertion:
+
+```python
+assert result["chat"]["retrieval_mode"] == "hybrid"
+assert result["chat"]["fusion"] == "rrf"
+assert result["chat"]["sparse_model"] == "Qdrant/bm25"
+```
+
+- [ ] **Step 2: Run eval config tests**
+
+Run:
+
+```bash
+PYTHONPATH=services/eval/app pytest services/eval/tests/test_config_capture.py -v
+```
+
+Expected: PASS if config capture already preserves arbitrary chat config keys. If it fails because the test fixture or response model filters keys, remove that filtering so `capture_run_config()` stores the full chat config dict.
+
+- [ ] **Step 3: Commit if code changed**
+
+If only tests changed and they pass:
+
+```bash
+git add services/eval/tests/test_config_capture.py
+git commit -m "test: cover hybrid retrieval config capture"
+```
+
+If `services/eval/app/config_capture.py` also changed:
+
+```bash
+git add services/eval/app/config_capture.py services/eval/tests/test_config_capture.py
+git commit -m "feat: capture hybrid retrieval config"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+- Verify all touched Python, Docker, and Kubernetes files.
+
+- [ ] **Step 1: Run Python preflight**
+
+Run:
+
+```bash
+make preflight-python
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run security preflight**
+
+Run:
+
+```bash
+make preflight-security
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Optional local compose smoke**
+
+Run only if Docker resources are available locally:
+
+```bash
+docker compose up -d qdrant mock-ollama ingestion chat
+```
+
+Then ingest a small PDF into a fresh collection and call `/search`. Expected:
+the response includes `"retrieval": {"retrieval_mode": "hybrid", ...}`.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -8
+```
+
+Expected: branch is `qa`, all intended commits are present, and there are no unstaged files unless generated local artifacts are intentionally left untracked.
+
+- [ ] **Step 5: Do not push doc-only or implementation commits unless branch rules allow the current work type**
+
+On `qa`, implementation commits may be pushed autonomously. Doc-only commits stay local until a later code change or explicit request.
+
+## Self-Review
+
+Spec coverage:
+
+- Dense+sparse indexing: Tasks 2, 3, and 4.
+- Qdrant native hybrid search with RRF: Task 5.
+- Legacy semantic fallback: Tasks 5 and 6.
+- Existing `/chat` and `/search` compatibility: Task 6.
+- Eval config capture: Task 7.
+- Version pinning: Task 1.
+- Verification: Task 8.
+
+Placeholder scan: no unresolved markers or vague implementation steps are present.
+
+Type consistency:
+
+- `SparseVectorEncoder.embed()` returns `list[qdrant_client.models.SparseVector]`.
+- `QdrantRetriever.search_hybrid()` and `search_semantic()` both return `RetrievalResult`.
+- API metadata uses one shape everywhere: `retrieval_mode`, `retrieval_fallback`, and `fusion`.

--- a/docs/superpowers/specs/2026-05-08-hybrid-search-design.md
+++ b/docs/superpowers/specs/2026-05-08-hybrid-search-design.md
@@ -1,0 +1,182 @@
+# Hybrid Search Design
+
+## Context
+
+Issue #80 adds keyword matching alongside semantic vector search for the RAG
+pipeline. The goal is to catch exact-match queries such as RFC numbers, section
+numbers, product IDs, and other terms that dense embeddings can miss.
+
+Phase 4a is already available under `services/eval/`, so this work should use
+the existing evaluation harness to compare semantic-only retrieval with hybrid
+retrieval.
+
+Current state:
+
+- `services/ingestion` chunks PDFs, embeds chunk text, and writes one dense
+  vector per point to Qdrant.
+- `services/chat` embeds each query and uses Qdrant search for semantic
+  retrieval.
+- `services/eval` calls chat `/search` and `/chat`, then scores the run.
+- Existing Qdrant collections are dense-only and should continue to work.
+
+## Goals
+
+- Store dense and BM25 sparse vectors for newly ingested RAG collections.
+- Use native Qdrant hybrid search with reciprocal rank fusion for default
+  retrieval.
+- Preserve existing `/chat` and `/search` callers.
+- Fall back to semantic-only retrieval for legacy dense-only collections.
+- Capture enough metadata for eval runs to compare semantic-only and hybrid
+  behavior.
+
+## Non-Goals
+
+- No migration or backfill job for existing collections.
+- No mutation of QA or production Qdrant data during implementation.
+- No UI redesign or new evaluation UI work.
+- No separate keyword index outside Qdrant.
+
+## Selected Approach
+
+Use Qdrant native hybrid search with client-side BM25 sparse vector generation.
+
+Ingestion will create new collections with two named vectors per point:
+
+- `dense`: the existing 768-dimensional embedding from `nomic-embed-text`.
+- `sparse`: a BM25 sparse vector generated from the same chunk text.
+
+Chat will query both vectors with Qdrant's Query API and fuse candidates with
+reciprocal rank fusion. Qdrant remains the single retrieval store, which avoids
+adding a second BM25 service or local index.
+
+The implementation must pin compatible Qdrant and `qdrant-client` versions.
+Qdrant's hybrid Query API is available in Qdrant 1.10 and newer, and the repo
+currently pins `qdrant-client==1.9.0`, so this feature requires an explicit
+client upgrade and a non-`latest` Qdrant image.
+
+## Architecture
+
+### Ingestion
+
+Add a small sparse-vector module in `services/ingestion` that converts chunk
+text into BM25 sparse vectors. The module should hide the concrete FastEmbed or
+Qdrant-client API so store code only receives normalized sparse-vector data.
+
+Update `QdrantStore._ensure_collection()` to create hybrid-capable collections
+for new collections:
+
+- named dense vector config for the existing 768-dimensional cosine vector
+- named sparse vector config for BM25 sparse vectors
+
+Update `QdrantStore.upsert()` to write each point with both named vectors and
+the existing payload fields:
+
+- `text`
+- `page_number`
+- `chunk_index`
+- `document_id`
+- `filename`
+
+If sparse vector generation fails during ingest, ingestion should fail before
+writing points. Partial hybrid collection writes make later retrieval behavior
+hard to reason about.
+
+Collection metadata should record hybrid capability and sparse model/config
+alongside existing chunk and embedding metadata. This allows eval snapshots to
+explain how a collection was indexed.
+
+### Chat
+
+Replace the single-vector retriever path with a retriever that supports two
+modes:
+
+- `semantic`: dense-vector search only, using named `dense` vectors for new
+  collections and the legacy unnamed vector for old collections
+- `hybrid`: dense and sparse prefetches fused by Qdrant RRF
+
+`hybrid` is the default for new collections. For legacy dense-only collections,
+chat should detect unsupported collection shape or Qdrant errors that indicate
+missing named vectors, log the reason, and retry semantic-only retrieval.
+
+The public `/chat` and `/search` request shapes remain compatible. Existing
+clients do not need to pass a new field. `/search` must return top-level
+retrieval metadata. `/chat` should include the same metadata in JSON responses
+and in the final SSE `done` event. Metadata fields are:
+
+- `retrieval_mode`: `hybrid` or `semantic`
+- `retrieval_fallback`: boolean
+- `fusion`: `rrf` when hybrid is used
+
+`/config` should include retrieval defaults and hybrid settings so eval runs
+can snapshot the active behavior.
+
+### Evaluation
+
+Use the Phase 4a evaluation harness in `services/eval`.
+
+The evaluation service should be able to compare:
+
+- semantic-only baseline
+- hybrid retrieval using the same dataset and equivalent collection content
+
+Eval config capture should include retrieval mode, fusion strategy, sparse
+model/config, and whether a run used fallback semantic retrieval. Context
+precision and context recall are the primary metrics for demonstrating
+retrieval improvement.
+
+## Error Handling
+
+- If a collection lacks named dense or sparse vectors, chat falls back to
+  semantic-only retrieval and marks the response metadata.
+- If query-time sparse vector generation fails and semantic retrieval is
+  possible, chat falls back to semantic-only retrieval.
+- If query-time sparse vector generation fails and semantic fallback is not
+  possible, chat returns a controlled `503`.
+- If Qdrant is unavailable, existing service-unavailable behavior is preserved.
+- If ingestion cannot produce sparse vectors, ingestion returns an error before
+  upserting points.
+
+## Compatibility
+
+- Existing `/chat` and `/search` callers keep working.
+- Existing dense-only collections keep working through semantic fallback.
+- Freshly ingested collections are hybrid-capable.
+- Existing collections become hybrid-capable only after explicit reingestion or
+  a future backfill/migration issue.
+- Docker Compose and Kubernetes Qdrant images should be pinned to a compatible
+  version instead of `qdrant/qdrant:latest`.
+
+## Testing
+
+Unit tests should cover:
+
+- ingestion creates hybrid-capable collection configs
+- ingestion upserts points with both named vectors and existing payload fields
+- sparse-vector conversion handles empty and normal text batches
+- chat hybrid search calls Qdrant Query API with dense and sparse prefetches
+  and RRF fusion
+- chat semantic fallback works for legacy dense-only collections
+- `/search` remains backward compatible while returning retrieval metadata
+- `/chat` JSON and SSE responses expose retrieval metadata without changing the
+  existing answer/token/source fields
+- eval config capture includes retrieval mode and hybrid settings
+
+Verification before commit should include:
+
+- `make preflight-python`
+- `make preflight-security`
+
+A local compose smoke test against a fresh Qdrant collection is useful if local
+resources allow it, but the core acceptance gate is covered by focused tests and
+the Python/security preflights.
+
+## Acceptance Criteria
+
+- Freshly ingested RAG collections store dense and sparse vectors for every
+  chunk.
+- Hybrid retrieval is the default for compatible collections.
+- Legacy dense-only collections still answer through semantic fallback.
+- `/chat` and `/search` remain compatible with existing callers.
+- Eval runs can compare semantic-only and hybrid retrieval and capture the
+  retrieval configuration used.
+- Relevant Python and security preflights pass, or any blocker is documented.

--- a/k8s/ai-services/deployments/qdrant.yml
+++ b/k8s/ai-services/deployments/qdrant.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: qdrant
-          image: qdrant/qdrant:latest
+          image: qdrant/qdrant:v1.16.3
           ports:
             - containerPort: 6333
             - containerPort: 6334

--- a/services/chat/app/chain.py
+++ b/services/chat/app/chain.py
@@ -31,6 +31,28 @@ def get_sparse_encoder() -> SparseVectorEncoder:
     return _sparse_encoder
 
 
+def _search_legacy_semantic_fallback(
+    retriever: QdrantRetriever,
+    query_vector: list[float],
+    top_k: int,
+    collection_name: str,
+    error: Exception,
+) -> RetrievalResult:
+    logger.warning(
+        "semantic_legacy_fallback",
+        error=str(error),
+        error_type=error.__class__.__name__,
+        collection=collection_name,
+        exc_info=True,
+    )
+    return retriever.search_semantic(
+        query_vector=query_vector,
+        top_k=top_k,
+        legacy_vector=True,
+        fallback=True,
+    )
+
+
 async def embed_texts(
     texts: list[str],
     provider: EmbeddingProvider,
@@ -121,14 +143,31 @@ async def retrieve_chunks(
                 collection=collection_name,
                 exc_info=True,
             )
-            result = retriever.search_semantic(
+            try:
+                result = retriever.search_semantic(
+                    query_vector=query_vector,
+                    top_k=top_k,
+                    fallback=True,
+                )
+            except Exception as semantic_error:
+                result = _search_legacy_semantic_fallback(
+                    retriever=retriever,
+                    query_vector=query_vector,
+                    top_k=top_k,
+                    collection_name=collection_name,
+                    error=semantic_error,
+                )
+    else:
+        try:
+            result = retriever.search_semantic(query_vector=query_vector, top_k=top_k)
+        except Exception as semantic_error:
+            result = _search_legacy_semantic_fallback(
+                retriever=retriever,
                 query_vector=query_vector,
                 top_k=top_k,
-                legacy_vector=True,
-                fallback=True,
+                collection_name=collection_name,
+                error=semantic_error,
             )
-    else:
-        result = retriever.search_semantic(query_vector=query_vector, top_k=top_k)
 
     RAG_PIPELINE_DURATION.labels(stage="retrieve").observe(
         time.perf_counter() - retrieve_start

--- a/services/chat/app/chain.py
+++ b/services/chat/app/chain.py
@@ -1,8 +1,12 @@
+import asyncio
 import time
 from collections.abc import AsyncGenerator
 
+import structlog
 from llm.base import EmbeddingProvider, LLMProvider
+from rag.sparse import SparseVectorEncoder
 
+from app.config import settings
 from app.metrics import (
     EMBEDDING_DURATION,
     OLLAMA_EVAL_DURATION,
@@ -11,7 +15,20 @@ from app.metrics import (
     RAG_PIPELINE_DURATION,
 )
 from app.prompt import SYSTEM_PROMPT, build_rag_prompt
-from app.retriever import QdrantRetriever
+from app.retriever import QdrantRetriever, RetrievalResult
+
+logger = structlog.get_logger()
+_sparse_encoder: SparseVectorEncoder | None = None
+
+
+def get_sparse_encoder() -> SparseVectorEncoder:
+    global _sparse_encoder
+    if _sparse_encoder is None:
+        _sparse_encoder = SparseVectorEncoder(
+            model_name=settings.sparse_model,
+            batch_size=settings.sparse_batch_size,
+        )
+    return _sparse_encoder
 
 
 async def embed_texts(
@@ -71,7 +88,7 @@ async def retrieve_chunks(
     qdrant_port: int,
     collection_name: str,
     top_k: int = 5,
-) -> list[dict]:
+) -> RetrievalResult:
     """Embed question and retrieve ranked chunks from Qdrant."""
     retrieve_start = time.perf_counter()
     vectors = await embed_texts(
@@ -84,11 +101,39 @@ async def retrieve_chunks(
     retriever = QdrantRetriever(
         host=qdrant_host, port=qdrant_port, collection_name=collection_name
     )
-    chunks = retriever.search(query_vector=query_vector, top_k=top_k)
+    if settings.retrieval_mode == "hybrid":
+        try:
+            sparse_vectors = await asyncio.to_thread(
+                get_sparse_encoder().embed, [question]
+            )
+            sparse_vector = sparse_vectors[0]
+            result = retriever.search_hybrid(
+                query_vector=query_vector,
+                sparse_vector=sparse_vector,
+                top_k=top_k,
+                prefetch_limit=settings.hybrid_prefetch_limit,
+            )
+        except Exception as e:
+            logger.warning(
+                "hybrid_retrieval_fallback",
+                error=str(e),
+                error_type=e.__class__.__name__,
+                collection=collection_name,
+                exc_info=True,
+            )
+            result = retriever.search_semantic(
+                query_vector=query_vector,
+                top_k=top_k,
+                legacy_vector=True,
+                fallback=True,
+            )
+    else:
+        result = retriever.search_semantic(query_vector=query_vector, top_k=top_k)
+
     RAG_PIPELINE_DURATION.labels(stage="retrieve").observe(
         time.perf_counter() - retrieve_start
     )
-    return chunks
+    return result
 
 
 async def rag_query(
@@ -103,7 +148,7 @@ async def rag_query(
     top_k: int = 5,
 ) -> AsyncGenerator[dict, None]:
     # Retrieve relevant chunks
-    chunks = await retrieve_chunks(
+    retrieval = await retrieve_chunks(
         question=question,
         embedding_provider=embedding_provider,
         embedding_model=embedding_model,
@@ -112,6 +157,7 @@ async def rag_query(
         collection_name=collection_name,
         top_k=top_k,
     )
+    chunks = retrieval.chunks
 
     # Build prompt
     build_start = time.perf_counter()
@@ -139,4 +185,4 @@ async def rag_query(
         time.perf_counter() - generate_start
     )
 
-    yield {"done": True, "sources": sources}
+    yield {"done": True, "sources": sources, "retrieval": retrieval.metadata}

--- a/services/chat/app/config.py
+++ b/services/chat/app/config.py
@@ -26,6 +26,12 @@ class Settings(BaseSettings):
 
     # Retrieval tuning — number of chunks pulled from Qdrant per query.
     top_k: int = 5
+    retrieval_mode: str = "hybrid"
+    dense_vector_name: str = "dense"
+    sparse_vector_name: str = "sparse"
+    sparse_model: str = "Qdrant/bm25"
+    sparse_batch_size: int = 256
+    hybrid_prefetch_limit: int = 20
 
     # Prompt versioning — selects which template in app.prompt.PROMPTS is active.
     # Validated in self.validate() to fail fast on typos.
@@ -56,6 +62,10 @@ class Settings(BaseSettings):
                 f"embedding_api_key is required when embedding_provider is "
                 f"'{self.embedding_provider}'"
             )
+        if self.retrieval_mode not in {"semantic", "hybrid"}:
+            raise ValueError("retrieval_mode must be 'semantic' or 'hybrid'")
+        if self.hybrid_prefetch_limit < self.top_k:
+            raise ValueError("hybrid_prefetch_limit must be >= top_k")
         # Lazy import: app.prompt imports settings, so a top-level import here
         # would create a cycle.
         from app.prompt import PROMPTS

--- a/services/chat/app/main.py
+++ b/services/chat/app/main.py
@@ -87,6 +87,12 @@ async def get_config():
         "embedding_model": settings.embedding_model,
         "top_k": settings.top_k,
         "prompt_version": settings.prompt_version,
+        "retrieval_mode": settings.retrieval_mode,
+        "hybrid_prefetch_limit": settings.hybrid_prefetch_limit,
+        "dense_vector_name": settings.dense_vector_name,
+        "sparse_vector_name": settings.sparse_vector_name,
+        "sparse_model": settings.sparse_model,
+        "fusion": "rrf" if settings.retrieval_mode == "hybrid" else None,
     }
 
 
@@ -133,6 +139,7 @@ async def chat(
         try:
             tokens = []
             sources = []
+            retrieval = {}
             async for event in rag_query(
                 question=body.question,
                 llm_provider=_llm_provider,
@@ -148,7 +155,12 @@ async def chat(
                     tokens.append(event["token"])
                 if event.get("done"):
                     sources = event.get("sources", [])
-            return {"answer": "".join(tokens), "sources": sources}
+                    retrieval = event.get("retrieval", {})
+            return {
+                "answer": "".join(tokens),
+                "sources": sources,
+                "retrieval": retrieval,
+            }
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             logger.error("Backend service error: %s", e)
             raise HTTPException(status_code=503, detail="Service unavailable")
@@ -186,7 +198,7 @@ async def search(
     request: Request, body: SearchRequest, user_id: str = Depends(require_auth)
 ):
     try:
-        chunks = await retrieve_chunks(
+        retrieval = await retrieve_chunks(
             question=body.query,
             embedding_provider=_embedding_provider,
             embedding_model=settings.embedding_model,
@@ -207,6 +219,7 @@ async def search(
                 "page_number": c["page_number"],
                 "score": c["score"],
             }
-            for c in chunks
-        ]
+            for c in retrieval.chunks
+        ],
+        "retrieval": retrieval.metadata,
     }

--- a/services/chat/app/retriever.py
+++ b/services/chat/app/retriever.py
@@ -1,8 +1,17 @@
 import time
+from dataclasses import dataclass
 
 from qdrant_client import QdrantClient
+from qdrant_client.models import Fusion, FusionQuery, Prefetch, SparseVector
 
+from app.config import settings
 from app.metrics import QDRANT_SEARCH_DURATION, QDRANT_SEARCH_RESULTS
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    chunks: list[dict]
+    metadata: dict
 
 
 class QdrantRetriever:
@@ -10,20 +19,7 @@ class QdrantRetriever:
         self.client = QdrantClient(host=host, port=port)
         self.collection_name = collection_name
 
-    def search(self, query_vector: list[float], top_k: int = 5) -> list[dict]:
-        start = time.perf_counter()
-        results = self.client.search(
-            collection_name=self.collection_name,
-            query_vector=query_vector,
-            limit=top_k,
-        )
-        QDRANT_SEARCH_DURATION.labels(collection=self.collection_name).observe(
-            time.perf_counter() - start
-        )
-        QDRANT_SEARCH_RESULTS.labels(collection=self.collection_name).observe(
-            len(results)
-        )
-
+    def _format_results(self, results) -> list[dict]:
         return [
             {
                 "text": hit.payload["text"],
@@ -34,3 +30,82 @@ class QdrantRetriever:
             }
             for hit in results
         ]
+
+    def _record_metrics(self, start: float, result_count: int) -> None:
+        QDRANT_SEARCH_DURATION.labels(collection=self.collection_name).observe(
+            time.perf_counter() - start
+        )
+        QDRANT_SEARCH_RESULTS.labels(collection=self.collection_name).observe(
+            result_count
+        )
+
+    def search_semantic(
+        self,
+        query_vector: list[float],
+        top_k: int = 5,
+        *,
+        legacy_vector: bool = False,
+        fallback: bool = False,
+    ) -> RetrievalResult:
+        start = time.perf_counter()
+        using = None if legacy_vector else settings.dense_vector_name
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            query=query_vector,
+            using=using,
+            limit=top_k,
+            with_payload=True,
+        )
+        results = response.points
+        self._record_metrics(start, len(results))
+
+        return RetrievalResult(
+            chunks=self._format_results(results),
+            metadata={
+                "retrieval_mode": "semantic",
+                "retrieval_fallback": fallback,
+                "fusion": None,
+            },
+        )
+
+    def search_hybrid(
+        self,
+        query_vector: list[float],
+        sparse_vector: SparseVector,
+        top_k: int = 5,
+        prefetch_limit: int | None = None,
+    ) -> RetrievalResult:
+        start = time.perf_counter()
+        effective_prefetch_limit = prefetch_limit or settings.hybrid_prefetch_limit
+        response = self.client.query_points(
+            collection_name=self.collection_name,
+            prefetch=[
+                Prefetch(
+                    query=query_vector,
+                    using=settings.dense_vector_name,
+                    limit=effective_prefetch_limit,
+                ),
+                Prefetch(
+                    query=sparse_vector,
+                    using=settings.sparse_vector_name,
+                    limit=effective_prefetch_limit,
+                ),
+            ],
+            query=FusionQuery(fusion=Fusion.RRF),
+            limit=top_k,
+            with_payload=True,
+        )
+        results = response.points
+        self._record_metrics(start, len(results))
+
+        return RetrievalResult(
+            chunks=self._format_results(results),
+            metadata={
+                "retrieval_mode": "hybrid",
+                "retrieval_fallback": False,
+                "fusion": "rrf",
+            },
+        )
+
+    def search(self, query_vector: list[float], top_k: int = 5) -> list[dict]:
+        return self.search_semantic(query_vector=query_vector, top_k=top_k).chunks

--- a/services/chat/requirements.txt
+++ b/services/chat/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.135.3
 uvicorn[standard]==0.44.0
-qdrant-client[fastembed]==1.17.1
+qdrant-client==1.17.1
 httpx==0.27.0
 pydantic-settings==2.3.0
 sse-starlette==2.1.0

--- a/services/chat/requirements.txt
+++ b/services/chat/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.135.3
 uvicorn[standard]==0.44.0
-qdrant-client==1.9.0
+qdrant-client[fastembed]==1.17.1
 httpx==0.27.0
 pydantic-settings==2.3.0
 sse-starlette==2.1.0

--- a/services/chat/tests/test_chain.py
+++ b/services/chat/tests/test_chain.py
@@ -1,25 +1,205 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from app.chain import rag_query
+from app.chain import rag_query, retrieve_chunks
+from app.retriever import RetrievalResult
+
+
+def hybrid_result(chunks: list[dict] | None = None) -> RetrievalResult:
+    return RetrievalResult(
+        chunks=chunks or [],
+        metadata={
+            "retrieval_mode": "hybrid",
+            "retrieval_fallback": False,
+            "fusion": "rrf",
+        },
+    )
+
+
+def semantic_fallback_result(chunks: list[dict] | None = None) -> RetrievalResult:
+    return RetrievalResult(
+        chunks=chunks or [],
+        metadata={
+            "retrieval_mode": "semantic",
+            "retrieval_fallback": True,
+            "fusion": None,
+        },
+    )
+
+
+@patch("app.chain.SparseVectorEncoder", create=True)
+@patch("app.chain.QdrantRetriever")
+@pytest.mark.asyncio
+async def test_retrieve_chunks_returns_hybrid_metadata(
+    mock_retriever_cls,
+    mock_sparse_encoder_cls,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "hybrid")
+    embedding_provider = AsyncMock()
+    embedding_provider.embed.return_value = [[0.1] * 768]
+
+    sparse_vector = MagicMock()
+    mock_sparse_encoder = MagicMock()
+    mock_sparse_encoder.embed.return_value = [sparse_vector]
+    mock_sparse_encoder_cls.return_value = mock_sparse_encoder
+
+    retriever = MagicMock()
+    retriever.search_hybrid.return_value = hybrid_result(
+        [
+            {
+                "text": "RFC 7231",
+                "page_number": 1,
+                "filename": "http.pdf",
+                "document_id": "doc",
+                "score": 0.9,
+            }
+        ]
+    )
+    mock_retriever_cls.return_value = retriever
+
+    result = await retrieve_chunks(
+        question="What is RFC 7231?",
+        embedding_provider=embedding_provider,
+        embedding_model="nomic-embed-text",
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=5,
+    )
+
+    assert result.metadata["retrieval_mode"] == "hybrid"
+    assert result.metadata["retrieval_fallback"] is False
+    assert result.chunks[0]["text"] == "RFC 7231"
+
+
+@patch("app.chain.logger", create=True)
+@patch("app.chain.get_sparse_encoder", create=True)
+@patch("app.chain.QdrantRetriever")
+@pytest.mark.asyncio
+async def test_retrieve_chunks_falls_back_when_sparse_generation_fails(
+    mock_retriever_cls,
+    mock_sparse_encoder,
+    mock_logger,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "hybrid")
+    embedding_provider = AsyncMock()
+    embedding_provider.embed.return_value = [[0.1] * 768]
+    sparse_error = RuntimeError("sparse unavailable")
+    mock_sparse_encoder.return_value.embed.side_effect = sparse_error
+
+    retriever = MagicMock()
+    retriever.search_semantic.return_value = semantic_fallback_result()
+    mock_retriever_cls.return_value = retriever
+
+    result = await retrieve_chunks(
+        question="What is RFC 7231?",
+        embedding_provider=embedding_provider,
+        embedding_model="nomic-embed-text",
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=5,
+    )
+
+    assert result.metadata["retrieval_mode"] == "semantic"
+    assert result.metadata["retrieval_fallback"] is True
+    assert result.metadata["fusion"] is None
+    retriever.search_hybrid.assert_not_called()
+    retriever.search_semantic.assert_called_once_with(
+        query_vector=[0.1] * 768,
+        top_k=5,
+        legacy_vector=True,
+        fallback=True,
+    )
+    mock_logger.warning.assert_called_once_with(
+        "hybrid_retrieval_fallback",
+        error="sparse unavailable",
+        error_type="RuntimeError",
+        collection="documents",
+        exc_info=True,
+    )
+
+
+@patch("app.chain.logger", create=True)
+@patch("app.chain.get_sparse_encoder", create=True)
+@patch("app.chain.QdrantRetriever")
+@pytest.mark.asyncio
+async def test_retrieve_chunks_falls_back_when_hybrid_search_fails(
+    mock_retriever_cls,
+    mock_sparse_encoder,
+    mock_logger,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "hybrid")
+    embedding_provider = AsyncMock()
+    embedding_provider.embed.return_value = [[0.1] * 768]
+    sparse_vector = MagicMock()
+    mock_sparse_encoder.return_value.embed.return_value = [sparse_vector]
+
+    retriever = MagicMock()
+    retriever.search_hybrid.side_effect = RuntimeError("hybrid unavailable")
+    retriever.search_semantic.return_value = semantic_fallback_result()
+    mock_retriever_cls.return_value = retriever
+
+    result = await retrieve_chunks(
+        question="What is RFC 7231?",
+        embedding_provider=embedding_provider,
+        embedding_model="nomic-embed-text",
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=5,
+    )
+
+    assert result.metadata["retrieval_mode"] == "semantic"
+    assert result.metadata["retrieval_fallback"] is True
+    assert result.metadata["fusion"] is None
+    retriever.search_hybrid.assert_called_once_with(
+        query_vector=[0.1] * 768,
+        sparse_vector=sparse_vector,
+        top_k=5,
+        prefetch_limit=20,
+    )
+    retriever.search_semantic.assert_called_once_with(
+        query_vector=[0.1] * 768,
+        top_k=5,
+        legacy_vector=True,
+        fallback=True,
+    )
+    mock_logger.warning.assert_called_once_with(
+        "hybrid_retrieval_fallback",
+        error="hybrid unavailable",
+        error_type="RuntimeError",
+        collection="documents",
+        exc_info=True,
+    )
 
 
 @pytest.mark.asyncio
 @patch("app.chain.stream_response")
 @patch("app.chain.embed_texts", new_callable=AsyncMock)
+@patch("app.chain.get_sparse_encoder", create=True)
 @patch("app.chain.QdrantRetriever")
-async def test_rag_query_returns_generator(MockRetriever, mock_embed, mock_stream):
+async def test_rag_query_returns_generator(
+    MockRetriever, mock_sparse_encoder, mock_embed, mock_stream, monkeypatch
+):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "hybrid")
     mock_embed.return_value = [[0.1] * 768]
+    mock_sparse_encoder.return_value.embed.return_value = [MagicMock()]
     retriever_instance = MagicMock()
-    retriever_instance.search.return_value = [
-        {
-            "text": "The answer is 42.",
-            "filename": "doc.pdf",
-            "page_number": 1,
-            "document_id": "abc",
-            "score": 0.9,
-        },
-    ]
+    retriever_instance.search_hybrid.return_value = hybrid_result(
+        [
+            {
+                "text": "The answer is 42.",
+                "filename": "doc.pdf",
+                "page_number": 1,
+                "document_id": "abc",
+                "score": 0.9,
+            },
+        ]
+    )
     MockRetriever.return_value = retriever_instance
 
     mock_llm_provider = AsyncMock()
@@ -34,6 +214,7 @@ async def test_rag_query_returns_generator(MockRetriever, mock_embed, mock_strea
 
     tokens = []
     sources = None
+    retrieval = None
     async for event in rag_query(
         question="What is the answer?",
         llm_provider=mock_llm_provider,
@@ -48,23 +229,29 @@ async def test_rag_query_returns_generator(MockRetriever, mock_embed, mock_strea
             tokens.append(event["token"])
         if "sources" in event:
             sources = event["sources"]
+        if "retrieval" in event:
+            retrieval = event["retrieval"]
 
     assert len(tokens) == 3
     assert sources is not None
     assert sources[0]["file"] == "doc.pdf"
     assert sources[0]["page"] == 1
+    assert retrieval["retrieval_mode"] == "hybrid"
 
 
 @pytest.mark.asyncio
 @patch("app.chain.stream_response")
 @patch("app.chain.embed_texts", new_callable=AsyncMock)
+@patch("app.chain.get_sparse_encoder", create=True)
 @patch("app.chain.QdrantRetriever")
 async def test_rag_query_no_results_still_responds(
-    MockRetriever, mock_embed, mock_stream
+    MockRetriever, mock_sparse_encoder, mock_embed, mock_stream, monkeypatch
 ):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "hybrid")
     mock_embed.return_value = [[0.1] * 768]
+    mock_sparse_encoder.return_value.embed.return_value = [MagicMock()]
     retriever_instance = MagicMock()
-    retriever_instance.search.return_value = []
+    retriever_instance.search_hybrid.return_value = hybrid_result()
     MockRetriever.return_value = retriever_instance
 
     mock_llm_provider = AsyncMock()

--- a/services/chat/tests/test_chain.py
+++ b/services/chat/tests/test_chain.py
@@ -110,7 +110,6 @@ async def test_retrieve_chunks_falls_back_when_sparse_generation_fails(
     retriever.search_semantic.assert_called_once_with(
         query_vector=[0.1] * 768,
         top_k=5,
-        legacy_vector=True,
         fallback=True,
     )
     mock_logger.warning.assert_called_once_with(
@@ -165,12 +164,148 @@ async def test_retrieve_chunks_falls_back_when_hybrid_search_fails(
     retriever.search_semantic.assert_called_once_with(
         query_vector=[0.1] * 768,
         top_k=5,
-        legacy_vector=True,
         fallback=True,
     )
     mock_logger.warning.assert_called_once_with(
         "hybrid_retrieval_fallback",
         error="hybrid unavailable",
+        error_type="RuntimeError",
+        collection="documents",
+        exc_info=True,
+    )
+
+
+@patch("app.chain.logger", create=True)
+@patch("app.chain.get_sparse_encoder", create=True)
+@patch("app.chain.QdrantRetriever")
+@pytest.mark.asyncio
+async def test_retrieve_chunks_falls_back_to_legacy_when_named_semantic_fallback_fails(
+    mock_retriever_cls,
+    mock_sparse_encoder,
+    mock_logger,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "hybrid")
+    embedding_provider = AsyncMock()
+    embedding_provider.embed.return_value = [[0.1] * 768]
+    sparse_vector = MagicMock()
+    mock_sparse_encoder.return_value.embed.return_value = [sparse_vector]
+
+    retriever = MagicMock()
+    retriever.search_hybrid.side_effect = RuntimeError("hybrid unavailable")
+    retriever.search_semantic.side_effect = [
+        RuntimeError("named vector missing"),
+        semantic_fallback_result(
+            [
+                {
+                    "text": "legacy chunk",
+                    "page_number": 2,
+                    "filename": "legacy.pdf",
+                    "document_id": "legacy-doc",
+                    "score": 0.8,
+                }
+            ]
+        ),
+    ]
+    mock_retriever_cls.return_value = retriever
+
+    result = await retrieve_chunks(
+        question="What is RFC 7231?",
+        embedding_provider=embedding_provider,
+        embedding_model="nomic-embed-text",
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=5,
+    )
+
+    assert result.metadata["retrieval_mode"] == "semantic"
+    assert result.metadata["retrieval_fallback"] is True
+    assert result.chunks[0]["text"] == "legacy chunk"
+    retriever.search_hybrid.assert_called_once_with(
+        query_vector=[0.1] * 768,
+        sparse_vector=sparse_vector,
+        top_k=5,
+        prefetch_limit=20,
+    )
+    assert retriever.search_semantic.call_args_list == [
+        ((), {"query_vector": [0.1] * 768, "top_k": 5, "fallback": True}),
+        (
+            (),
+            {
+                "query_vector": [0.1] * 768,
+                "top_k": 5,
+                "legacy_vector": True,
+                "fallback": True,
+            },
+        ),
+    ]
+    assert mock_logger.warning.call_args_list[0] == (
+        ("hybrid_retrieval_fallback",),
+        {
+            "error": "hybrid unavailable",
+            "error_type": "RuntimeError",
+            "collection": "documents",
+            "exc_info": True,
+        },
+    )
+    assert mock_logger.warning.call_args_list[1] == (
+        ("semantic_legacy_fallback",),
+        {
+            "error": "named vector missing",
+            "error_type": "RuntimeError",
+            "collection": "documents",
+            "exc_info": True,
+        },
+    )
+
+
+@patch("app.chain.logger", create=True)
+@patch("app.chain.QdrantRetriever")
+@pytest.mark.asyncio
+async def test_retrieve_chunks_semantic_mode_falls_back_to_legacy_vector(
+    mock_retriever_cls,
+    mock_logger,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.chain.settings.retrieval_mode", "semantic")
+    embedding_provider = AsyncMock()
+    embedding_provider.embed.return_value = [[0.1] * 768]
+
+    retriever = MagicMock()
+    retriever.search_semantic.side_effect = [
+        RuntimeError("named vector missing"),
+        semantic_fallback_result(),
+    ]
+    mock_retriever_cls.return_value = retriever
+
+    result = await retrieve_chunks(
+        question="What is RFC 7231?",
+        embedding_provider=embedding_provider,
+        embedding_model="nomic-embed-text",
+        qdrant_host="localhost",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=5,
+    )
+
+    assert result.metadata["retrieval_mode"] == "semantic"
+    assert result.metadata["retrieval_fallback"] is True
+    assert retriever.search_semantic.call_args_list == [
+        ((), {"query_vector": [0.1] * 768, "top_k": 5}),
+        (
+            (),
+            {
+                "query_vector": [0.1] * 768,
+                "top_k": 5,
+                "legacy_vector": True,
+                "fallback": True,
+            },
+        ),
+    ]
+    mock_logger.warning.assert_called_once_with(
+        "semantic_legacy_fallback",
+        error="named vector missing",
         error_type="RuntimeError",
         collection="documents",
         exc_info=True,

--- a/services/chat/tests/test_config.py
+++ b/services/chat/tests/test_config.py
@@ -1,0 +1,16 @@
+import pytest
+from app.config import Settings
+
+
+def test_settings_validate_rejects_invalid_retrieval_mode():
+    settings = Settings(retrieval_mode="keyword")
+
+    with pytest.raises(ValueError, match="retrieval_mode"):
+        settings.validate()
+
+
+def test_settings_validate_rejects_hybrid_prefetch_limit_below_top_k():
+    settings = Settings(top_k=10, hybrid_prefetch_limit=9)
+
+    with pytest.raises(ValueError, match="hybrid_prefetch_limit"):
+        settings.validate()

--- a/services/chat/tests/test_main.py
+++ b/services/chat/tests/test_main.py
@@ -3,9 +3,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 from app.main import app
+from app.retriever import RetrievalResult
 from fastapi.testclient import TestClient
 
 client = TestClient(app)
+
+
+def retrieval_result(chunks: list[dict] | None = None) -> RetrievalResult:
+    return RetrievalResult(
+        chunks=chunks or [],
+        metadata={
+            "retrieval_mode": "hybrid",
+            "retrieval_fallback": False,
+            "fusion": "rrf",
+        },
+    )
 
 
 def test_config_endpoint_returns_active_settings():
@@ -18,6 +30,12 @@ def test_config_endpoint_returns_active_settings():
     assert body["embedding_model"] == settings.embedding_model
     assert body["top_k"] == settings.top_k
     assert body["prompt_version"] == settings.prompt_version
+    assert body["retrieval_mode"] == settings.retrieval_mode
+    assert body["hybrid_prefetch_limit"] == settings.hybrid_prefetch_limit
+    assert body["dense_vector_name"] == settings.dense_vector_name
+    assert body["sparse_vector_name"] == settings.sparse_vector_name
+    assert body["sparse_model"] == settings.sparse_model
+    assert body["fusion"] == ("rrf" if settings.retrieval_mode == "hybrid" else None)
 
 
 @patch("app.main.rag_query")
@@ -26,7 +44,7 @@ def test_chat_threads_settings_top_k_into_rag_query(mock_rag_query):
 
     async def fake(**kwargs):
         captured.update(kwargs)
-        yield {"done": True, "sources": []}
+        yield {"done": True, "sources": [], "retrieval": {}}
 
     mock_rag_query.side_effect = fake
 
@@ -95,7 +113,11 @@ def test_chat_streams_response(mock_rag_query):
     async def fake_rag_query(**kwargs):
         yield {"token": "Hello"}
         yield {"token": " world"}
-        yield {"done": True, "sources": [{"file": "test.pdf", "page": 1}]}
+        yield {
+            "done": True,
+            "sources": [{"file": "test.pdf", "page": 1}],
+            "retrieval": {"retrieval_mode": "hybrid"},
+        }
 
     mock_rag_query.return_value = fake_rag_query()
 
@@ -116,6 +138,7 @@ def test_chat_streams_response(mock_rag_query):
     done_events = [e for e in events if e.get("done")]
     assert len(done_events) == 1
     assert done_events[0]["sources"][0]["file"] == "test.pdf"
+    assert done_events[0]["retrieval"]["retrieval_mode"] == "hybrid"
 
 
 def test_chat_requires_question():
@@ -144,7 +167,7 @@ def test_chat_accepts_valid_collection_name(mock_rag_query):
     """Verify valid collection names pass Pydantic validation."""
 
     async def fake_rag_query(**kwargs):
-        yield {"done": True, "sources": []}
+        yield {"done": True, "sources": [], "retrieval": {}}
 
     mock_rag_query.return_value = fake_rag_query()
 
@@ -177,22 +200,24 @@ def test_chat_returns_error_when_backend_unreachable(mock_rag_query):
 
 @patch("app.main.retrieve_chunks", new_callable=AsyncMock)
 def test_search_returns_chunks(mock_retrieve):
-    mock_retrieve.return_value = [
-        {
-            "text": "Hello world",
-            "filename": "test.pdf",
-            "page_number": 1,
-            "document_id": "abc",
-            "score": 0.92,
-        },
-        {
-            "text": "Goodbye world",
-            "filename": "test.pdf",
-            "page_number": 2,
-            "document_id": "abc",
-            "score": 0.85,
-        },
-    ]
+    mock_retrieve.return_value = retrieval_result(
+        [
+            {
+                "text": "Hello world",
+                "filename": "test.pdf",
+                "page_number": 1,
+                "document_id": "abc",
+                "score": 0.92,
+            },
+            {
+                "text": "Goodbye world",
+                "filename": "test.pdf",
+                "page_number": 2,
+                "document_id": "abc",
+                "score": 0.85,
+            },
+        ]
+    )
 
     response = client.post("/search", json={"query": "hello", "limit": 5})
     assert response.status_code == 200
@@ -200,6 +225,7 @@ def test_search_returns_chunks(mock_retrieve):
     assert len(data["results"]) == 2
     assert data["results"][0]["text"] == "Hello world"
     assert data["results"][0]["score"] == 0.92
+    assert data["retrieval"]["retrieval_mode"] == "hybrid"
 
 
 def test_search_requires_query():
@@ -219,7 +245,11 @@ def test_chat_json_mode(mock_rag_query):
     async def fake_rag_query(**kwargs):
         yield {"token": "Hello"}
         yield {"token": " world"}
-        yield {"done": True, "sources": [{"file": "test.pdf", "page": 1}]}
+        yield {
+            "done": True,
+            "sources": [{"file": "test.pdf", "page": 1}],
+            "retrieval": {"retrieval_mode": "hybrid"},
+        }
 
     mock_rag_query.return_value = fake_rag_query()
 
@@ -233,6 +263,7 @@ def test_chat_json_mode(mock_rag_query):
     assert data["answer"] == "Hello world"
     assert len(data["sources"]) == 1
     assert data["sources"][0]["file"] == "test.pdf"
+    assert data["retrieval"]["retrieval_mode"] == "hybrid"
 
 
 def test_cors_rejects_unknown_origin():

--- a/services/chat/tests/test_retriever.py
+++ b/services/chat/tests/test_retriever.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from app.retriever import QdrantRetriever
+from qdrant_client.models import Fusion, FusionQuery, SparseVector
 
 
 @pytest.fixture
@@ -12,49 +13,130 @@ def mock_qdrant_client():
         yield client
 
 
-def test_search_returns_chunks_with_scores(mock_qdrant_client):
-    mock_qdrant_client.search.return_value = [
-        MagicMock(
-            score=0.95,
-            payload={
-                "text": "relevant chunk",
-                "page_number": 1,
-                "filename": "doc.pdf",
-                "document_id": "abc",
-            },
-        ),
-        MagicMock(
-            score=0.85,
-            payload={
-                "text": "another chunk",
-                "page_number": 2,
-                "filename": "doc.pdf",
-                "document_id": "abc",
-            },
-        ),
+def _hit(score=0.95, text="relevant chunk"):
+    return MagicMock(
+        score=score,
+        payload={
+            "text": text,
+            "page_number": 1,
+            "filename": "doc.pdf",
+            "document_id": "abc",
+        },
+    )
+
+
+def test_hybrid_search_uses_prefetch_and_rrf(mock_qdrant_client):
+    mock_qdrant_client.query_points.return_value = MagicMock(points=[_hit()])
+    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
+    query_vector = [0.1] * 768
+    sparse_vector = SparseVector(indices=[1], values=[0.7])
+
+    result = retriever.search_hybrid(
+        query_vector=query_vector,
+        sparse_vector=sparse_vector,
+        top_k=5,
+        prefetch_limit=20,
+    )
+
+    assert result.metadata == {
+        "retrieval_mode": "hybrid",
+        "retrieval_fallback": False,
+        "fusion": "rrf",
+    }
+    assert result.chunks[0]["text"] == "relevant chunk"
+    call_args = mock_qdrant_client.query_points.call_args
+    assert call_args.kwargs["collection_name"] == "test"
+    assert call_args.kwargs["limit"] == 5
+    assert call_args.kwargs["with_payload"] is True
+    assert call_args.kwargs["query"] == FusionQuery(fusion=Fusion.RRF)
+
+    dense_prefetch, sparse_prefetch = call_args.kwargs["prefetch"]
+    assert dense_prefetch.query == query_vector
+    assert dense_prefetch.using == "dense"
+    assert dense_prefetch.limit == 20
+    assert sparse_prefetch.query == sparse_vector
+    assert sparse_prefetch.using == "sparse"
+    assert sparse_prefetch.limit == 20
+
+
+def test_hybrid_search_defaults_prefetch_limit_from_settings(
+    mock_qdrant_client, monkeypatch
+):
+    mock_qdrant_client.query_points.return_value = MagicMock(points=[])
+    monkeypatch.setattr("app.retriever.settings.hybrid_prefetch_limit", 37)
+    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
+
+    retriever.search_hybrid(
+        query_vector=[0.1] * 768,
+        sparse_vector=SparseVector(indices=[1], values=[0.7]),
+        top_k=5,
+    )
+
+    dense_prefetch, sparse_prefetch = mock_qdrant_client.query_points.call_args.kwargs[
+        "prefetch"
     ]
+    assert dense_prefetch.limit == 37
+    assert sparse_prefetch.limit == 37
 
+
+def test_semantic_search_uses_named_dense_vector(mock_qdrant_client):
+    mock_qdrant_client.query_points.return_value = MagicMock(points=[_hit()])
     retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
-    results = retriever.search(query_vector=[0.1] * 768, top_k=5)
+    query_vector = [0.1] * 768
 
-    assert len(results) == 2
-    assert results[0]["text"] == "relevant chunk"
-    assert results[0]["score"] == 0.95
-    assert results[0]["page_number"] == 1
-    assert results[0]["filename"] == "doc.pdf"
+    result = retriever.search_semantic(query_vector=query_vector, top_k=3)
 
-
-def test_search_respects_top_k(mock_qdrant_client):
-    mock_qdrant_client.search.return_value = []
-    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
-    retriever.search(query_vector=[0.1] * 768, top_k=3)
-
-    call_args = mock_qdrant_client.search.call_args
+    assert result.metadata == {
+        "retrieval_mode": "semantic",
+        "retrieval_fallback": False,
+        "fusion": None,
+    }
+    assert result.chunks[0]["text"] == "relevant chunk"
+    assert mock_qdrant_client.search.call_count == 0
+    call_args = mock_qdrant_client.query_points.call_args
+    assert call_args.kwargs["collection_name"] == "test"
+    assert call_args.kwargs["query"] == query_vector
+    assert call_args.kwargs["using"] == "dense"
     assert call_args.kwargs["limit"] == 3
+    assert call_args.kwargs["with_payload"] is True
 
 
-def test_search_empty_results(mock_qdrant_client):
-    mock_qdrant_client.search.return_value = []
+def test_search_returns_plain_list_from_query_points(mock_qdrant_client):
+    mock_qdrant_client.query_points.return_value = MagicMock(points=[])
     retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
-    results = retriever.search(query_vector=[0.1] * 768, top_k=5)
-    assert results == []
+
+    result = retriever.search(query_vector=[0.1] * 768, top_k=3)
+
+    assert result == []
+    assert mock_qdrant_client.search.call_count == 0
+    call_args = mock_qdrant_client.query_points.call_args
+    assert call_args.kwargs["query"] == [0.1] * 768
+    assert call_args.kwargs["using"] == "dense"
+    assert call_args.kwargs["limit"] == 3
+    assert call_args.kwargs["with_payload"] is True
+
+
+def test_legacy_semantic_search_uses_unnamed_vector(mock_qdrant_client):
+    mock_qdrant_client.query_points.return_value = MagicMock(points=[_hit()])
+    retriever = QdrantRetriever(host="localhost", port=6333, collection_name="test")
+    query_vector = [0.1] * 768
+
+    result = retriever.search_semantic(
+        query_vector=query_vector,
+        top_k=3,
+        legacy_vector=True,
+        fallback=True,
+    )
+
+    assert result.metadata == {
+        "retrieval_mode": "semantic",
+        "retrieval_fallback": True,
+        "fusion": None,
+    }
+    assert mock_qdrant_client.search.call_count == 0
+    call_args = mock_qdrant_client.query_points.call_args
+    assert call_args.kwargs["collection_name"] == "test"
+    assert call_args.kwargs["query"] == query_vector
+    assert call_args.kwargs.get("using") is None
+    assert call_args.kwargs["limit"] == 3
+    assert call_args.kwargs["with_payload"] is True

--- a/services/debug/requirements.txt
+++ b/services/debug/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.135.3
 uvicorn[standard]==0.44.0
 langchain-text-splitters==0.3.11
-qdrant-client==1.9.0
+qdrant-client[fastembed]==1.17.1
 httpx==0.28.1
 pydantic-settings==2.3.0
 sse-starlette==2.1.0

--- a/services/debug/requirements.txt
+++ b/services/debug/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.135.3
 uvicorn[standard]==0.44.0
 langchain-text-splitters==0.3.11
-qdrant-client[fastembed]==1.17.1
+qdrant-client==1.17.1
 httpx==0.28.1
 pydantic-settings==2.3.0
 sse-starlette==2.1.0

--- a/services/eval/tests/test_config_capture.py
+++ b/services/eval/tests/test_config_capture.py
@@ -7,15 +7,23 @@ from app.config_capture import capture_run_config
 @pytest.mark.asyncio
 @respx.mock
 async def test_capture_merges_chat_and_collection():
+    expected_chat_config = {
+        "llm_model": "qwen2.5:14b",
+        "embedding_model": "nomic-embed-text",
+        "top_k": 5,
+        "prompt_version": "v1-baseline",
+        "retrieval_mode": "hybrid",
+        "hybrid_prefetch_limit": 20,
+        "dense_vector_name": "dense",
+        "sparse_vector_name": "sparse",
+        "sparse_model": "Qdrant/bm25",
+        "fusion": "rrf",
+    }
+
     respx.get("http://chat/config").mock(
         return_value=httpx.Response(
             200,
-            json={
-                "llm_model": "qwen2.5:14b",
-                "embedding_model": "nomic-embed-text",
-                "top_k": 5,
-                "prompt_version": "v1-baseline",
-            },
+            json=expected_chat_config,
         )
     )
     respx.get("http://ingestion/collections/documents/config").mock(
@@ -35,9 +43,7 @@ async def test_capture_merges_chat_and_collection():
         collection="documents",
     )
 
-    assert cfg["chat"]["llm_model"] == "qwen2.5:14b"
-    assert cfg["chat"]["top_k"] == 5
-    assert cfg["chat"]["prompt_version"] == "v1-baseline"
+    assert cfg["chat"] == expected_chat_config
     assert cfg["collection"]["chunk_size"] == 1000
     assert "captured_at" in cfg
     assert "_capture_error" not in cfg

--- a/services/ingestion/app/collection_meta.py
+++ b/services/ingestion/app/collection_meta.py
@@ -25,10 +25,26 @@ class CollectionMetaDB:
                 collection TEXT PRIMARY KEY,
                 chunk_size INTEGER NOT NULL,
                 chunk_overlap INTEGER NOT NULL,
-                embedding_model TEXT NOT NULL
+                embedding_model TEXT NOT NULL,
+                hybrid_enabled INTEGER NOT NULL DEFAULT 1,
+                dense_vector_name TEXT NOT NULL DEFAULT 'dense',
+                sparse_vector_name TEXT NOT NULL DEFAULT 'sparse',
+                sparse_model TEXT
             )
             """
         )
+        existing_columns = await self._db.execute("PRAGMA table_info(collection_meta)")
+        column_names = {row["name"] for row in await existing_columns.fetchall()}
+        for column_name, definition in {
+            "hybrid_enabled": "INTEGER NOT NULL DEFAULT 1",
+            "dense_vector_name": "TEXT NOT NULL DEFAULT 'dense'",
+            "sparse_vector_name": "TEXT NOT NULL DEFAULT 'sparse'",
+            "sparse_model": "TEXT",
+        }.items():
+            if column_name not in column_names:
+                await self._db.execute(
+                    f"ALTER TABLE collection_meta ADD COLUMN {column_name} {definition}"
+                )
         await self._db.commit()
 
     async def close(self) -> None:
@@ -42,30 +58,57 @@ class CollectionMetaDB:
         chunk_size: int,
         chunk_overlap: int,
         embedding_model: str,
+        sparse_model: str | None = None,
+        hybrid_enabled: bool = True,
     ) -> None:
         await self._db.execute(
             "INSERT INTO collection_meta "
-            "(collection, chunk_size, chunk_overlap, embedding_model) "
-            "VALUES (?, ?, ?, ?) "
+            "(collection, chunk_size, chunk_overlap, embedding_model, "
+            "hybrid_enabled, dense_vector_name, sparse_vector_name, sparse_model) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(collection) DO UPDATE SET "
             "chunk_size=excluded.chunk_size, "
             "chunk_overlap=excluded.chunk_overlap, "
-            "embedding_model=excluded.embedding_model",
-            (collection, chunk_size, chunk_overlap, embedding_model),
+            "embedding_model=excluded.embedding_model, "
+            "hybrid_enabled=excluded.hybrid_enabled, "
+            "dense_vector_name=excluded.dense_vector_name, "
+            "sparse_vector_name=excluded.sparse_vector_name, "
+            "sparse_model=excluded.sparse_model",
+            (
+                collection,
+                chunk_size,
+                chunk_overlap,
+                embedding_model,
+                int(hybrid_enabled),
+                "dense",
+                "sparse",
+                sparse_model,
+            ),
         )
         await self._db.commit()
 
     async def get(self, collection: str) -> dict | None:
         cursor = await self._db.execute(
-            "SELECT chunk_size, chunk_overlap, embedding_model "
+            "SELECT chunk_size, chunk_overlap, embedding_model, hybrid_enabled, "
+            "dense_vector_name, sparse_vector_name, sparse_model "
             "FROM collection_meta WHERE collection = ?",
             (collection,),
         )
         row = await cursor.fetchone()
         if not row:
             return None
-        return {
+        config = {
             "chunk_size": row["chunk_size"],
             "chunk_overlap": row["chunk_overlap"],
             "embedding_model": row["embedding_model"],
         }
+        if row["sparse_model"] is not None:
+            config.update(
+                {
+                    "hybrid_enabled": bool(row["hybrid_enabled"]),
+                    "dense_vector_name": row["dense_vector_name"],
+                    "sparse_vector_name": row["sparse_vector_name"],
+                    "sparse_model": row["sparse_model"],
+                }
+            )
+        return config

--- a/services/ingestion/app/config.py
+++ b/services/ingestion/app/config.py
@@ -13,6 +13,9 @@ class Settings(BaseSettings):
     embedding_base_url: str = "http://host.docker.internal:11434"
     embedding_api_key: str = ""
     embedding_model: str = "nomic-embed-text"
+    sparse_model: str = "Qdrant/bm25"
+    sparse_batch_size: int = 256
+    hybrid_enabled: bool = True
 
     # Legacy — used as fallback for embedding_base_url when provider is ollama
     ollama_base_url: str = "http://host.docker.internal:11434"

--- a/services/ingestion/app/main.py
+++ b/services/ingestion/app/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from llm.factory import get_embedding_provider
 from qdrant_client import QdrantClient
+from rag.sparse import SparseVectorEncoder
 from shared.auth import create_auth_dependency
 from shared.logging import RequestLoggingMiddleware, configure_logging
 from shared.tracing import configure_tracing, instrument_app
@@ -63,9 +64,9 @@ _embedding_provider = get_embedding_provider(
     api_key=settings.embedding_api_key,
     model=settings.embedding_model,
 )
-
 _store: QdrantStore | None = None
 _meta_db: CollectionMetaDB | None = None
+_sparse_encoder: SparseVectorEncoder | None = None
 
 
 def get_store() -> QdrantStore:
@@ -77,6 +78,16 @@ def get_store() -> QdrantStore:
             collection_name=settings.collection_name,
         )
     return _store
+
+
+def get_sparse_encoder() -> SparseVectorEncoder:
+    global _sparse_encoder
+    if _sparse_encoder is None:
+        _sparse_encoder = SparseVectorEncoder(
+            model_name=settings.sparse_model,
+            batch_size=settings.sparse_batch_size,
+        )
+    return _sparse_encoder
 
 
 async def get_meta_db() -> CollectionMetaDB:
@@ -211,6 +222,12 @@ async def ingest(
         logger.error("embedding_service_error", error=str(e))
         raise HTTPException(status_code=503, detail="Embedding service unavailable")
 
+    try:
+        sparse_vectors = get_sparse_encoder().embed(texts)
+    except Exception as e:
+        logger.error("sparse_vector_error", error=str(e), exc_info=True)
+        raise HTTPException(status_code=503, detail="Sparse vector generation failed")
+
     document_id = str(uuid.uuid4())
     target_collection = collection or settings.collection_name
     try:
@@ -225,6 +242,7 @@ async def ingest(
         store.upsert(
             chunks=chunks,
             vectors=vectors,
+            sparse_vectors=sparse_vectors,
             document_id=document_id,
             filename=file.filename,
         )
@@ -243,6 +261,8 @@ async def ingest(
             chunk_size=settings.chunk_size,
             chunk_overlap=settings.chunk_overlap,
             embedding_model=settings.embedding_model,
+            sparse_model=settings.sparse_model,
+            hybrid_enabled=settings.hybrid_enabled,
         )
     except Exception as e:
         # Metadata write failure must not poison a successful upload — log it

--- a/services/ingestion/app/store.py
+++ b/services/ingestion/app/store.py
@@ -8,10 +8,15 @@ from qdrant_client.models import (
     Filter,
     MatchValue,
     PointStruct,
+    SparseVector,
+    SparseVectorParams,
     VectorParams,
 )
 
 from app.metrics import QDRANT_OPERATION_DURATION
+
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
 
 
 class QdrantStore:
@@ -24,23 +29,37 @@ class QdrantStore:
         if not self.client.collection_exists(self.collection_name):
             self.client.create_collection(
                 collection_name=self.collection_name,
-                vectors_config=VectorParams(
-                    size=768,
-                    distance=Distance.COSINE,
-                ),
+                vectors_config={
+                    DENSE_VECTOR_NAME: VectorParams(
+                        size=768,
+                        distance=Distance.COSINE,
+                    )
+                },
+                sparse_vectors_config={
+                    SPARSE_VECTOR_NAME: SparseVectorParams(),
+                },
             )
 
     def upsert(
         self,
         chunks: list[dict],
         vectors: list[list[float]],
+        sparse_vectors: list[SparseVector],
         document_id: str,
         filename: str,
     ) -> None:
+        if not (len(chunks) == len(vectors) == len(sparse_vectors)):
+            raise ValueError(
+                "chunks, dense vectors, and sparse vectors must have matching lengths"
+            )
+
         points = [
             PointStruct(
                 id=str(uuid.uuid4()),
-                vector=vector,
+                vector={
+                    DENSE_VECTOR_NAME: vector,
+                    SPARSE_VECTOR_NAME: sparse_vector,
+                },
                 payload={
                     "text": chunk["text"],
                     "page_number": chunk["page_number"],
@@ -49,7 +68,7 @@ class QdrantStore:
                     "filename": filename,
                 },
             )
-            for chunk, vector in zip(chunks, vectors)
+            for chunk, vector, sparse_vector in zip(chunks, vectors, sparse_vectors)
         ]
         start = time.perf_counter()
         self.client.upsert(

--- a/services/ingestion/requirements.txt
+++ b/services/ingestion/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.44.0
 python-multipart==0.0.26
 pypdf==6.10.2
 langchain-text-splitters==0.3.11
-qdrant-client==1.9.0
+qdrant-client[fastembed]==1.17.1
 httpx==0.28.1
 pydantic-settings==2.3.0
 aiosqlite==0.21.0

--- a/services/ingestion/requirements.txt
+++ b/services/ingestion/requirements.txt
@@ -1,9 +1,9 @@
 fastapi==0.135.3
 uvicorn[standard]==0.44.0
-python-multipart==0.0.26
+python-multipart==0.0.27
 pypdf==6.10.2
 langchain-text-splitters==0.3.11
-qdrant-client[fastembed]==1.17.1
+qdrant-client==1.17.1
 httpx==0.28.1
 pydantic-settings==2.3.0
 aiosqlite==0.21.0

--- a/services/ingestion/tests/test_main.py
+++ b/services/ingestion/tests/test_main.py
@@ -4,8 +4,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 from app.main import app
 from fastapi.testclient import TestClient
+from qdrant_client.models import SparseVector
 
 client = TestClient(app)
+
+
+def _mock_sparse_encoder(count: int = 2) -> MagicMock:
+    sparse_encoder = MagicMock()
+    sparse_encoder.embed.return_value = [
+        SparseVector(indices=[index], values=[0.1]) for index in range(count)
+    ]
+    return sparse_encoder
 
 
 @patch("app.main._embedding_provider")
@@ -42,16 +51,22 @@ def test_health_qdrant_down(mock_qdrant_cls, mock_provider):
     assert data["llm"] == "connected"
 
 
+@patch("app.main.get_meta_db")
+@patch("app.main.get_sparse_encoder")
 @patch("app.main.get_store")
 @patch("app.main.embed_texts", new_callable=AsyncMock)
 @patch("app.main.extract_pages")
-def test_ingest_pdf_success(mock_extract, mock_embed, mock_get_store):
+def test_ingest_pdf_success(
+    mock_extract, mock_embed, mock_get_store, mock_get_sparse_encoder, mock_get_meta_db
+):
     mock_extract.return_value = [
         {"page_number": 1, "text": "Hello world. " * 100},
     ]
     mock_embed.return_value = [[0.1] * 768] * 2
     mock_store = MagicMock()
     mock_get_store.return_value = mock_store
+    mock_get_sparse_encoder.return_value = _mock_sparse_encoder()
+    mock_get_meta_db.return_value = AsyncMock()
 
     pdf_content = b"%PDF-1.4 fake content"
     response = client.post(
@@ -98,6 +113,52 @@ def test_ingest_returns_503_when_ollama_unreachable(
     assert response.status_code == 503
     assert "Connection refused" not in response.json()["detail"]
     assert response.json()["detail"] == "Embedding service unavailable"
+
+
+@patch("app.main.get_meta_db")
+@patch("app.main.get_sparse_encoder")
+@patch("app.main.QdrantStore")
+@patch("app.main.embed_texts", new_callable=AsyncMock)
+@patch("app.main.extract_pages")
+def test_ingest_generates_sparse_vectors_and_records_hybrid_metadata(
+    mock_extract,
+    mock_embed,
+    mock_qdrant_store_cls,
+    mock_get_sparse_encoder,
+    mock_get_meta_db,
+):
+    mock_extract.return_value = [{"page_number": 1, "text": "RFC 7231 section 4.2"}]
+    mock_embed.return_value = [[0.1] * 768]
+
+    mock_sparse_encoder = MagicMock()
+    sparse_vectors = [SparseVector(indices=[1, 2], values=[0.7, 0.4])]
+    mock_sparse_encoder.embed.return_value = sparse_vectors
+    mock_get_sparse_encoder.return_value = mock_sparse_encoder
+
+    mock_store = MagicMock()
+    mock_qdrant_store_cls.return_value = mock_store
+    mock_db = AsyncMock()
+    mock_get_meta_db.return_value = mock_db
+
+    response = client.post(
+        "/ingest",
+        files={"file": ("http.pdf", b"%PDF-1.4 fake", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    mock_sparse_encoder.embed.assert_called_once_with(["RFC 7231 section 4.2"])
+    mock_store.upsert.assert_called_once()
+    assert mock_store.upsert.call_args.kwargs["sparse_vectors"] == sparse_vectors
+    from app.config import settings
+
+    mock_db.upsert.assert_awaited_once_with(
+        collection=settings.collection_name,
+        chunk_size=settings.chunk_size,
+        chunk_overlap=settings.chunk_overlap,
+        embedding_model=settings.embedding_model,
+        sparse_model=settings.sparse_model,
+        hybrid_enabled=settings.hybrid_enabled,
+    )
 
 
 @patch("app.main.get_store")
@@ -177,16 +238,26 @@ def test_cors_rejects_unknown_origin():
     )
 
 
+@patch("app.main.get_meta_db")
+@patch("app.main.get_sparse_encoder")
 @patch("app.main.QdrantStore")
 @patch("app.main.embed_texts", new_callable=AsyncMock)
 @patch("app.main.extract_pages")
-def test_ingest_with_custom_collection(mock_extract, mock_embed, mock_qdrant_store_cls):
+def test_ingest_with_custom_collection(
+    mock_extract,
+    mock_embed,
+    mock_qdrant_store_cls,
+    mock_get_sparse_encoder,
+    mock_get_meta_db,
+):
     mock_extract.return_value = [
         {"page_number": 1, "text": "Hello world. " * 100},
     ]
     mock_embed.return_value = [[0.1] * 768] * 2
     mock_store = MagicMock()
     mock_qdrant_store_cls.return_value = mock_store
+    mock_get_sparse_encoder.return_value = _mock_sparse_encoder()
+    mock_get_meta_db.return_value = AsyncMock()
 
     pdf_content = b"%PDF-1.4 fake content"
     response = client.post(
@@ -284,16 +355,18 @@ def test_get_collection_config_404_when_unknown(mock_get_meta_db):
 
 
 @patch("app.main.get_meta_db")
+@patch("app.main.get_sparse_encoder")
 @patch("app.main.get_store")
 @patch("app.main.embed_texts", new_callable=AsyncMock)
 @patch("app.main.extract_pages")
 def test_ingest_persists_collection_metadata(
-    mock_extract, mock_embed, mock_get_store, mock_get_meta_db
+    mock_extract, mock_embed, mock_get_store, mock_get_sparse_encoder, mock_get_meta_db
 ):
     mock_extract.return_value = [{"page_number": 1, "text": "Hello world. " * 100}]
     mock_embed.return_value = [[0.1] * 768] * 2
     mock_store = MagicMock()
     mock_get_store.return_value = mock_store
+    mock_get_sparse_encoder.return_value = _mock_sparse_encoder()
     mock_db = AsyncMock()
     mock_get_meta_db.return_value = mock_db
 
@@ -311,4 +384,6 @@ def test_ingest_persists_collection_metadata(
         chunk_size=settings.chunk_size,
         chunk_overlap=settings.chunk_overlap,
         embedding_model=settings.embedding_model,
+        sparse_model=settings.sparse_model,
+        hybrid_enabled=settings.hybrid_enabled,
     )

--- a/services/ingestion/tests/test_store.py
+++ b/services/ingestion/tests/test_store.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from app.store import QdrantStore
+from qdrant_client.models import Distance, SparseVector, SparseVectorParams
 
 
 @pytest.fixture
@@ -37,6 +38,10 @@ def test_upsert_vectors(mock_qdrant_client):
     store.upsert(
         chunks=chunks,
         vectors=vectors,
+        sparse_vectors=[
+            SparseVector(indices=[1], values=[0.1]),
+            SparseVector(indices=[2], values=[0.2]),
+        ],
         document_id="doc-123",
         filename="test.pdf",
     )
@@ -191,3 +196,64 @@ def test_list_collections(mock_qdrant_client):
     assert result[0]["point_count"] == 150
     assert result[1]["name"] == "debug-myproject"
     assert result[1]["point_count"] == 42
+
+
+def test_store_init_creates_hybrid_collection(mock_qdrant_client):
+    mock_qdrant_client.collection_exists.return_value = False
+
+    QdrantStore(host="localhost", port=6333, collection_name="test")
+
+    call_args = mock_qdrant_client.create_collection.call_args
+    assert call_args.kwargs["collection_name"] == "test"
+    assert sorted(call_args.kwargs["vectors_config"].keys()) == ["dense"]
+    assert sorted(call_args.kwargs["sparse_vectors_config"].keys()) == ["sparse"]
+    dense_config = call_args.kwargs["vectors_config"]["dense"]
+    assert dense_config.size == 768
+    assert dense_config.distance == Distance.COSINE
+    assert isinstance(
+        call_args.kwargs["sparse_vectors_config"]["sparse"], SparseVectorParams
+    )
+
+
+def test_upsert_writes_named_dense_and_sparse_vectors(mock_qdrant_client):
+    mock_qdrant_client.collection_exists.return_value = True
+    store = QdrantStore(host="localhost", port=6333, collection_name="test")
+
+    chunks = [{"text": "RFC 7231", "page_number": 1, "chunk_index": 0}]
+    dense_vectors = [[0.1] * 768]
+    sparse_vectors = [SparseVector(indices=[10, 11], values=[0.8, 0.4])]
+
+    store.upsert(
+        chunks=chunks,
+        vectors=dense_vectors,
+        sparse_vectors=sparse_vectors,
+        document_id="doc-123",
+        filename="http.pdf",
+    )
+
+    point = mock_qdrant_client.upsert.call_args.kwargs["points"][0]
+    assert point.vector["dense"] == dense_vectors[0]
+    assert point.vector["sparse"] == sparse_vectors[0]
+    assert point.payload["text"] == "RFC 7231"
+    assert point.payload["page_number"] == 1
+    assert point.payload["chunk_index"] == 0
+    assert point.payload["document_id"] == "doc-123"
+    assert point.payload["filename"] == "http.pdf"
+
+
+def test_upsert_rejects_vector_count_mismatch(mock_qdrant_client):
+    mock_qdrant_client.collection_exists.return_value = True
+    store = QdrantStore(host="localhost", port=6333, collection_name="test")
+
+    chunks = [{"text": "RFC 7231", "page_number": 1, "chunk_index": 0}]
+
+    with pytest.raises(ValueError, match="matching lengths"):
+        store.upsert(
+            chunks=chunks,
+            vectors=[],
+            sparse_vectors=[SparseVector(indices=[1], values=[0.7])],
+            document_id="doc-123",
+            filename="http.pdf",
+        )
+
+    mock_qdrant_client.upsert.assert_not_called()

--- a/services/shared/pyproject.toml
+++ b/services/shared/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
     "httpx>=0.27",
     "openai>=1.0",
     "anthropic>=0.30",
+    "qdrant-client[fastembed]==1.17.1",
 ]
 
 [tool.setuptools.packages.find]
-include = ["llm*"]
+include = ["llm*", "rag*"]

--- a/services/shared/pyproject.toml
+++ b/services/shared/pyproject.toml
@@ -10,7 +10,9 @@ dependencies = [
     "httpx>=0.27",
     "openai>=1.0",
     "anthropic>=0.30",
-    "qdrant-client[fastembed]==1.17.1",
+    "qdrant-client==1.17.1",
+    "fastembed==0.8.0",
+    "pillow==12.2.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/services/shared/rag/__init__.py
+++ b/services/shared/rag/__init__.py
@@ -1,0 +1,3 @@
+from rag.sparse import SparseVectorEncoder, normalize_sparse_vector
+
+__all__ = ["SparseVectorEncoder", "normalize_sparse_vector"]

--- a/services/shared/rag/sparse.py
+++ b/services/shared/rag/sparse.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from fastembed import SparseTextEmbedding
+from qdrant_client.models import SparseVector
+
+
+def _as_list(value: Any) -> list:
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+
+def normalize_sparse_vector(raw: Any) -> SparseVector:
+    return SparseVector(
+        indices=[int(index) for index in _as_list(raw.indices)],
+        values=[float(value) for value in _as_list(raw.values)],
+    )
+
+
+class SparseVectorEncoder:
+    def __init__(self, model_name: str = "Qdrant/bm25", batch_size: int = 256):
+        self.model_name = model_name
+        self.batch_size = batch_size
+        self._model: SparseTextEmbedding | None = None
+
+    def _get_model(self) -> SparseTextEmbedding:
+        if self._model is None:
+            self._model = SparseTextEmbedding(
+                model_name=self.model_name,
+            )
+        return self._model
+
+    def embed(self, texts: Sequence[str]) -> list[SparseVector]:
+        if not texts:
+            return []
+        return [
+            normalize_sparse_vector(vector)
+            for vector in self._get_model().embed(
+                list(texts),
+                batch_size=self.batch_size,
+            )
+        ]

--- a/services/shared/tests/test_sparse.py
+++ b/services/shared/tests/test_sparse.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+from qdrant_client.models import SparseVector
+from rag.sparse import SparseVectorEncoder, normalize_sparse_vector
+
+
+def test_normalize_sparse_vector_converts_numpy_like_values():
+    raw = SimpleNamespace(
+        indices=SimpleNamespace(tolist=lambda: [2, 7]),
+        values=SimpleNamespace(tolist=lambda: [0.5, 1.25]),
+    )
+
+    vector = normalize_sparse_vector(raw)
+
+    assert vector == SparseVector(indices=[2, 7], values=[0.5, 1.25])
+
+
+def test_sparse_vector_encoder_returns_one_vector_per_text(monkeypatch):
+    class FakeSparseTextEmbedding:
+        def __init__(self, model_name: str):
+            self.model_name = model_name
+
+        def embed(self, texts, batch_size: int):
+            assert texts == ["RFC 7231", "section 4.2"]
+            assert batch_size == 16
+            return [
+                SimpleNamespace(indices=[1], values=[0.7]),
+                SimpleNamespace(indices=[3, 4], values=[0.2, 0.9]),
+            ]
+
+    monkeypatch.setattr("rag.sparse.SparseTextEmbedding", FakeSparseTextEmbedding)
+
+    encoder = SparseVectorEncoder(model_name="Qdrant/bm25", batch_size=16)
+    vectors = encoder.embed(["RFC 7231", "section 4.2"])
+
+    assert vectors == [
+        SparseVector(indices=[1], values=[0.7]),
+        SparseVector(indices=[3, 4], values=[0.2, 0.9]),
+    ]
+
+
+def test_sparse_vector_encoder_returns_empty_list_for_empty_input(monkeypatch):
+    class FailingSparseTextEmbedding:
+        def __init__(self, model_name: str):
+            raise AssertionError("model should not load for empty input")
+
+    monkeypatch.setattr("rag.sparse.SparseTextEmbedding", FailingSparseTextEmbedding)
+
+    encoder = SparseVectorEncoder(model_name="Qdrant/bm25", batch_size=16)
+
+    assert encoder.embed([]) == []


### PR DESCRIPTION
## Summary
- Add BM25 sparse vector encoding and store named dense/sparse vectors for newly ingested Qdrant collections.
- Add chat hybrid retrieval with Qdrant Query API RRF fusion, named semantic fallback, legacy dense-only fallback, and retrieval metadata on /search, /chat, and /config.
- Capture hybrid retrieval settings in eval config snapshots and pin compatible Qdrant/qdrant-client versions.

## Test Plan
- [x] PATH=\"$PWD/.venv/bin:$PATH\" PYTHONPATH=services/ingestion:services pytest services/ingestion/tests/ -v (52 passed, 2 warnings)
- [x] PATH=\"$PWD/.venv/bin:$PATH\" PYTHONPATH=services/chat:services pytest services/chat/tests/ -v (40 passed)
- [x] PATH=\"$PWD/.venv/bin:$PATH\" PYTHONPATH=services/eval pytest services/eval/tests/test_config_capture.py -v (4 passed)
- [x] PATH=\"$PWD/.venv/bin:$PATH\" PYTHONPATH=services pytest services/shared/tests/test_sparse.py -v (3 passed)
- [x] PATH=\"$PWD/.venv/bin:$PATH\" PYTHONPATH=services/debug:services pytest services/debug/tests/ -v (42 passed)
- [x] PATH=\"$PWD/.venv/bin:$PATH\" make preflight-security (passed)
- [ ] PATH=\"$PWD/.venv/bin:$PATH\" make preflight-python (blocked: Makefile invokes bare pytest; ingestion collection cannot import shared without service-aware PYTHONPATH)

## Notes
- Pre-existing untracked data/ was left untouched.
- Local pip check currently reports shared-venv contamination after installing eval requirements: numpy 1.26.4 conflicts with qdrant-client/fastembed on Python 3.13. No committed eval numpy pin was added; CI/runtime target Python is 3.11.