### PR TITLE
Use RabbitMQ channel publish sequence

### DIFF
--- a/go/payment-service/cmd/server/deps_test.go
+++ b/go/payment-service/cmd/server/deps_test.go
@@ -66,6 +66,10 @@ func (f *fakeConfirmChannel) NotifyReturn(ret chan amqp.Return) chan amqp.Return
 	return ret
 }
 
+func (f *fakeConfirmChannel) GetNextPublishSeqNo() uint64 {
+	return uint64(f.publishCalls + 1)
+}
+
 func (f *fakeConfirmChannel) PublishWithContext(
 	_ context.Context,
 	_, _ string,

--- a/go/pkg/rabbitmq/publisher.go
+++ b/go/pkg/rabbitmq/publisher.go
@@ -16,6 +16,7 @@ type ConfirmChannel interface {
 	Confirm(noWait bool) error
 	NotifyPublish(confirm chan amqp.Confirmation) chan amqp.Confirmation
 	NotifyReturn(ret chan amqp.Return) chan amqp.Return
+	GetNextPublishSeqNo() uint64
 	PublishWithContext(
 		ctx context.Context,
 		exchange, key string,
@@ -25,16 +26,15 @@ type ConfirmChannel interface {
 }
 
 type Publisher struct {
-	ch              ConfirmChannel
-	confirms        <-chan amqp.Confirmation
-	returns         <-chan amqp.Return
-	publishMux      sync.Mutex
-	stateMux        sync.Mutex
-	nextDeliveryTag uint64
-	nextReturnID    uint64
-	confirmsClosed  bool
-	currentWaiter   *publishWaiter
-	waiters         map[uint64]*publishWaiter
+	ch             ConfirmChannel
+	confirms       <-chan amqp.Confirmation
+	returns        <-chan amqp.Return
+	publishMux     sync.Mutex
+	stateMux       sync.Mutex
+	nextReturnID   uint64
+	confirmsClosed bool
+	currentWaiter  *publishWaiter
+	waiters        map[uint64]*publishWaiter
 }
 
 type publishWaiter struct {
@@ -65,7 +65,7 @@ func (p *Publisher) Publish(ctx context.Context, exchange, routingKey string, ms
 		msg.DeliveryMode = amqp.Persistent
 	}
 
-	expectedDeliveryTag := p.reserveDeliveryTag()
+	expectedDeliveryTag := p.ch.GetNextPublishSeqNo()
 	returnID := p.reserveReturnID()
 	waiter, ok := p.registerWaiter(expectedDeliveryTag, returnID)
 	if !ok {
@@ -97,14 +97,6 @@ func (p *Publisher) Publish(ctx context.Context, exchange, routingKey string, ms
 			return ctx.Err()
 		}
 	}
-}
-
-func (p *Publisher) reserveDeliveryTag() uint64 {
-	p.stateMux.Lock()
-	defer p.stateMux.Unlock()
-
-	p.nextDeliveryTag++
-	return p.nextDeliveryTag
 }
 
 func (p *Publisher) reserveReturnID() string {

--- a/go/pkg/rabbitmq/publisher_test.go
+++ b/go/pkg/rabbitmq/publisher_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 type fakeChannel struct {
-	confirmErr  error
-	confirmWait bool
-	publishErr  error
-	confirmCh   chan amqp.Confirmation
-	returnCh    chan amqp.Return
-	onPublish   func(*fakeChannel)
+	confirmErr         error
+	confirmWait        bool
+	publishErr         error
+	confirmCh          chan amqp.Confirmation
+	returnCh           chan amqp.Return
+	onPublish          func(*fakeChannel)
+	nextPublishSeq     uint64
+	currentDeliveryTag uint64
 
 	publishCount int
 	publishing   amqp.Publishing
@@ -28,8 +30,9 @@ type fakeChannel struct {
 
 func newFakeChannel() *fakeChannel {
 	return &fakeChannel{
-		confirmCh: make(chan amqp.Confirmation, 4),
-		returnCh:  make(chan amqp.Return, 4),
+		confirmCh:      make(chan amqp.Confirmation, 4),
+		returnCh:       make(chan amqp.Return, 4),
+		nextPublishSeq: 1,
 	}
 }
 
@@ -52,6 +55,10 @@ func (f *fakeChannel) NotifyReturn(ret chan amqp.Return) chan amqp.Return {
 	return f.returnCh
 }
 
+func (f *fakeChannel) GetNextPublishSeqNo() uint64 {
+	return f.nextPublishSeq
+}
+
 func (f *fakeChannel) PublishWithContext(
 	_ context.Context,
 	_, _ string,
@@ -59,6 +66,7 @@ func (f *fakeChannel) PublishWithContext(
 	msg amqp.Publishing,
 ) error {
 	f.publishCount++
+	f.currentDeliveryTag = f.nextPublishSeq
 	f.publishing = msg
 	f.mandatory = mandatory
 	f.immediate = immediate
@@ -66,7 +74,11 @@ func (f *fakeChannel) PublishWithContext(
 	if f.onPublish != nil {
 		f.onPublish(f)
 	}
-	return f.publishErr
+	if f.publishErr != nil {
+		return f.publishErr
+	}
+	f.nextPublishSeq++
+	return nil
 }
 
 func TestNewPublisherReturnsConfirmError(t *testing.T) {
@@ -174,7 +186,7 @@ func TestPublisherReturnsPublishError(t *testing.T) {
 	}
 }
 
-func TestPublisherAdvancesSequenceAfterPublishError(t *testing.T) {
+func TestPublisherUsesChannelSequenceAfterPublishError(t *testing.T) {
 	want := errors.New("publish failed before broker send")
 	fake := newFakeChannel()
 	fake.publishErr = want
@@ -191,7 +203,7 @@ func TestPublisherAdvancesSequenceAfterPublishError(t *testing.T) {
 	fake.publishErr = nil
 	fake.onPublish = func(f *fakeChannel) {
 		if f.publishCount == 2 {
-			f.confirmCh <- amqp.Confirmation{DeliveryTag: 2, Ack: true}
+			f.confirmCh <- amqp.Confirmation{DeliveryTag: f.currentDeliveryTag, Ack: true}
 		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -245,7 +257,7 @@ func TestPublisherIgnoresReturnAfterPublishError(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 	}
 
-	fake.confirmCh <- amqp.Confirmation{DeliveryTag: 2, Ack: true}
+	fake.confirmCh <- amqp.Confirmation{DeliveryTag: fake.currentDeliveryTag, Ack: true}
 	select {
 	case err := <-secondDone:
 		if err != nil {


### PR DESCRIPTION
## Summary
- use amqp091-go channel publish sequence numbers for confirmed publisher waiters
- update publisher tests to model publish errors without locally advancing confirm tags
- update payment-service reconnect test fake for the expanded confirm channel interface

## Verification
- cd go/pkg && go test ./rabbitmq
- cd go/payment-service && go test ./cmd/server -run TestReconnectingRabbitMQPublisher -count=1
- make preflight-go