### PR TITLE
Add RAG evaluation workflow guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,15 @@ Determine the current branch with `git branch --show-current`.
 Agents create feature worktrees in `.codex/worktrees/<branch-name>/` when a
 separate worktree is needed.
 
+After creating or selecting a feature worktree, immediately switch all work into
+that worktree. Confirm with `pwd`, `git branch --show-current`, and
+`git rev-parse --show-toplevel`. All subsequent file reads, searches, edits,
+tests, commits, pushes, and PR commands for that task must run with the
+worktree path as the command working directory. Before any file edit, confirm
+the working directory is inside `.codex/worktrees/<branch-name>/`; if it is not,
+stop and switch to the worktree before continuing. Do not edit task files from
+the original repo root after a feature worktree has been created.
+
 ## Verification
 
 Before every commit, run the relevant local preflight and fix failures:

--- a/docs/adr/document-qa/eval-baseline-validation.md
+++ b/docs/adr/document-qa/eval-baseline-validation.md
@@ -1,0 +1,75 @@
+# Eval Baseline Validation
+
+- **Date:** 2026-05-12
+- **Status:** Accepted
+- **Related PR:** #263
+- **Builds on:** [rag-tracking-foundation.md](rag-tracking-foundation.md)
+
+## Context
+
+The eval service stores `baseline_eval_id` on an evaluation run so the
+dashboard can show score deltas against a deliberate baseline. The original
+tracking foundation intentionally treated stale or wrong baseline pointers as
+display concerns: the API accepted any baseline id and persisted it with the new
+run.
+
+That was too loose once baseline deltas became part of the experiment workflow.
+A missing, running, failed, cross-dataset, or cross-collection baseline can make
+the dashboard imply that two runs are comparable when they are not. The baseline
+relationship is request-time comparison policy, not a persistence constraint:
+SQLite can express existence with a foreign key, but it cannot cleanly enforce
+"completed, same dataset, same effective collection" for this workflow.
+
+## Decision
+
+`POST /evaluations` validates `baseline_eval_id` before inserting the new
+evaluation row. The endpoint still loads the requested dataset first, preserving
+the existing `404 Dataset not found` behavior and ensuring missing datasets are
+not masked by baseline errors.
+
+When a baseline id is supplied, the eval API:
+
+1. Looks up the referenced run with `EvalDB.get_evaluation()`.
+2. Returns `404 Baseline evaluation not found` if it does not exist.
+3. Returns `400 Baseline evaluation must be completed` unless the baseline
+   status is `completed`.
+4. Returns `400 Baseline evaluation must use the same dataset` when the
+   baseline dataset differs from the requested dataset.
+5. Returns `400 Baseline evaluation must use the same collection` when the
+   baseline collection differs from the new run's effective collection.
+
+The effective collection is computed once as `body.collection or "documents"`
+and is used for both baseline comparison and evaluation creation. The background
+runner still receives the original request collection so its existing defaulting
+behavior remains unchanged.
+
+No schema, migration, comparison endpoint, history endpoint, or frontend change
+is needed. The existing `baseline_eval_id` column remains the storage model; the
+new behavior is an API-layer guard before persistence.
+
+## Consequences
+
+Positive outcomes:
+
+- Dashboard deltas are only created from completed runs that are comparable by
+  dataset and collection.
+- Bad baseline requests fail before a new evaluation row or background task is
+  created.
+- Error responses distinguish unknown baselines from incomparable baselines.
+- No-baseline evaluation runs keep the existing `202` behavior.
+- The implementation is small and testable at the API layer.
+
+Trade-offs:
+
+- The API now rejects requests that previously stored arbitrary baseline ids.
+  This is intentional, but callers must create or select a valid completed
+  baseline first.
+- Legacy rows with a null or otherwise nonstandard collection value are not
+  normalized during validation; the stored baseline collection must match the new
+  run's effective collection.
+- The database still allows invalid historical pointers because this decision
+  does not add schema constraints or backfill old data.
+
+This ADR supersedes the earlier "stale baseline pointers are harmless data"
+portion of the tracking foundation decision. Baseline pointers are still stored
+on the evaluation row, but new writes are now validated before persistence.

--- a/docs/runbooks/rag-evaluation-workflow.md
+++ b/docs/runbooks/rag-evaluation-workflow.md
@@ -1,0 +1,137 @@
+# RAG Evaluation Workflow
+
+Use this workflow in production when measuring whether a RAG change improved
+answer quality. The goal is not to produce one perfect score. The goal is to
+build a repeatable habit: stable dataset, baseline run, candidate run, score
+comparison, per-query review, and a written decision.
+
+## Prerequisites
+
+- You can log in to the production frontend.
+- The eval service health gate on `/ai/eval` passes.
+- The chat and ingestion services are serving the collection you want to test.
+- Use the `documents` collection unless you are deliberately evaluating another
+  collection.
+
+## 1. Create Or Select A Golden Dataset
+
+Open `/ai/eval`, then open `Datasets`.
+
+Create a dataset with 8-15 high-signal questions for the first pass. Each item
+must include:
+
+- `query`: a realistic user question.
+- `expected_answer`: the answer the system should be able to produce from the
+  indexed documents.
+- `expected_sources`: source names that should support the answer.
+
+Good first datasets include a mix of:
+
+- Easy factual questions that should always pass.
+- Multi-source questions that test retrieval coverage.
+- Questions that previously failed during manual testing.
+- Edge cases where a plausible answer could hallucinate unsupported details.
+
+Once a dataset becomes a baseline set, avoid changing its meaning. If the test
+coverage needs to change materially, create a new dataset version with a clear
+name such as `product-docs-rag-v2`.
+
+## 2. Run A Baseline
+
+Open `Evaluate`.
+
+Use these settings:
+
+- Dataset: the golden dataset you want to track.
+- Collection: `documents`, unless evaluating another collection intentionally.
+- Baseline run: leave empty.
+- Notes: describe the baseline context, for example
+  `Baseline before rerank comparison`.
+
+Start the evaluation and wait for it to complete. The run may take several
+minutes because every dataset item calls retrieval, generation, and judge logic.
+
+## 3. Inspect Baseline Results
+
+Open `Results`.
+
+Review aggregate scores first:
+
+- `faithfulness`: whether the answer is supported by retrieved context.
+- `answer_relevancy`: whether the answer addresses the question.
+- `context_precision`: whether the top retrieved chunks are useful.
+- `context_recall`: whether retrieval found enough supporting information.
+
+Then expand low-scoring questions and classify each failure:
+
+- Retrieval miss: the needed context was not retrieved.
+- Weak answer: context was present but the generated answer was incomplete.
+- Unsupported answer: the model made claims not supported by context.
+- Dataset issue: the expected answer or source is wrong or ambiguous.
+- Expected-source mismatch: the answer is right, but the source expectation is
+  too narrow or stale.
+
+Fix dataset issues before treating the score as a system failure.
+
+## 4. Run A Candidate
+
+Make one deliberate RAG change at a time. Examples:
+
+- Enable or tune reranking.
+- Change chunk size or overlap.
+- Change prompt version.
+- Change retrieval `top_k`.
+- Re-index a collection after improving parsing or chunking.
+
+Open `Evaluate` and run the same dataset against the same collection.
+
+Use these settings:
+
+- Baseline run: select the completed baseline run for the same dataset and
+  collection.
+- Notes: state the exact change, for example
+  `Candidate: enabled cross-encoder reranking`.
+
+If the baseline selector rejects a run, use a completed run from the same
+dataset and collection.
+
+## 5. Compare Runs
+
+Open `Dashboard`.
+
+Select the same dataset and collection. Compare the baseline run to the
+candidate run.
+
+Read metric deltas as directional evidence:
+
+- Positive faithfulness delta suggests fewer unsupported claims.
+- Positive answer relevancy delta suggests answers better address the query.
+- Positive context precision delta suggests better ranking.
+- Positive context recall delta suggests retrieval found more required support.
+
+Do not accept a change from aggregate deltas alone. Inspect per-query results,
+especially when one metric improves and another regresses.
+
+## 6. Decide
+
+Keep the change when:
+
+- Aggregate scores improve or remain stable in the metrics the change targeted.
+- Important per-query results do not regress.
+- The result makes sense after reading retrieved contexts and answers.
+
+Revert or adjust the change when:
+
+- Improvements are tiny and likely noisy.
+- A high-value query regresses.
+- Retrieval metrics improve but answers become less faithful.
+- The dataset was too weak to support a clear decision.
+
+When the next improvement requires code or UI work, create a focused follow-up
+issue with the baseline run, candidate run, metric deltas, and failure examples.
+
+## 7. Repeat
+
+Build history gradually. For now, evaluation notes and dashboard history are the
+lightweight experiment log. After several real measurement cycles, use that
+experience to decide what the experiment ledger should store.

--- a/docs/superpowers/plans/2026-05-12-eval-baseline-validation.md
+++ b/docs/superpowers/plans/2026-05-12-eval-baseline-validation.md
@@ -1,0 +1,404 @@
+# Eval Baseline Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate `baseline_eval_id` before starting eval runs so only completed runs from the same dataset and effective collection can be used as baselines.
+
+**Architecture:** Keep validation in the eval API layer with a private helper in `services/eval/app/main.py`. The endpoint will reuse `EvalDB.get_evaluation()` for baseline lookup, map invalid relationships to HTTP errors, and only create/schedule a new run after validation passes.
+
+**Tech Stack:** Python 3, FastAPI, Pydantic, pytest, `unittest.mock.AsyncMock`, existing eval service SQLite access through `EvalDB`.
+
+---
+
+## File Structure
+
+- Modify `services/eval/app/main.py`
+  - Add `_validate_baseline(...)`.
+  - Compute the effective collection once in `start_evaluation`.
+  - Call baseline validation before `create_evaluation`.
+- Modify `services/eval/tests/test_main.py`
+  - Add API tests for valid and invalid baseline links.
+  - Update the existing baseline persistence test so the mocked baseline lookup is explicit.
+- No DB schema, model, or migration changes.
+
+## Execution Prerequisite
+
+This plan changes application behavior. If execution starts from `qa`, create an
+isolated feature worktree first with the `superpowers:using-git-worktrees` skill.
+Use a branch name such as `feature/eval-baseline-validation` and target the final
+PR to `qa`.
+
+## Task 1: Add Failing API Tests For Baseline Validation
+
+**Files:**
+- Modify: `services/eval/tests/test_main.py`
+
+- [ ] **Step 1: Add a reusable completed baseline fixture helper near the evaluation endpoint tests**
+
+Add this helper after `test_start_evaluation_dataset_not_found` and before `test_get_evaluation`:
+
+```python
+def _baseline_run(
+    *,
+    status="completed",
+    dataset_id="ds-123",
+    collection="documents",
+):
+    return {
+        "id": "eval-prev",
+        "dataset_id": dataset_id,
+        "status": status,
+        "collection": collection,
+        "aggregate_scores": {"faithfulness": 0.87},
+        "results": [],
+        "error": None,
+        "created_at": "2026-04-16T00:00:00Z",
+        "completed_at": "2026-04-16T00:05:00Z",
+        "notes": None,
+        "config": None,
+        "baseline_eval_id": None,
+    }
+```
+
+- [ ] **Step 2: Update the existing baseline persistence test to mock baseline lookup**
+
+In `test_start_evaluation_persists_notes_and_baseline`, add this line before `mock_db.create_evaluation.return_value = "eval-789"`:
+
+```python
+    mock_db.get_evaluation.return_value = _baseline_run()
+```
+
+Then add this assertion after the response status assertion:
+
+```python
+    mock_db.get_evaluation.assert_awaited_once_with("eval-prev")
+```
+
+- [ ] **Step 3: Add a test for unknown baseline id**
+
+Add this test after `test_start_evaluation_persists_notes_and_baseline`:
+
+```python
+@patch("app.main.get_db")
+def test_start_evaluation_rejects_unknown_baseline(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.get_evaluation.return_value = None
+    mock_get_db.return_value = mock_db
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-123", "baseline_eval_id": "missing-eval"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Baseline evaluation not found"
+    mock_db.get_evaluation.assert_awaited_once_with("missing-eval")
+    mock_db.create_evaluation.assert_not_awaited()
+```
+
+- [ ] **Step 4: Add a test for non-completed baseline status**
+
+Add this test after the unknown baseline test:
+
+```python
+@patch("app.main.get_db")
+def test_start_evaluation_rejects_incomplete_baseline(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.get_evaluation.return_value = _baseline_run(status="running")
+    mock_get_db.return_value = mock_db
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-123", "baseline_eval_id": "eval-prev"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Baseline evaluation must be completed"
+    mock_db.create_evaluation.assert_not_awaited()
+```
+
+- [ ] **Step 5: Add a test for failed baseline status**
+
+Add this test after the incomplete baseline test:
+
+```python
+@patch("app.main.get_db")
+def test_start_evaluation_rejects_failed_baseline(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.get_evaluation.return_value = _baseline_run(status="failed")
+    mock_get_db.return_value = mock_db
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-123", "baseline_eval_id": "eval-prev"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Baseline evaluation must be completed"
+    mock_db.create_evaluation.assert_not_awaited()
+```
+
+- [ ] **Step 6: Add a test for dataset mismatch**
+
+Add this test after the failed baseline test:
+
+```python
+@patch("app.main.get_db")
+def test_start_evaluation_rejects_baseline_for_different_dataset(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.get_evaluation.return_value = _baseline_run(dataset_id="other-ds")
+    mock_get_db.return_value = mock_db
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-123", "baseline_eval_id": "eval-prev"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Baseline evaluation must use the same dataset"
+    mock_db.create_evaluation.assert_not_awaited()
+```
+
+- [ ] **Step 7: Add a test for collection mismatch**
+
+Add this test after the dataset mismatch test:
+
+```python
+@patch("app.main.get_db")
+def test_start_evaluation_rejects_baseline_for_different_collection(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.get_evaluation.return_value = _baseline_run(collection="other-docs")
+    mock_get_db.return_value = mock_db
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-123", "baseline_eval_id": "eval-prev"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Baseline evaluation must use the same collection"
+    mock_db.create_evaluation.assert_not_awaited()
+```
+
+- [ ] **Step 8: Add a test for valid custom collection baseline**
+
+Add this test after the collection mismatch test:
+
+```python
+@patch("app.main.get_db")
+def test_start_evaluation_accepts_valid_baseline_for_custom_collection(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.get_evaluation.return_value = _baseline_run(collection="release-notes")
+    mock_db.create_evaluation.return_value = "eval-new"
+    mock_get_db.return_value = mock_db
+
+    response = client.post(
+        "/evaluations",
+        json={
+            "dataset_id": "ds-123",
+            "collection": "release-notes",
+            "baseline_eval_id": "eval-prev",
+        },
+    )
+
+    assert response.status_code == 202
+    mock_db.create_evaluation.assert_awaited_once_with(
+        dataset_id="ds-123",
+        collection="release-notes",
+        notes=None,
+        baseline_eval_id="eval-prev",
+    )
+```
+
+- [ ] **Step 9: Run the new/changed tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services/eval pytest services/eval/tests/test_main.py \
+  -k "baseline or omits_optional_fields or dataset_not_found" -q
+```
+
+Expected: at least the new invalid-baseline tests fail because the endpoint does not validate `baseline_eval_id` yet.
+
+- [ ] **Step 10: Commit the failing tests**
+
+```bash
+git add services/eval/tests/test_main.py
+git commit -m "test: cover eval baseline validation"
+```
+
+## Task 2: Implement API-Layer Baseline Validation
+
+**Files:**
+- Modify: `services/eval/app/main.py`
+
+- [ ] **Step 1: Add the private validation helper above `start_evaluation`**
+
+Add this function after `_run_evaluation_task`:
+
+```python
+async def _validate_baseline(
+    db: EvalDB,
+    baseline_eval_id: str,
+    dataset_id: str,
+    collection: str,
+) -> None:
+    baseline = await db.get_evaluation(baseline_eval_id)
+    if not baseline:
+        raise HTTPException(status_code=404, detail="Baseline evaluation not found")
+
+    if baseline["status"] != "completed":
+        raise HTTPException(
+            status_code=400,
+            detail="Baseline evaluation must be completed",
+        )
+
+    if baseline["dataset_id"] != dataset_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Baseline evaluation must use the same dataset",
+        )
+
+    if baseline["collection"] != collection:
+        raise HTTPException(
+            status_code=400,
+            detail="Baseline evaluation must use the same collection",
+        )
+```
+
+- [ ] **Step 2: Update `start_evaluation` to compute collection once and validate before creating**
+
+Replace the body section after dataset lookup with:
+
+```python
+    collection = body.collection or "documents"
+
+    if body.baseline_eval_id is not None:
+        await _validate_baseline(
+            db=db,
+            baseline_eval_id=body.baseline_eval_id,
+            dataset_id=body.dataset_id,
+            collection=collection,
+        )
+
+    eval_id = await db.create_evaluation(
+        dataset_id=body.dataset_id,
+        collection=collection,
+        notes=body.notes,
+        baseline_eval_id=body.baseline_eval_id,
+    )
+```
+
+Leave the existing `background_tasks.add_task(...)` call in place:
+
+```python
+    background_tasks.add_task(
+        _run_evaluation_task, eval_id, dataset["items"], body.collection, body.rerank
+    )
+```
+
+- [ ] **Step 3: Run the targeted API tests**
+
+Run:
+
+```bash
+PYTHONPATH=services/eval pytest services/eval/tests/test_main.py \
+  -k "baseline or omits_optional_fields or dataset_not_found" -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 4: Run all eval service tests**
+
+Run:
+
+```bash
+PYTHONPATH=services/eval pytest services/eval/tests -q
+```
+
+Expected: all eval service tests pass.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add services/eval/app/main.py
+git commit -m "feat: validate eval baseline links"
+```
+
+## Task 3: Run Required Preflights
+
+**Files:**
+- No file changes expected unless tools auto-format.
+
+- [ ] **Step 1: Run Python preflight**
+
+Run:
+
+```bash
+make preflight-python
+```
+
+Expected: command exits 0. If ruff or formatting changes files, inspect the diff and commit those changes with:
+
+```bash
+git add services/eval/app/main.py services/eval/tests/test_main.py
+git commit -m "style: format eval baseline validation"
+```
+
+- [ ] **Step 2: Run security preflight**
+
+Run:
+
+```bash
+make preflight-security
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 3: Verify final git state**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -3
+```
+
+Expected: working tree is clean except for unrelated user changes that predated execution, and the recent commits include the test and implementation commits.

--- a/docs/superpowers/plans/2026-05-12-rag-evaluation-workflow-guide.md
+++ b/docs/superpowers/plans/2026-05-12-rag-evaluation-workflow-guide.md
@@ -1,0 +1,576 @@
+# RAG Evaluation Workflow Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a production-focused RAG evaluation workflow runbook and expose the same workflow as a discoverable `Guide` tab in `/ai/eval`.
+
+**Architecture:** The runbook is the durable source of truth under `docs/runbooks/`. The frontend gets a focused `EvalGuideTab` component that renders a compact operator checklist and switches the existing `/ai/eval` tab state through callbacks. Existing eval API behavior remains unchanged.
+
+**Tech Stack:** Markdown docs, Next.js 16 App Router, React 19, TypeScript, Tailwind CSS, Playwright mocked e2e tests.
+
+---
+
+## File Structure
+
+- Create `docs/runbooks/rag-evaluation-workflow.md`
+  - Production-facing usage workflow for the existing eval service.
+  - Covers dataset creation, baseline runs, candidate runs, comparison, per-query inspection, and decisions.
+
+- Create `frontend/src/components/eval/EvalGuideTab.tsx`
+  - Pure client component for the `/ai/eval` guide content.
+  - Receives `onSelectTab(tab: EvalTabId)` and uses it for action buttons.
+  - Does not call APIs or own eval state.
+
+- Modify `frontend/src/app/ai/eval/page.tsx`
+  - Export or define shared `EvalTabId` including `"guide"`.
+  - Add `Guide` as the first tab and default active tab.
+  - Render `EvalGuideTab` when active.
+  - Pass a tab-switch callback to the guide.
+
+- Modify `frontend/e2e/mocked/eval-dashboard.spec.ts`
+  - Add mocked coverage that `/ai/eval` opens on `Guide`.
+  - Assert the guide contains the workflow content.
+  - Assert guide action buttons switch to `Datasets`, `Evaluate`, `Results`, and `Dashboard`.
+
+---
+
+### Task 1: Add The Production Runbook
+
+**Files:**
+- Create: `docs/runbooks/rag-evaluation-workflow.md`
+
+- [ ] **Step 1: Create the runbook**
+
+Use this exact content:
+
+```markdown
+# RAG Evaluation Workflow
+
+Use this workflow in production when measuring whether a RAG change improved
+answer quality. The goal is not to produce one perfect score. The goal is to
+build a repeatable habit: stable dataset, baseline run, candidate run, score
+comparison, per-query review, and a written decision.
+
+## Prerequisites
+
+- You can log in to the production frontend.
+- The eval service health gate on `/ai/eval` passes.
+- The chat and ingestion services are serving the collection you want to test.
+- Use the `documents` collection unless you are deliberately evaluating another
+  collection.
+
+## 1. Create Or Select A Golden Dataset
+
+Open `/ai/eval`, then open `Datasets`.
+
+Create a dataset with 8-15 high-signal questions for the first pass. Each item
+must include:
+
+- `query`: a realistic user question.
+- `expected_answer`: the answer the system should be able to produce from the
+  indexed documents.
+- `expected_sources`: source names that should support the answer.
+
+Good first datasets include a mix of:
+
+- Easy factual questions that should always pass.
+- Multi-source questions that test retrieval coverage.
+- Questions that previously failed during manual testing.
+- Edge cases where a plausible answer could hallucinate unsupported details.
+
+Once a dataset becomes a baseline set, avoid changing its meaning. If the test
+coverage needs to change materially, create a new dataset version with a clear
+name such as `product-docs-rag-v2`.
+
+## 2. Run A Baseline
+
+Open `Evaluate`.
+
+Use these settings:
+
+- Dataset: the golden dataset you want to track.
+- Collection: `documents`, unless evaluating another collection intentionally.
+- Baseline run: leave empty.
+- Notes: describe the baseline context, for example
+  `Baseline before rerank comparison`.
+
+Start the evaluation and wait for it to complete. The run may take several
+minutes because every dataset item calls retrieval, generation, and judge logic.
+
+## 3. Inspect Baseline Results
+
+Open `Results`.
+
+Review aggregate scores first:
+
+- `faithfulness`: whether the answer is supported by retrieved context.
+- `answer_relevancy`: whether the answer addresses the question.
+- `context_precision`: whether the top retrieved chunks are useful.
+- `context_recall`: whether retrieval found enough supporting information.
+
+Then expand low-scoring questions and classify each failure:
+
+- Retrieval miss: the needed context was not retrieved.
+- Weak answer: context was present but the generated answer was incomplete.
+- Unsupported answer: the model made claims not supported by context.
+- Dataset issue: the expected answer or source is wrong or ambiguous.
+- Expected-source mismatch: the answer is right, but the source expectation is
+  too narrow or stale.
+
+Fix dataset issues before treating the score as a system failure.
+
+## 4. Run A Candidate
+
+Make one deliberate RAG change at a time. Examples:
+
+- Enable or tune reranking.
+- Change chunk size or overlap.
+- Change prompt version.
+- Change retrieval `top_k`.
+- Re-index a collection after improving parsing or chunking.
+
+Open `Evaluate` and run the same dataset against the same collection.
+
+Use these settings:
+
+- Baseline run: select the completed baseline run for the same dataset and
+  collection.
+- Notes: state the exact change, for example
+  `Candidate: enabled cross-encoder reranking`.
+
+If the baseline selector rejects a run, use a completed run from the same
+dataset and collection.
+
+## 5. Compare Runs
+
+Open `Dashboard`.
+
+Select the same dataset and collection. Compare the baseline run to the
+candidate run.
+
+Read metric deltas as directional evidence:
+
+- Positive faithfulness delta suggests fewer unsupported claims.
+- Positive answer relevancy delta suggests answers better address the query.
+- Positive context precision delta suggests better ranking.
+- Positive context recall delta suggests retrieval found more required support.
+
+Do not accept a change from aggregate deltas alone. Inspect per-query results,
+especially when one metric improves and another regresses.
+
+## 6. Decide
+
+Keep the change when:
+
+- Aggregate scores improve or remain stable in the metrics the change targeted.
+- Important per-query results do not regress.
+- The result makes sense after reading retrieved contexts and answers.
+
+Revert or adjust the change when:
+
+- Improvements are tiny and likely noisy.
+- A high-value query regresses.
+- Retrieval metrics improve but answers become less faithful.
+- The dataset was too weak to support a clear decision.
+
+When the next improvement requires code or UI work, create a focused follow-up
+issue with the baseline run, candidate run, metric deltas, and failure examples.
+
+## 7. Repeat
+
+Build history gradually. For now, evaluation notes and dashboard history are the
+lightweight experiment log. After several real measurement cycles, use that
+experience to decide what the experiment ledger should store.
+```
+
+- [ ] **Step 2: Review the runbook for production wording**
+
+Run:
+
+```bash
+sed -n '1,260p' docs/runbooks/rag-evaluation-workflow.md
+```
+
+Expected: The document is production-focused, refers to `/ai/eval`, and does not require unbuilt endpoints or issue #240/#241.
+
+- [ ] **Step 3: Commit the runbook**
+
+```bash
+git add docs/runbooks/rag-evaluation-workflow.md
+git commit -m "docs: add rag evaluation workflow runbook"
+```
+
+---
+
+### Task 2: Add The Eval Guide Component
+
+**Files:**
+- Create: `frontend/src/components/eval/EvalGuideTab.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `frontend/src/components/eval/EvalGuideTab.tsx` with:
+
+```tsx
+"use client";
+
+export type EvalGuideTarget = "datasets" | "evaluate" | "results" | "dashboard";
+
+type GuideStep = {
+  title: string;
+  body: string;
+  actionLabel: string;
+  target: EvalGuideTarget;
+};
+
+const GUIDE_STEPS: GuideStep[] = [
+  {
+    title: "Create or select a golden dataset",
+    body:
+      "Start with 8-15 stable, high-signal questions. Each item should include a realistic query, expected answer, and expected sources.",
+    actionLabel: "Create dataset",
+    target: "datasets",
+  },
+  {
+    title: "Run a baseline",
+    body:
+      "Use the same collection you plan to improve, usually documents. Leave Baseline run empty and use notes such as Baseline before rerank comparison.",
+    actionLabel: "Run baseline",
+    target: "evaluate",
+  },
+  {
+    title: "Inspect low-scoring queries",
+    body:
+      "Review aggregate scores first, then expand weak queries and classify failures as retrieval misses, weak answers, unsupported claims, or dataset issues.",
+    actionLabel: "Review results",
+    target: "results",
+  },
+  {
+    title: "Run one candidate change",
+    body:
+      "Change one RAG variable at a time, then run the same dataset and collection. Select the completed baseline and write notes that name the exact change.",
+    actionLabel: "Run candidate",
+    target: "evaluate",
+  },
+  {
+    title: "Compare and decide",
+    body:
+      "Use dashboard deltas as directional evidence, then inspect per-query results before deciding whether to keep, adjust, or revert the change.",
+    actionLabel: "Compare runs",
+    target: "dashboard",
+  },
+];
+
+interface EvalGuideTabProps {
+  onSelectTab: (tab: EvalGuideTarget) => void;
+}
+
+export function EvalGuideTab({ onSelectTab }: EvalGuideTabProps) {
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">
+          RAG Evaluation Workflow
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm text-gray-600">
+          Use this page to build a measurement history: stable golden dataset,
+          baseline run, candidate run, score comparison, per-query review, and
+          a written decision. Treat aggregate scores as signals, not proof, and
+          always inspect the queries that moved.
+        </p>
+      </section>
+
+      <section
+        aria-label="Evaluation workflow steps"
+        className="grid gap-4 md:grid-cols-2"
+      >
+        {GUIDE_STEPS.map((step, index) => (
+          <article
+            key={step.title}
+            className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"
+          >
+            <div className="flex items-start gap-3">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-50 text-sm font-semibold text-indigo-700">
+                {index + 1}
+              </span>
+              <div className="min-w-0">
+                <h3 className="text-base font-semibold text-gray-900">
+                  {step.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-gray-600">
+                  {step.body}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => onSelectTab(step.target)}
+                  className="mt-4 rounded-md border border-indigo-200 px-3 py-2 text-sm font-medium text-indigo-700 transition-colors hover:border-indigo-300 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                  {step.actionLabel}
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">
+          Decision checklist
+        </h3>
+        <div className="mt-4 grid gap-3 text-sm text-gray-700 md:grid-cols-3">
+          <p className="rounded-md border border-gray-100 p-3">
+            Keep changes when targeted metrics improve and important queries do
+            not regress.
+          </p>
+          <p className="rounded-md border border-gray-100 p-3">
+            Adjust changes when aggregate gains are narrow, noisy, or conflict
+            with per-query evidence.
+          </p>
+          <p className="rounded-md border border-gray-100 p-3">
+            Fix dataset issues before treating a bad score as a RAG pipeline
+            failure.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run TypeScript check for the new component**
+
+Run:
+
+```bash
+cd frontend && npm run lint -- src/components/eval/EvalGuideTab.tsx
+```
+
+Expected: PASS with no ESLint errors for the new component.
+
+- [ ] **Step 3: Commit the guide component**
+
+```bash
+git add frontend/src/components/eval/EvalGuideTab.tsx
+git commit -m "feat: add rag eval guide component"
+```
+
+---
+
+### Task 3: Wire The Guide Into `/ai/eval`
+
+**Files:**
+- Modify: `frontend/src/app/ai/eval/page.tsx`
+
+- [ ] **Step 1: Update imports and tab types**
+
+Modify the imports and tab type near the top of `frontend/src/app/ai/eval/page.tsx` to include the guide:
+
+```tsx
+import { EvalGuideTab } from "@/components/eval/EvalGuideTab";
+import { DashboardTab } from "@/components/eval/DashboardTab";
+import { DatasetTab } from "@/components/eval/DatasetTab";
+import EvaluateTab from "@/components/eval/EvaluateTab";
+import ResultsTab from "@/components/eval/ResultsTab";
+import { EvaluationDetail } from "@/lib/eval-api";
+
+type TabId = "guide" | "datasets" | "evaluate" | "results" | "dashboard";
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "guide", label: "Guide" },
+  { id: "datasets", label: "Datasets" },
+  { id: "evaluate", label: "Evaluate" },
+  { id: "results", label: "Results" },
+  { id: "dashboard", label: "Dashboard" },
+];
+```
+
+- [ ] **Step 2: Make Guide the default active tab**
+
+Change the active tab state initialization in `EvalPageInner`:
+
+```tsx
+const [activeTab, setActiveTab] = useState<TabId>("guide");
+```
+
+- [ ] **Step 3: Render the guide tab**
+
+Add guide rendering before the existing tab content:
+
+```tsx
+{/* Tab content */}
+{activeTab === "guide" && <EvalGuideTab onSelectTab={setActiveTab} />}
+{activeTab === "datasets" && <DatasetTab />}
+{activeTab === "evaluate" && (
+  <EvaluateTab onComplete={handleEvalComplete} />
+)}
+{activeTab === "results" && (
+  <ResultsTab selectedEvaluation={completedEval} />
+)}
+{activeTab === "dashboard" && (
+  <DashboardTab onSelectEvaluation={handleDashboardSelect} />
+)}
+```
+
+- [ ] **Step 4: Run targeted lint**
+
+Run:
+
+```bash
+cd frontend && npm run lint -- src/app/ai/eval/page.tsx src/components/eval/EvalGuideTab.tsx
+```
+
+Expected: PASS with no ESLint errors.
+
+- [ ] **Step 5: Commit the page wiring**
+
+```bash
+git add frontend/src/app/ai/eval/page.tsx frontend/src/components/eval/EvalGuideTab.tsx
+git commit -m "feat: show rag eval workflow guide"
+```
+
+---
+
+### Task 4: Add Mocked E2E Coverage
+
+**Files:**
+- Modify: `frontend/e2e/mocked/eval-dashboard.spec.ts`
+
+- [ ] **Step 1: Add guide tab assertions**
+
+Inside `test.describe("/ai/eval dashboard", () => { ... })`, add this test before the existing dashboard test:
+
+```ts
+test("opens on guide tab and links to eval workflow tabs", async ({ page }) => {
+  await page.goto("/ai/eval");
+
+  await expect(page.getByRole("button", { name: "Guide" })).toHaveClass(
+    /border-b-2/,
+  );
+  await expect(
+    page.getByRole("heading", { name: "RAG Evaluation Workflow" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("stable golden dataset, baseline run, candidate run"),
+  ).toBeVisible();
+  await expect(page.getByText("Decision checklist")).toBeVisible();
+
+  await page.getByRole("button", { name: "Create dataset" }).click();
+  await expect(page.getByRole("heading", { name: "Create a Golden Dataset" }))
+    .toBeVisible();
+
+  await page.getByRole("button", { name: "Guide" }).click();
+  await page.getByRole("button", { name: "Run baseline" }).click();
+  await expect(page.getByRole("heading", { name: "Run Evaluation" }))
+    .toBeVisible();
+
+  await page.getByRole("button", { name: "Guide" }).click();
+  await page.getByRole("button", { name: "Review results" }).click();
+  await expect(page.getByLabel("Evaluation")).toBeVisible();
+
+  await page.getByRole("button", { name: "Guide" }).click();
+  await page.getByRole("button", { name: "Compare runs" }).click();
+  await expect(
+    page.getByRole("heading", { name: "RAG Improvement Dashboard" }),
+  ).toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run the targeted mocked e2e test file**
+
+Run:
+
+```bash
+cd frontend && npm run e2e -- e2e/mocked/eval-dashboard.spec.ts
+```
+
+Expected: PASS for all tests in `eval-dashboard.spec.ts`.
+
+- [ ] **Step 3: Commit the e2e coverage**
+
+```bash
+git add frontend/e2e/mocked/eval-dashboard.spec.ts
+git commit -m "test: cover rag eval guide tab"
+```
+
+---
+
+### Task 5: Run Required Preflights
+
+**Files:**
+- No file edits expected.
+
+- [ ] **Step 1: Run frontend preflight**
+
+Run from repo root:
+
+```bash
+make preflight-frontend
+```
+
+Expected: PASS. If it fails, fix only failures related to this change.
+
+- [ ] **Step 2: Run e2e preflight**
+
+Run from repo root:
+
+```bash
+make preflight-e2e
+```
+
+Expected: PASS. If it fails, fix only failures related to this change.
+
+- [ ] **Step 3: Check git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean working tree after the previous commits, or only intentional changes that need one final commit.
+
+---
+
+### Task 6: Final Review And PR Prep
+
+**Files:**
+- Review only unless preflight fixes are needed.
+
+- [ ] **Step 1: Review final diff**
+
+Run:
+
+```bash
+git log --oneline -n 6
+git diff origin/qa...HEAD -- docs/runbooks/rag-evaluation-workflow.md frontend/src/app/ai/eval/page.tsx frontend/src/components/eval/EvalGuideTab.tsx frontend/e2e/mocked/eval-dashboard.spec.ts
+```
+
+Expected: Diff includes the runbook, guide tab wiring, guide component, and e2e test only.
+
+- [ ] **Step 2: Push feature branch**
+
+Run:
+
+```bash
+git branch --show-current
+git push -u origin HEAD
+```
+
+Expected: Branch pushes successfully. Do not push directly from `qa`; execute this plan from a feature worktree.
+
+- [ ] **Step 3: Create PR to `qa`**
+
+Run:
+
+```bash
+gh pr create --base qa --head "$(git branch --show-current)" --title "Add RAG evaluation workflow guide" --body "## Summary
+- add a production runbook for using the RAG eval service
+- add a Guide tab to /ai/eval with workflow actions
+- cover guide tab navigation in mocked Playwright tests
+
+## Verification
+- make preflight-frontend
+- make preflight-e2e"
+```
+
+Expected: PR is created targeting `qa`. Do not watch CI unless explicitly requested.

--- a/docs/superpowers/specs/2026-05-12-rag-evaluation-workflow-guide-design.md
+++ b/docs/superpowers/specs/2026-05-12-rag-evaluation-workflow-guide-design.md
@@ -1,0 +1,167 @@
+# RAG Evaluation Workflow Guide Design
+
+- **Date:** 2026-05-12
+- **Status:** Draft for review
+- **Scope:** Production usage workflow for the existing RAG eval service and `/ai/eval` UI
+
+## Problem
+
+The eval service and `/ai/eval` UI can create golden datasets, run evaluations,
+show per-query scorecards, compare runs, and track score history. The missing
+piece is an operator workflow. Opening `/ai/eval` does not clearly answer where
+to start, what a baseline means, when to run a candidate, or how to interpret
+the resulting scores.
+
+The existing ADRs explain the architecture and metric choices, but they are not
+step-by-step usage instructions. The next slice should make the current system
+usable before adding more backend capability.
+
+## Goals
+
+- Provide a production-focused workflow for using the existing eval service.
+- Make the workflow visible from `/ai/eval`, so the page teaches the user what
+  to do next.
+- Keep the first workflow practical: baseline run, candidate run, comparison,
+  per-query inspection, and decision.
+- Use the current API and UI behavior; do not require issue #240 or #241 first.
+- Build a foundation for accumulating a history of measured RAG performance.
+
+## Non-Goals
+
+- Do not add experiment ledger records in this slice.
+- Do not add the dashboard summary endpoint from issue #240 in this slice.
+- Do not redesign the eval UI broadly.
+- Do not make reranking the default workflow until a baseline-vs-candidate
+  process is clear.
+- Do not claim score changes are definitive without per-query review.
+
+## Recommended Approach
+
+Create a runbook as the source of truth, then expose a compact version in the
+frontend:
+
+1. Add `docs/runbooks/rag-evaluation-workflow.md`.
+2. Add a discoverable `Guide` tab to `/ai/eval`, placed before `Datasets`.
+3. Keep the guide action-oriented: what to click, what to enter, what to inspect,
+   and what decision to make.
+4. Link the guide steps to existing tabs where useful by switching the active
+   tab in the current page state.
+
+This is preferred over a docs-only runbook because the current pain happens in
+the UI. It is preferred over UI-only instructions because the workflow should
+also exist as durable engineering documentation.
+
+## Workflow Content
+
+The workflow should use production as its default context:
+
+1. **Prepare**
+   - Log in through the production frontend.
+   - Open `/ai/eval`.
+   - Confirm the eval service health gate passes.
+   - Use the `documents` collection unless deliberately evaluating another
+     collection.
+
+2. **Create a Golden Dataset**
+   - Start with 8-15 high-signal questions.
+   - Each item includes a realistic user query, expected answer, and expected
+     source names.
+   - Include easy factual questions, multi-source questions, and edge cases that
+     have failed manually.
+   - Once a dataset becomes a baseline set, avoid editing its meaning. Create a
+     new dataset version for materially different coverage.
+
+3. **Run a Baseline**
+   - Select the dataset and collection.
+   - Leave baseline empty.
+   - Add notes such as `Baseline before rerank comparison`.
+   - Run the evaluation and wait for completion.
+
+4. **Inspect Baseline Results**
+   - Review aggregate scores first.
+   - Expand low-scoring queries.
+   - Classify failures as retrieval miss, weak answer, unsupported answer,
+     dataset issue, or expected-source mismatch.
+   - Treat bad dataset items as test-data fixes, not model failures.
+
+5. **Run a Candidate**
+   - Make one deliberate RAG change at a time, such as reranking, prompt changes,
+     chunking changes, or retrieval tuning.
+   - Run the same dataset and collection.
+   - Select the completed baseline run when available.
+   - Use notes that state the exact measured change.
+
+6. **Compare**
+   - Open the dashboard for the same dataset and collection.
+   - Compare baseline vs candidate.
+   - Read deltas for faithfulness, answer relevancy, context precision, and
+     context recall.
+   - Use aggregate deltas as a signal, then inspect per-query results before
+     deciding.
+
+7. **Decide**
+   - Keep the change when aggregate scores improve and per-query review does not
+     show unacceptable regressions.
+   - Revert or adjust when gains are narrow, noisy, or created by worse answers
+     on important questions.
+   - Create a follow-up issue when the next improvement requires new backend or
+     frontend capability.
+
+8. **Repeat**
+   - Accumulate measured runs over time.
+   - Use notes and dashboard history as the lightweight change log until the
+     experiment ledger from issue #241 is justified by real usage.
+
+## Frontend Design
+
+Add a `Guide` tab as the first tab in `/ai/eval`.
+
+The tab should be an operator checklist, not a marketing page. It should use
+compact sections with short explanations and direct actions:
+
+- `Prepare`
+- `Create dataset`
+- `Run baseline`
+- `Inspect results`
+- `Run candidate`
+- `Compare and decide`
+
+Where useful, buttons should switch to the relevant existing tab:
+
+- `Create dataset` -> `Datasets`
+- `Run evaluation` -> `Evaluate`
+- `Review results` -> `Results`
+- `Compare runs` -> `Dashboard`
+
+The page should keep the existing tab model and avoid introducing routing,
+modals, or persistent onboarding state.
+
+## Error Handling And Edge Cases
+
+- If no datasets exist, the guide should point to `Datasets` first.
+- If only one completed run exists, the guide should explain that comparison
+  needs a second run against the same dataset and collection.
+- If baseline selection fails, the copy should explain that baselines must be
+  completed runs for the same dataset and collection.
+- If a run fails, the workflow should direct the user to inspect the error in
+  `Results` before starting another run.
+
+## Testing
+
+Documentation-only changes need no automated test.
+
+Frontend changes should include:
+
+- Existing frontend preflight: `make preflight-frontend`.
+- Existing e2e preflight: `make preflight-e2e`.
+- A mocked Playwright assertion that `/ai/eval` exposes the guide tab and can
+  switch from the guide to the existing tabs.
+
+## Implementation Notes
+
+This should be implemented as a small frontend/documentation slice on a feature
+worktree because it changes production frontend behavior. The PR should target
+`qa`.
+
+The runbook and UI guide should share wording closely, but the runbook can be
+more detailed. The UI should stay concise and focused on immediate actions.

--- a/frontend/e2e/mocked/eval-dashboard.spec.ts
+++ b/frontend/e2e/mocked/eval-dashboard.spec.ts
@@ -179,6 +179,50 @@ test.describe("/ai/eval dashboard", () => {
     await mockEvalApi(page);
   });
 
+  test("opens on guide tab and links to eval workflow tabs", async ({
+    page,
+  }) => {
+    await page.goto("/ai/eval");
+
+    await expect(page.getByRole("button", { name: "Guide" })).toHaveClass(
+      /border-b-2/,
+    );
+    await expect(
+      page.getByRole("heading", { name: "RAG Evaluation Workflow" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("stable golden dataset, baseline run, candidate run"),
+    ).toBeVisible();
+    await expect(page.getByText("Decision checklist")).toBeVisible();
+
+    await page.getByRole("button", { name: "Create dataset" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Create a Golden Dataset" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Guide" }).click();
+    await page.getByRole("button", { name: "Run baseline" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Run Evaluation" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Guide" }).click();
+    await page.getByRole("button", { name: "Run candidate" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Run Evaluation" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Guide" }).click();
+    await page.getByRole("button", { name: "Review results" }).click();
+    await expect(page.getByLabel("Evaluation")).toBeVisible();
+
+    await page.getByRole("button", { name: "Guide" }).click();
+    await page.getByRole("button", { name: "Compare runs" }).click();
+    await expect(
+      page.getByRole("heading", { name: "RAG Improvement Dashboard" }),
+    ).toBeVisible();
+  });
+
   test("renders dashboard tab with trends, comparison, and change log", async ({
     page,
   }) => {

--- a/frontend/src/app/ai/eval/page.tsx
+++ b/frontend/src/app/ai/eval/page.tsx
@@ -6,13 +6,15 @@ import { HealthGate } from "@/components/HealthGate";
 import { GoAuthProvider, useGoAuth } from "@/components/go/GoAuthProvider";
 import { DashboardTab } from "@/components/eval/DashboardTab";
 import { DatasetTab } from "@/components/eval/DatasetTab";
+import { EvalGuideTab } from "@/components/eval/EvalGuideTab";
 import EvaluateTab from "@/components/eval/EvaluateTab";
 import ResultsTab from "@/components/eval/ResultsTab";
 import { EvaluationDetail } from "@/lib/eval-api";
 
-type TabId = "datasets" | "evaluate" | "results" | "dashboard";
+type TabId = "guide" | "datasets" | "evaluate" | "results" | "dashboard";
 
 const TABS: { id: TabId; label: string }[] = [
+  { id: "guide", label: "Guide" },
   { id: "datasets", label: "Datasets" },
   { id: "evaluate", label: "Evaluate" },
   { id: "results", label: "Results" },
@@ -21,7 +23,7 @@ const TABS: { id: TabId; label: string }[] = [
 
 function EvalPageInner() {
   const { isLoggedIn } = useGoAuth();
-  const [activeTab, setActiveTab] = useState<TabId>("datasets");
+  const [activeTab, setActiveTab] = useState<TabId>("guide");
   const [completedEval, setCompletedEval] = useState<EvaluationDetail | null>(
     null,
   );
@@ -80,6 +82,7 @@ function EvalPageInner() {
         </div>
 
         {/* Tab content */}
+        {activeTab === "guide" && <EvalGuideTab onSelectTab={setActiveTab} />}
         {activeTab === "datasets" && <DatasetTab />}
         {activeTab === "evaluate" && (
           <EvaluateTab onComplete={handleEvalComplete} />

--- a/frontend/src/components/eval/EvalGuideTab.tsx
+++ b/frontend/src/components/eval/EvalGuideTab.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+export type EvalGuideTarget = "datasets" | "evaluate" | "results" | "dashboard";
+
+type GuideStep = {
+  title: string;
+  body: string;
+  actionLabel: string;
+  target: EvalGuideTarget;
+};
+
+const GUIDE_STEPS: GuideStep[] = [
+  {
+    title: "Create or select a golden dataset",
+    body:
+      "Start with 8-15 stable, high-signal questions. Each item should include a realistic query, expected answer, and expected sources.",
+    actionLabel: "Create dataset",
+    target: "datasets",
+  },
+  {
+    title: "Run a baseline",
+    body:
+      "Use the same collection you plan to improve, usually documents. Leave Baseline run empty and use notes such as Baseline before rerank comparison.",
+    actionLabel: "Run baseline",
+    target: "evaluate",
+  },
+  {
+    title: "Inspect low-scoring queries",
+    body:
+      "Review aggregate scores first, then expand weak queries and classify failures as retrieval misses, weak answers, unsupported claims, or dataset issues.",
+    actionLabel: "Review results",
+    target: "results",
+  },
+  {
+    title: "Run one candidate change",
+    body:
+      "Change one RAG variable at a time, then run the same dataset and collection. Select the completed baseline and write notes that name the exact change.",
+    actionLabel: "Run candidate",
+    target: "evaluate",
+  },
+  {
+    title: "Compare and decide",
+    body:
+      "Use dashboard deltas as directional evidence, then inspect per-query results before deciding whether to keep, adjust, or revert the change.",
+    actionLabel: "Compare runs",
+    target: "dashboard",
+  },
+];
+
+interface EvalGuideTabProps {
+  onSelectTab: (tab: EvalGuideTarget) => void;
+}
+
+export function EvalGuideTab({ onSelectTab }: EvalGuideTabProps) {
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">
+          RAG Evaluation Workflow
+        </h2>
+        <p className="mt-2 max-w-3xl text-sm text-gray-600">
+          Use this page to build a measurement history: stable golden dataset,
+          baseline run, candidate run, score comparison, per-query review, and
+          a written decision. Treat aggregate scores as signals, not proof, and
+          always inspect the queries that moved.
+        </p>
+      </section>
+
+      <section
+        aria-label="Evaluation workflow steps"
+        className="grid gap-4 md:grid-cols-2"
+      >
+        {GUIDE_STEPS.map((step, index) => (
+          <article
+            key={step.title}
+            className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm"
+          >
+            <div className="flex items-start gap-3">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-50 text-sm font-semibold text-indigo-700">
+                {index + 1}
+              </span>
+              <div className="min-w-0">
+                <h3 className="text-base font-semibold text-gray-900">
+                  {step.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-gray-600">
+                  {step.body}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => onSelectTab(step.target)}
+                  className="mt-4 rounded-md border border-indigo-200 px-3 py-2 text-sm font-medium text-indigo-700 transition-colors hover:border-indigo-300 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                  {step.actionLabel}
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">
+          Decision checklist
+        </h3>
+        <div className="mt-4 grid gap-3 text-sm text-gray-700 md:grid-cols-3">
+          <p className="rounded-md border border-gray-100 p-3">
+            Keep changes when targeted metrics improve and important queries do
+            not regress.
+          </p>
+          <p className="rounded-md border border-gray-100 p-3">
+            Adjust changes when aggregate gains are narrow, noisy, or conflict
+            with per-query evidence.
+          </p>
+          <p className="rounded-md border border-gray-100 p-3">
+            Fix dataset issues before treating a bad score as a RAG pipeline
+            failure.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a production runbook for using the RAG eval service
- add a Guide tab to /ai/eval with workflow actions
- cover guide tab navigation in mocked Playwright tests

## Verification
- make preflight-frontend
- make preflight-e2e