### PR TITLE
Fix ecommerce category filters

### DIFF
--- a/frontend/e2e/mocked/ecommerce-category-filter.spec.ts
+++ b/frontend/e2e/mocked/ecommerce-category-filter.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "./fixtures";
+
+const products = [
+  {
+    id: "book-1",
+    name: "Domain-Driven Design",
+    category: "Books",
+    price: 4500,
+  },
+  {
+    id: "clothing-1",
+    name: "Canvas Jacket",
+    category: "Clothing",
+    price: 7900,
+  },
+  {
+    id: "electronics-1",
+    name: "Smoke Test Widget",
+    category: "Electronics",
+    price: 1299,
+  },
+  {
+    id: "electronics-2",
+    name: "USB-C Dock",
+    category: "Electronics",
+    price: 8999,
+  },
+];
+
+test.describe("ecommerce category filtering", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/categories", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ categories: ["Books", "Clothing", "Electronics"] }),
+      }),
+    );
+  });
+
+  test("loads all products once and filters categories locally", async ({ page }) => {
+    const productRequests: URL[] = [];
+    const unexpectedProductRequests: string[] = [];
+    let guardCategoryRequests = false;
+
+    await page.route("**/products**", (route) => {
+      const url = new URL(route.request().url());
+      productRequests.push(url);
+      if (guardCategoryRequests) {
+        unexpectedProductRequests.push(`${url.pathname}${url.search}`);
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          products,
+          total: products.length,
+          page: 1,
+          limit: 100,
+          hasMore: false,
+        }),
+      });
+    });
+
+    await page.goto("/go/ecommerce");
+
+    await expect(page.getByText("Domain-Driven Design")).toBeVisible();
+    await expect(page.getByText("Canvas Jacket")).toBeVisible();
+    await expect(page.getByText("Smoke Test Widget")).toBeVisible();
+    await expect(page.getByText("USB-C Dock")).toBeVisible();
+    expect(productRequests.length).toBeGreaterThan(0);
+    expect(
+      productRequests.every(
+        (request) => request.searchParams.get("limit") === "100",
+      ),
+    ).toBe(true);
+    const initialProductRequestCount = productRequests.length;
+    guardCategoryRequests = true;
+
+    await page.getByRole("button", { name: "Clothing" }).click();
+    await expect(page.getByText("Canvas Jacket")).toBeVisible();
+    await expect(page.getByText("Smoke Test Widget")).toBeHidden();
+    expect(productRequests).toHaveLength(initialProductRequestCount);
+    expect(unexpectedProductRequests).toEqual([]);
+
+    await page.getByRole("button", { name: "Electronics" }).click();
+    await expect(page.getByText("Smoke Test Widget")).toBeVisible();
+    await expect(page.getByText("USB-C Dock")).toBeVisible();
+    await expect(page.getByText("Canvas Jacket")).toBeHidden();
+    expect(productRequests).toHaveLength(initialProductRequestCount);
+    expect(unexpectedProductRequests).toEqual([]);
+  });
+
+  test("shows a temporary unavailable message when products fail to load", async ({
+    page,
+  }) => {
+    await page.route("**/products**", (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: "text/plain",
+        body: "Service unavailable",
+      }),
+    );
+
+    await page.goto("/go/ecommerce");
+
+    await expect(page.getByText("Products are temporarily unavailable.")).toBeVisible();
+    await expect(page.getByText("No products found.")).toBeHidden();
+  });
+});

--- a/frontend/e2e/smoke-go-compose/smoke-go-ci.spec.ts
+++ b/frontend/e2e/smoke-go-compose/smoke-go-ci.spec.ts
@@ -64,18 +64,42 @@ test.describe("Go compose-smoke CI tests", () => {
     await ctx.dispose();
   });
 
-  test("product catalog returns data", async ({ request }) => {
-    const productsRes = await request.get(`${PRODUCT_URL}/products`);
+  test("product catalog returns the full fixed catalog", async ({ request }) => {
+    const productsRes = await request.get(`${PRODUCT_URL}/products?limit=100`);
     expect(productsRes.status()).toBe(200);
     const productsBody = await productsRes.json();
     expect(Array.isArray(productsBody.products)).toBe(true);
-    expect(productsBody.products.length).toBeGreaterThan(0);
+    expect(productsBody.products.length).toBe(41);
+    expect(productsBody.total).toBe(41);
+
+    const clothingProducts = productsBody.products.filter(
+      (p: { category: string }) => p.category === "Clothing"
+    );
+    expect(clothingProducts.length).toBe(8);
+
+    const electronicsProducts = productsBody.products.filter(
+      (p: { category: string }) => p.category === "Electronics"
+    );
+    expect(electronicsProducts.length).toBe(9);
+    expect(
+      electronicsProducts.some(
+        (p: { name: string }) => p.name === "Smoke Test Widget"
+      )
+    ).toBe(true);
 
     const categoriesRes = await request.get(`${PRODUCT_URL}/categories`);
     expect(categoriesRes.status()).toBe(200);
     const categoriesBody = await categoriesRes.json();
     expect(Array.isArray(categoriesBody.categories)).toBe(true);
-    expect(categoriesBody.categories.length).toBeGreaterThan(0);
+    expect(categoriesBody.categories).toEqual(
+      expect.arrayContaining([
+        "Books",
+        "Clothing",
+        "Electronics",
+        "Home",
+        "Sports",
+      ])
+    );
   });
 
   test("cart flow: add item and verify", async ({ playwright }) => {
@@ -95,7 +119,7 @@ test.describe("Go compose-smoke CI tests", () => {
     expect(loginRes.status()).toBe(200);
 
     // Find Smoke Test Widget
-    const productsRes = await authCtx.get(`${PRODUCT_URL}/products?limit=50`);
+    const productsRes = await authCtx.get(`${PRODUCT_URL}/products?limit=100`);
     const productsBody = await productsRes.json();
     const smokeProduct = productsBody.products.find(
       (p: { name: string }) => p.name === "Smoke Test Widget"

--- a/frontend/e2e/smoke-prod/smoke.spec.ts
+++ b/frontend/e2e/smoke-prod/smoke.spec.ts
@@ -267,12 +267,28 @@ test.describe("Go ecommerce smoke tests", () => {
   const SMOKE_EMAIL = "smoke@kylebradshaw.dev";
   const SMOKE_PASSWORD = process.env.SMOKE_GO_PASSWORD;
 
-  test("products endpoint returns a non-empty catalog", async ({ request }) => {
-    const res = await request.get(`${API_URL}/go-products/products`);
+  test("products endpoint returns the full fixed catalog", async ({ request }) => {
+    const res = await request.get(`${API_URL}/go-products/products?limit=100`);
     expect(res.status()).toBe(200);
     const body = await res.json();
     expect(Array.isArray(body.products)).toBe(true);
-    expect(body.products.length).toBeGreaterThan(0);
+    expect(body.products.length).toBe(41);
+    expect(body.total).toBe(41);
+
+    const clothingProducts = body.products.filter(
+      (p: { category: string }) => p.category === "Clothing"
+    );
+    expect(clothingProducts.length).toBe(8);
+
+    const electronicsProducts = body.products.filter(
+      (p: { category: string }) => p.category === "Electronics"
+    );
+    expect(electronicsProducts.length).toBe(9);
+    expect(
+      electronicsProducts.some(
+        (p: { name: string }) => p.name === "Smoke Test Widget"
+      )
+    ).toBe(true);
   });
 
   test("categories endpoint returns a non-empty list", async ({ request }) => {
@@ -336,7 +352,7 @@ test.describe("Go ecommerce smoke tests", () => {
 
     // Step 2: Find the Smoke Test Widget product
     const productsRes = await authContext.get(
-      `${API_URL}/go-products/products?limit=50`
+      `${API_URL}/go-products/products?limit=100`
     );
     expect(productsRes.status()).toBe(200);
     const productsBody = await productsRes.json();

--- a/frontend/src/app/go/ecommerce/page.tsx
+++ b/frontend/src/app/go/ecommerce/page.tsx
@@ -16,12 +16,47 @@ interface Product {
 export default function EcommercePage() {
   const { activeCategory } = useGoStore();
   const [products, setProducts] = useState<Product[]>([]);
+  const [status, setStatus] = useState<"loading" | "error" | "success">(
+    "loading",
+  );
 
   useEffect(() => {
-    fetch(`${GO_PRODUCT_URL}/products`)
-      .then((r) => r.json())
-      .then((data) => setProducts(data?.products ?? []))
-      .catch(() => {});
+    const controller = new AbortController();
+    const params = new URLSearchParams({ limit: "100" });
+
+    async function loadProducts() {
+      try {
+        const res = await fetch(`${GO_PRODUCT_URL}/products?${params.toString()}`, {
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          throw new Error(`Failed to load products: ${res.status}`);
+        }
+
+        const data = await res.json();
+
+        if (!Array.isArray(data?.products)) {
+          throw new Error("Product response did not include a products array");
+        }
+
+        setProducts(data.products);
+        setStatus("success");
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        setProducts([]);
+        setStatus("error");
+      }
+    }
+
+    loadProducts();
+
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   const filtered = activeCategory
@@ -43,7 +78,19 @@ export default function EcommercePage() {
         ))}
       </div>
 
-      {filtered.length === 0 && (
+      {status === "loading" && (
+        <p className="mt-12 text-center text-muted-foreground">
+          Loading products...
+        </p>
+      )}
+
+      {status === "error" && (
+        <p className="mt-12 text-center text-muted-foreground">
+          Products are temporarily unavailable.
+        </p>
+      )}
+
+      {status === "success" && filtered.length === 0 && (
         <p className="mt-12 text-center text-muted-foreground">
           No products found.
         </p>


### PR DESCRIPTION
## Summary
- fetch the fixed ecommerce demo catalog with limit=100 on initial store load
- keep category switching local with no product refetch on tab changes
- add mocked UI regression coverage and full-catalog smoke assertions

## Verification
- make preflight-frontend
- make preflight-e2e

## Rollout
Frontend-only change. After merge to qa, deploy the QA frontend through the normal Vercel flow and verify /go/ecommerce Clothing shows 8 products and Electronics shows 9, including Smoke Test Widget. Promote through the normal qa-to-main flow for production frontend deployment. No Go service image rebuild, database mutation, seed rerun, Kubernetes change, or env-var change is required.