### PR TITLE
Authenticate eval MCP service with auth-service

### DIFF
--- a/docs/superpowers/plans/2026-05-15-eval-mcp-auth-integration.md
+++ b/docs/superpowers/plans/2026-05-15-eval-mcp-auth-integration.md
@@ -1,0 +1,1420 @@
+# Eval MCP Auth Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `go/eval-mcp-service` authenticate through `go/auth-service`, cache tokens locally, and call the authenticated Python eval API without manually supplied bearer tokens.
+
+**Architecture:** Auth-service keeps cookie behavior by default and adds opt-in token fields for machine clients. Eval MCP gains a focused auth client, token store, and auth provider that supplies bearer tokens to the existing eval API client. The eval API client retries one request after a `401` by asking the provider to invalidate and recover token state.
+
+**Tech Stack:** Go, Gin, `httptest`, JWT tokens from `go/auth-service`, local JSON token cache, existing MCP stdio service, existing Python eval bearer-auth dependency.
+
+---
+
+## File Structure
+
+- Modify `go/auth-service/internal/model/user.go`: add `IncludeTokens` to login and refresh request models, plus `ExpiresInSeconds` to auth responses.
+- Modify `go/auth-service/internal/service/auth.go`: populate access-token TTL seconds in generated auth responses.
+- Modify `go/auth-service/internal/handler/auth.go`: return token fields only when `includeTokens` is true for login and refresh.
+- Modify `go/auth-service/internal/handler/auth_test.go`: cover default no-token body and opt-in token body.
+- Modify `go/eval-mcp-service/internal/config/config.go`: add auth-service URL, auth email, auth password, token cache path, and refresh skew.
+- Modify `go/eval-mcp-service/internal/config/config_test.go`: cover defaults, overrides, static-token bypass, and missing auth config.
+- Create `go/eval-mcp-service/internal/authclient/client.go`: typed login and refresh client for auth-service.
+- Create `go/eval-mcp-service/internal/authclient/client_test.go`: auth-client request and error tests.
+- Create `go/eval-mcp-service/internal/tokenstore/file.go`: local JSON token cache with permission checks.
+- Create `go/eval-mcp-service/internal/tokenstore/file_test.go`: cache read, write, expiry, and unsafe-permission tests.
+- Create `go/eval-mcp-service/internal/authprovider/provider.go`: token provider that loads cache, refreshes, logs in, invalidates, and hides secrets.
+- Create `go/eval-mcp-service/internal/authprovider/provider_test.go`: provider behavior tests with fake auth client and fake store.
+- Modify `go/eval-mcp-service/internal/evalapi/client.go`: accept a token provider and retry once on `401`.
+- Modify `go/eval-mcp-service/internal/evalapi/client_test.go`: keep static token coverage and add provider retry coverage.
+- Modify `go/eval-mcp-service/cmd/eval-mcp/main.go`: wire static token override or auth provider into the eval API client.
+- Modify `go/eval-mcp-service/cmd/eval-mcp/main_test.go`: verify static-token bypass and auth-provider config.
+- Modify `go/eval-mcp-service/README.md`: document auth-service configuration and secret handling.
+
+## Task 0: Create Feature Worktree
+
+**Files:**
+- No source files changed in this task.
+
+- [ ] **Step 1: Create the feature worktree**
+
+Run from `/Users/kylebradshaw/repos/gen_ai_engineer`:
+
+```bash
+git fetch origin
+git worktree add .codex/worktrees/eval-mcp-auth-integration -b feature/eval-mcp-auth-integration main
+```
+
+Expected: worktree is created at `.codex/worktrees/eval-mcp-auth-integration`.
+
+- [ ] **Step 2: Confirm all work is inside the feature worktree**
+
+Run:
+
+```bash
+cd /Users/kylebradshaw/repos/gen_ai_engineer/.codex/worktrees/eval-mcp-auth-integration
+pwd
+git branch --show-current
+git rev-parse --show-toplevel
+```
+
+Expected:
+
+```text
+/Users/kylebradshaw/repos/gen_ai_engineer/.codex/worktrees/eval-mcp-auth-integration
+feature/eval-mcp-auth-integration
+/Users/kylebradshaw/repos/gen_ai_engineer/.codex/worktrees/eval-mcp-auth-integration
+```
+
+- [ ] **Step 3: Commit boundary**
+
+Do not commit in this task. All later commands run with workdir:
+
+```text
+/Users/kylebradshaw/repos/gen_ai_engineer/.codex/worktrees/eval-mcp-auth-integration
+```
+
+## Task 1: Auth-Service Opt-In Token Response
+
+**Files:**
+- Modify: `go/auth-service/internal/model/user.go`
+- Modify: `go/auth-service/internal/service/auth.go`
+- Modify: `go/auth-service/internal/handler/auth.go`
+- Test: `go/auth-service/internal/handler/auth_test.go`
+
+- [ ] **Step 1: Add failing login tests for opt-in tokens**
+
+Append these tests to `go/auth-service/internal/handler/auth_test.go`:
+
+```go
+func TestLoginHandler_DefaultResponseOmitsTokens(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := newMockUserRepo()
+	svc := service.NewAuthService(repo, "test-secret", 900000, 604800000)
+	_, err := svc.Register(context.Background(), "smoke@example.com", "password123456", "Smoke")
+	if err != nil {
+		t.Fatalf("register fixture: %v", err)
+	}
+	h := handler.NewAuthHandler(svc, nil, service.NewTokenDenylist(nil), 15*time.Minute, 7*24*time.Hour, defaultCookieCfg())
+
+	router := testRouter()
+	router.POST("/auth/login", h.Login)
+
+	body := strings.NewReader(`{"email":"smoke@example.com","password":"password123456"}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := resp["accessToken"]; ok {
+		t.Fatal("accessToken must not appear without includeTokens")
+	}
+	if _, ok := resp["refreshToken"]; ok {
+		t.Fatal("refreshToken must not appear without includeTokens")
+	}
+	if _, ok := resp["expiresInSeconds"]; ok {
+		t.Fatal("expiresInSeconds must not appear without includeTokens")
+	}
+	if !hasCookie(w, "access_token") || !hasCookie(w, "refresh_token") {
+		t.Fatal("expected auth cookies")
+	}
+}
+
+func TestLoginHandler_IncludeTokensReturnsTokenFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := newMockUserRepo()
+	svc := service.NewAuthService(repo, "test-secret", 900000, 604800000)
+	_, err := svc.Register(context.Background(), "smoke@example.com", "password123456", "Smoke")
+	if err != nil {
+		t.Fatalf("register fixture: %v", err)
+	}
+	h := handler.NewAuthHandler(svc, nil, service.NewTokenDenylist(nil), 15*time.Minute, 7*24*time.Hour, defaultCookieCfg())
+
+	router := testRouter()
+	router.POST("/auth/login", h.Login)
+
+	body := strings.NewReader(`{"email":"smoke@example.com","password":"password123456","includeTokens":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["accessToken"] == "" || resp["refreshToken"] == "" {
+		t.Fatalf("expected token fields, got %#v", resp)
+	}
+	if resp["expiresInSeconds"] != float64(900) {
+		t.Fatalf("expiresInSeconds = %#v", resp["expiresInSeconds"])
+	}
+	if !hasCookie(w, "access_token") || !hasCookie(w, "refresh_token") {
+		t.Fatal("expected auth cookies")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cd go/auth-service
+go test ./internal/handler -run 'TestLoginHandler_(DefaultResponseOmitsTokens|IncludeTokensReturnsTokenFields)' -count=1
+```
+
+Expected: `TestLoginHandler_IncludeTokensReturnsTokenFields` fails because `includeTokens` is not modeled and token fields are not returned.
+
+- [ ] **Step 3: Add request and response fields**
+
+Update `go/auth-service/internal/model/user.go`:
+
+```go
+type LoginRequest struct {
+	Email         string `json:"email" binding:"required,email"`
+	Password      string `json:"password" binding:"required"`
+	IncludeTokens bool   `json:"includeTokens"`
+}
+
+type RefreshRequest struct {
+	RefreshToken   string `json:"refreshToken" binding:"required"`
+	IncludeTokens  bool   `json:"includeTokens"`
+}
+
+type AuthResponse struct {
+	AccessToken      string `json:"accessToken"`
+	RefreshToken     string `json:"refreshToken"`
+	UserID           string `json:"userId"`
+	Email            string `json:"email"`
+	Name             string `json:"name"`
+	AvatarURL        string `json:"avatarUrl,omitempty"`
+	ExpiresInSeconds int64  `json:"expiresInSeconds"`
+}
+```
+
+- [ ] **Step 4: Populate access token TTL**
+
+In `go/auth-service/internal/service/auth.go`, update `generateTokens` to set `ExpiresInSeconds`:
+
+```go
+	return &model.AuthResponse{
+		AccessToken:      accessToken,
+		RefreshToken:     refreshToken,
+		UserID:           user.ID.String(),
+		Email:            user.Email,
+		Name:             user.Name,
+		AvatarURL:        avatar,
+		ExpiresInSeconds: int64(s.accessTokenTTL.Seconds()),
+	}, nil
+```
+
+- [ ] **Step 5: Add token-aware response helper**
+
+In `go/auth-service/internal/handler/auth.go`, add this helper near `clearAuthCookies`:
+
+```go
+func authJSON(resp *model.AuthResponse, includeTokens bool) gin.H {
+	body := gin.H{
+		"userId":    resp.UserID,
+		"email":     resp.Email,
+		"name":      resp.Name,
+		"avatarUrl": resp.AvatarURL,
+	}
+	if includeTokens {
+		body["accessToken"] = resp.AccessToken
+		body["refreshToken"] = resp.RefreshToken
+		body["expiresInSeconds"] = resp.ExpiresInSeconds
+	}
+	return body
+}
+```
+
+- [ ] **Step 6: Use the helper in login and refresh**
+
+In `go/auth-service/internal/handler/auth.go`, replace the response bodies in `Login` and `Refresh`:
+
+```go
+	h.setAuthCookies(c, resp)
+	c.JSON(http.StatusOK, authJSON(resp, req.IncludeTokens))
+```
+
+For `Refresh`, keep the cookie fallback. When refresh token comes from cookie and no JSON body was parsed, `req.IncludeTokens` stays false.
+
+- [ ] **Step 7: Run auth handler tests**
+
+Run:
+
+```bash
+cd go/auth-service
+go test ./internal/handler -count=1
+```
+
+Expected: all handler tests pass.
+
+- [ ] **Step 8: Commit auth-service contract**
+
+Run:
+
+```bash
+git add go/auth-service/internal/model/user.go go/auth-service/internal/service/auth.go go/auth-service/internal/handler/auth.go go/auth-service/internal/handler/auth_test.go
+git commit -m "feat: expose auth tokens for machine clients"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Eval MCP Auth Client And Token Store
+
+**Files:**
+- Create: `go/eval-mcp-service/internal/authclient/client.go`
+- Create: `go/eval-mcp-service/internal/authclient/client_test.go`
+- Create: `go/eval-mcp-service/internal/tokenstore/file.go`
+- Create: `go/eval-mcp-service/internal/tokenstore/file_test.go`
+
+- [ ] **Step 1: Add failing auth client tests**
+
+Create `go/eval-mcp-service/internal/authclient/client_test.go`:
+
+```go
+package authclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLoginSendsIncludeTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/login" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		var body loginRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.Email != "smoke@example.com" || body.Password != "secret" || !body.IncludeTokens {
+			t.Fatalf("body = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:      "access",
+			RefreshToken:     "refresh",
+			ExpiresInSeconds: 900,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(server.URL+"/auth", server.Client())
+	got, err := client.Login(context.Background(), "smoke@example.com", "secret")
+	if err != nil {
+		t.Fatalf("Login error: %v", err)
+	}
+	if got.AccessToken != "access" || got.RefreshToken != "refresh" || got.ExpiresInSeconds != 900 {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestRefreshSendsIncludeTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/refresh" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		var body refreshRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.RefreshToken != "refresh-old" || !body.IncludeTokens {
+			t.Fatalf("body = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:      "access-new",
+			RefreshToken:     "refresh-new",
+			ExpiresInSeconds: 900,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(server.URL+"/auth", server.Client())
+	got, err := client.Refresh(context.Background(), "refresh-old")
+	if err != nil {
+		t.Fatalf("Refresh error: %v", err)
+	}
+	if got.AccessToken != "access-new" || got.RefreshToken != "refresh-new" {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestHTTPErrorIncludesStatusAndExcerpt(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, strings.Repeat("x", 300), http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(server.URL+"/auth", server.Client())
+	_, err := client.Login(context.Background(), "smoke@example.com", "bad")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "status 401") {
+		t.Fatalf("error = %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run auth client tests and verify failure**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/authclient -count=1
+```
+
+Expected: package does not compile because `internal/authclient` does not exist.
+
+- [ ] **Step 3: Implement auth client**
+
+Create `go/eval-mcp-service/internal/authclient/client.go`:
+
+```go
+package authclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHTTPTimeout = 30 * time.Second
+	errorExcerptLimit  = 256
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type TokenResponse struct {
+	AccessToken      string `json:"accessToken"`
+	RefreshToken     string `json:"refreshToken"`
+	ExpiresInSeconds int64  `json:"expiresInSeconds"`
+}
+
+type loginRequest struct {
+	Email         string `json:"email"`
+	Password      string `json:"password"`
+	IncludeTokens bool   `json:"includeTokens"`
+}
+
+type refreshRequest struct {
+	RefreshToken  string `json:"refreshToken"`
+	IncludeTokens bool   `json:"includeTokens"`
+}
+
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), httpClient: httpClient}
+}
+
+func (c *Client) Login(ctx context.Context, email, password string) (TokenResponse, error) {
+	return c.do(ctx, http.MethodPost, "/login", loginRequest{
+		Email: email, Password: password, IncludeTokens: true,
+	})
+}
+
+func (c *Client) Refresh(ctx context.Context, refreshToken string) (TokenResponse, error) {
+	return c.do(ctx, http.MethodPost, "/refresh", refreshRequest{
+		RefreshToken: refreshToken, IncludeTokens: true,
+	})
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any) (TokenResponse, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		return TokenResponse{}, fmt.Errorf("%s %s: encode request: %w", method, path, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, &buf)
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("%s %s: create request: %w", method, path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, errorExcerptLimit))
+		return TokenResponse{}, fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(excerpt)))
+	}
+	var out TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return TokenResponse{}, fmt.Errorf("%s %s: decode response: %w", method, path, err)
+	}
+	if out.AccessToken == "" || out.RefreshToken == "" || out.ExpiresInSeconds <= 0 {
+		return TokenResponse{}, fmt.Errorf("%s %s: response missing token fields", method, path)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Add failing token store tests**
+
+Create `go/eval-mcp-service/internal/tokenstore/file_test.go`:
+
+```go
+package tokenstore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileStoreSaveLoadAndPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	store := NewFileStore(path)
+	now := time.Now().UTC()
+	state := State{
+		AccessToken:    "access",
+		RefreshToken:   "refresh",
+		AccessTokenExp: now.Add(15 * time.Minute),
+		AuthEmail:      "smoke@example.com",
+		AuthServiceURL: "http://auth/auth",
+		WrittenAt:      now,
+	}
+	if err := store.Save(context.Background(), state); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o", got)
+	}
+	loaded, ok, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cached state")
+	}
+	if loaded.AccessToken != state.AccessToken || loaded.RefreshToken != state.RefreshToken || loaded.AuthEmail != state.AuthEmail {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+}
+
+func TestFileStoreMissingFile(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "missing.json"))
+	_, ok, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no cached state")
+	}
+}
+
+func TestFileStoreRejectsUnsafePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "auth.json")
+	if err := os.WriteFile(path, []byte(`{"accessToken":"access"}`), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	store := NewFileStore(path)
+	_, _, err := store.Load(context.Background())
+	if err == nil {
+		t.Fatal("expected unsafe permissions error")
+	}
+}
+```
+
+- [ ] **Step 5: Run token store tests and verify failure**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/tokenstore -count=1
+```
+
+Expected: package does not compile because `internal/tokenstore` does not exist.
+
+- [ ] **Step 6: Implement token store**
+
+Create `go/eval-mcp-service/internal/tokenstore/file.go`:
+
+```go
+package tokenstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type State struct {
+	AccessToken    string    `json:"accessToken"`
+	RefreshToken   string    `json:"refreshToken"`
+	AccessTokenExp time.Time `json:"accessTokenExp"`
+	AuthEmail      string    `json:"authEmail"`
+	AuthServiceURL string    `json:"authServiceUrl"`
+	WrittenAt      time.Time `json:"writtenAt"`
+}
+
+type FileStore struct {
+	path string
+}
+
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path: path}
+}
+
+func (s *FileStore) Load(_ context.Context) (State, bool, error) {
+	info, err := os.Stat(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return State{}, false, nil
+		}
+		return State{}, false, fmt.Errorf("stat token cache: %w", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		return State{}, false, fmt.Errorf("token cache %s has permissions %o, want 600", s.path, info.Mode().Perm())
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return State{}, false, fmt.Errorf("read token cache: %w", err)
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return State{}, false, fmt.Errorf("decode token cache: %w", err)
+	}
+	return state, true, nil
+}
+
+func (s *FileStore) Save(_ context.Context, state State) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create token cache directory: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode token cache: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write token cache temp file: %w", err)
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		return fmt.Errorf("chmod token cache temp file: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("replace token cache: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 7: Run auth client and token store tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/authclient ./internal/tokenstore -count=1
+```
+
+Expected: both packages pass.
+
+- [ ] **Step 8: Commit auth client and token store**
+
+Run:
+
+```bash
+git add go/eval-mcp-service/internal/authclient go/eval-mcp-service/internal/tokenstore
+git commit -m "feat: add eval mcp auth token plumbing"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Eval MCP Auth Provider And Config
+
+**Files:**
+- Modify: `go/eval-mcp-service/internal/config/config.go`
+- Modify: `go/eval-mcp-service/internal/config/config_test.go`
+- Create: `go/eval-mcp-service/internal/authprovider/provider.go`
+- Create: `go/eval-mcp-service/internal/authprovider/provider_test.go`
+
+- [ ] **Step 1: Add failing config tests**
+
+Update `go/eval-mcp-service/internal/config/config_test.go` default and override tests to assert these fields:
+
+```go
+if cfg.AuthServiceURL != "http://localhost:8091/auth" {
+	t.Fatalf("AuthServiceURL = %q", cfg.AuthServiceURL)
+}
+if cfg.AuthEmail != "" || cfg.AuthPassword != "" {
+	t.Fatalf("expected empty auth credentials by default")
+}
+if cfg.TokenCachePath != "data/eval-mcp-auth.json" {
+	t.Fatalf("TokenCachePath = %q", cfg.TokenCachePath)
+}
+if cfg.TokenRefreshSkew != time.Minute {
+	t.Fatalf("TokenRefreshSkew = %s", cfg.TokenRefreshSkew)
+}
+```
+
+Add this test:
+
+```go
+func TestFromEnvRequiresAuthCredentialsWhenNoStaticToken(t *testing.T) {
+	t.Setenv("EVAL_API_TOKEN", "")
+	t.Setenv("EVAL_MCP_AUTH_EMAIL", "")
+	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "")
+
+	_, err := FromEnv()
+	if err == nil {
+		t.Fatal("expected missing auth credentials error")
+	}
+}
+```
+
+In `TestFromEnvDefaults`, set `EVAL_API_TOKEN` to `token-123` so defaults can be tested through the static-token bypass.
+
+- [ ] **Step 2: Run config tests and verify failure**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/config -count=1
+```
+
+Expected: compile failure for missing config fields.
+
+- [ ] **Step 3: Implement config fields and validation**
+
+Update `go/eval-mcp-service/internal/config/config.go`:
+
+```go
+const (
+	defaultDBPath           = "data/eval-mcp.db"
+	defaultEvalAPIURL       = "http://localhost:8000/eval"
+	defaultAuthServiceURL   = "http://localhost:8091/auth"
+	defaultTokenCachePath   = "data/eval-mcp-auth.json"
+	defaultPollInterval     = time.Second
+	defaultWaitTimeout      = 5 * time.Minute
+	defaultTokenRefreshSkew = time.Minute
+)
+
+type Config struct {
+	DBPath           string
+	EvalAPIURL       string
+	APIToken         string
+	AuthServiceURL   string
+	AuthEmail        string
+	AuthPassword     string
+	TokenCachePath   string
+	TokenRefreshSkew time.Duration
+	PollInterval     time.Duration
+	WaitTimeout      time.Duration
+}
+```
+
+In `FromEnv`, parse `EVAL_MCP_TOKEN_REFRESH_SKEW` with `durationEnv`, reject non-positive values, and return:
+
+```go
+	cfg := Config{
+		DBPath:           getenv("EVAL_MCP_DB_PATH", defaultDBPath),
+		EvalAPIURL:       getenv("EVAL_API_URL", defaultEvalAPIURL),
+		APIToken:         os.Getenv("EVAL_API_TOKEN"),
+		AuthServiceURL:   getenv("AUTH_SERVICE_URL", defaultAuthServiceURL),
+		AuthEmail:        os.Getenv("EVAL_MCP_AUTH_EMAIL"),
+		AuthPassword:     os.Getenv("EVAL_MCP_AUTH_PASSWORD"),
+		TokenCachePath:   getenv("EVAL_MCP_TOKEN_CACHE_PATH", defaultTokenCachePath),
+		TokenRefreshSkew: tokenRefreshSkew,
+		PollInterval:     pollInterval,
+		WaitTimeout:      waitTimeout,
+	}
+	if cfg.APIToken == "" && (cfg.AuthEmail == "" || cfg.AuthPassword == "") {
+		return Config{}, fmt.Errorf("EVAL_MCP_AUTH_EMAIL and EVAL_MCP_AUTH_PASSWORD are required when EVAL_API_TOKEN is not set")
+	}
+	return cfg, nil
+```
+
+- [ ] **Step 4: Add failing auth provider tests**
+
+Create `go/eval-mcp-service/internal/authprovider/provider_test.go`:
+
+```go
+package authprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authclient"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
+)
+
+type fakeAuthClient struct {
+	loginCalls   int
+	refreshCalls int
+	refreshErr   error
+	loginResp    authclient.TokenResponse
+	refreshResp  authclient.TokenResponse
+}
+
+func (f *fakeAuthClient) Login(_ context.Context, _, _ string) (authclient.TokenResponse, error) {
+	f.loginCalls++
+	return f.loginResp, nil
+}
+
+func (f *fakeAuthClient) Refresh(_ context.Context, _ string) (authclient.TokenResponse, error) {
+	f.refreshCalls++
+	if f.refreshErr != nil {
+		return authclient.TokenResponse{}, f.refreshErr
+	}
+	return f.refreshResp, nil
+}
+
+type fakeStore struct {
+	state tokenstore.State
+	ok    bool
+	saved tokenstore.State
+}
+
+func (f *fakeStore) Load(context.Context) (tokenstore.State, bool, error) {
+	return f.state, f.ok, nil
+}
+
+func (f *fakeStore) Save(_ context.Context, state tokenstore.State) error {
+	f.saved = state
+	f.state = state
+	f.ok = true
+	return nil
+}
+
+func TestProviderUsesValidCachedAccessToken(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{ok: true, state: tokenstore.State{
+		AccessToken: "cached", RefreshToken: "refresh", AccessTokenExp: now.Add(10 * time.Minute),
+		AuthEmail: "smoke@example.com", AuthServiceURL: "http://auth/auth",
+	}}
+	client := &fakeAuthClient{}
+	provider := New(client, store, Config{
+		Email: "smoke@example.com", Password: "secret", AuthServiceURL: "http://auth/auth", RefreshSkew: time.Minute, Now: func() time.Time { return now },
+	})
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if token != "cached" || client.loginCalls != 0 || client.refreshCalls != 0 {
+		t.Fatalf("token=%q login=%d refresh=%d", token, client.loginCalls, client.refreshCalls)
+	}
+}
+
+func TestProviderRefreshesNearExpiryToken(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{ok: true, state: tokenstore.State{
+		AccessToken: "old", RefreshToken: "refresh-old", AccessTokenExp: now.Add(30 * time.Second),
+		AuthEmail: "smoke@example.com", AuthServiceURL: "http://auth/auth",
+	}}
+	client := &fakeAuthClient{refreshResp: authclient.TokenResponse{AccessToken: "new", RefreshToken: "refresh-new", ExpiresInSeconds: 900}}
+	provider := New(client, store, Config{
+		Email: "smoke@example.com", Password: "secret", AuthServiceURL: "http://auth/auth", RefreshSkew: time.Minute, Now: func() time.Time { return now },
+	})
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if token != "new" || client.refreshCalls != 1 || client.loginCalls != 0 {
+		t.Fatalf("token=%q login=%d refresh=%d", token, client.loginCalls, client.refreshCalls)
+	}
+	if store.saved.AccessTokenExp != now.Add(900*time.Second) {
+		t.Fatalf("saved expiry = %s", store.saved.AccessTokenExp)
+	}
+}
+
+func TestProviderFallsBackToLoginAfterRefreshFailure(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{ok: true, state: tokenstore.State{
+		AccessToken: "old", RefreshToken: "refresh-old", AccessTokenExp: now.Add(-time.Second),
+		AuthEmail: "smoke@example.com", AuthServiceURL: "http://auth/auth",
+	}}
+	client := &fakeAuthClient{
+		refreshErr: errors.New("refresh failed"),
+		loginResp: authclient.TokenResponse{AccessToken: "login-access", RefreshToken: "login-refresh", ExpiresInSeconds: 900},
+	}
+	provider := New(client, store, Config{
+		Email: "smoke@example.com", Password: "secret", AuthServiceURL: "http://auth/auth", RefreshSkew: time.Minute, Now: func() time.Time { return now },
+	})
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if token != "login-access" || client.refreshCalls != 1 || client.loginCalls != 1 {
+		t.Fatalf("token=%q login=%d refresh=%d", token, client.loginCalls, client.refreshCalls)
+	}
+}
+
+func TestProviderInvalidateForcesRefresh(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{ok: true, state: tokenstore.State{
+		AccessToken: "cached", RefreshToken: "refresh-old", AccessTokenExp: now.Add(10 * time.Minute),
+		AuthEmail: "smoke@example.com", AuthServiceURL: "http://auth/auth",
+	}}
+	client := &fakeAuthClient{refreshResp: authclient.TokenResponse{AccessToken: "new", RefreshToken: "refresh-new", ExpiresInSeconds: 900}}
+	provider := New(client, store, Config{
+		Email: "smoke@example.com", Password: "secret", AuthServiceURL: "http://auth/auth", RefreshSkew: time.Minute, Now: func() time.Time { return now },
+	})
+	provider.Invalidate()
+	token, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if token != "new" || client.refreshCalls != 1 || client.loginCalls != 0 {
+		t.Fatalf("token=%q login=%d refresh=%d", token, client.loginCalls, client.refreshCalls)
+	}
+}
+```
+
+- [ ] **Step 5: Run auth provider tests and verify failure**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/authprovider -count=1
+```
+
+Expected: package does not compile because `internal/authprovider` does not exist.
+
+- [ ] **Step 6: Implement auth provider**
+
+Create `go/eval-mcp-service/internal/authprovider/provider.go`:
+
+```go
+package authprovider
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authclient"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
+)
+
+type AuthClient interface {
+	Login(context.Context, string, string) (authclient.TokenResponse, error)
+	Refresh(context.Context, string) (authclient.TokenResponse, error)
+}
+
+type Store interface {
+	Load(context.Context) (tokenstore.State, bool, error)
+	Save(context.Context, tokenstore.State) error
+}
+
+type Config struct {
+	Email          string
+	Password       string
+	AuthServiceURL string
+	RefreshSkew    time.Duration
+	Now            func() time.Time
+}
+
+type Provider struct {
+	client      AuthClient
+	store       Store
+	cfg         Config
+	mu          sync.Mutex
+	invalidated bool
+}
+
+func New(client AuthClient, store Store, cfg Config) *Provider {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Provider{client: client, store: store, cfg: cfg}
+}
+
+func (p *Provider) Token(ctx context.Context) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	state, ok, err := p.store.Load(ctx)
+	if err != nil {
+		return "", err
+	}
+	if ok && !p.invalidated && state.AuthEmail == p.cfg.Email && state.AuthServiceURL == p.cfg.AuthServiceURL && state.AccessToken != "" && p.cfg.Now().Add(p.cfg.RefreshSkew).Before(state.AccessTokenExp) {
+		return state.AccessToken, nil
+	}
+	p.invalidated = false
+	if ok && state.RefreshToken != "" {
+		resp, err := p.client.Refresh(ctx, state.RefreshToken)
+		if err == nil {
+			return p.save(ctx, resp)
+		}
+	}
+	resp, err := p.client.Login(ctx, p.cfg.Email, p.cfg.Password)
+	if err != nil {
+		return "", err
+	}
+	return p.save(ctx, resp)
+}
+
+func (p *Provider) Invalidate() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.invalidated = true
+}
+
+func (p *Provider) save(ctx context.Context, resp authclient.TokenResponse) (string, error) {
+	now := p.cfg.Now().UTC()
+	state := tokenstore.State{
+		AccessToken:    resp.AccessToken,
+		RefreshToken:   resp.RefreshToken,
+		AccessTokenExp: now.Add(time.Duration(resp.ExpiresInSeconds) * time.Second),
+		AuthEmail:      p.cfg.Email,
+		AuthServiceURL: p.cfg.AuthServiceURL,
+		WrittenAt:      now,
+	}
+	if err := p.store.Save(ctx, state); err != nil {
+		return "", err
+	}
+	return resp.AccessToken, nil
+}
+```
+
+- [ ] **Step 7: Run config and provider tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/config ./internal/authprovider -count=1
+```
+
+Expected: both packages pass.
+
+- [ ] **Step 8: Commit provider and config**
+
+Run:
+
+```bash
+git add go/eval-mcp-service/internal/config go/eval-mcp-service/internal/authprovider
+git commit -m "feat: add eval mcp auth provider"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Eval API Retry Wiring And Command Startup
+
+**Files:**
+- Modify: `go/eval-mcp-service/internal/evalapi/client.go`
+- Modify: `go/eval-mcp-service/internal/evalapi/client_test.go`
+- Modify: `go/eval-mcp-service/cmd/eval-mcp/main.go`
+- Modify: `go/eval-mcp-service/cmd/eval-mcp/main_test.go`
+- Modify: `go/eval-mcp-service/README.md`
+
+- [ ] **Step 1: Add failing eval API retry test**
+
+Append to `go/eval-mcp-service/internal/evalapi/client_test.go`:
+
+```go
+type fakeTokenProvider struct {
+	tokens      []string
+	calls       int
+	invalidated int
+}
+
+func (f *fakeTokenProvider) Token(context.Context) (string, error) {
+	token := f.tokens[f.calls]
+	f.calls++
+	return token, nil
+}
+
+func (f *fakeTokenProvider) Invalidate() {
+	f.invalidated++
+}
+
+func TestListDatasetsRetriesOnceAfterUnauthorized(t *testing.T) {
+	provider := &fakeTokenProvider{tokens: []string{"expired", "fresh"}}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch requests {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "Bearer expired" {
+				t.Fatalf("first Authorization = %q", got)
+			}
+			http.Error(w, "expired", http.StatusUnauthorized)
+		case 2:
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh" {
+				t.Fatalf("second Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"datasets": []Dataset{{ID: "ds-1", Name: "rag", ItemCount: 2}}})
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewWithTokenProvider(server.URL, provider, server.Client())
+	got, err := client.ListDatasets(context.Background())
+	if err != nil {
+		t.Fatalf("ListDatasets error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ds-1" {
+		t.Fatalf("datasets = %#v", got)
+	}
+	if provider.invalidated != 1 || provider.calls != 2 {
+		t.Fatalf("invalidated=%d calls=%d", provider.invalidated, provider.calls)
+	}
+}
+```
+
+- [ ] **Step 2: Run eval API tests and verify failure**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./internal/evalapi -run TestListDatasetsRetriesOnceAfterUnauthorized -count=1
+```
+
+Expected: compile failure for missing `NewWithTokenProvider`.
+
+- [ ] **Step 3: Implement token provider and retry**
+
+Update `go/eval-mcp-service/internal/evalapi/client.go`:
+
+```go
+type TokenProvider interface {
+	Token(context.Context) (string, error)
+	Invalidate()
+}
+
+type staticTokenProvider struct {
+	token string
+}
+
+func (p staticTokenProvider) Token(context.Context) (string, error) {
+	return p.token, nil
+}
+
+func (p staticTokenProvider) Invalidate() {
+}
+```
+
+Change `Client` fields:
+
+```go
+type Client struct {
+	baseURL       string
+	tokenProvider TokenProvider
+	httpClient    *http.Client
+}
+```
+
+Keep the current constructor and add a provider constructor:
+
+```go
+func New(baseURL, token string, httpClient *http.Client) *Client {
+	var provider TokenProvider
+	if token != "" {
+		provider = staticTokenProvider{token: token}
+	}
+	return NewWithTokenProvider(baseURL, provider, httpClient)
+}
+
+func NewWithTokenProvider(baseURL string, tokenProvider TokenProvider, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &Client{
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		tokenProvider: tokenProvider,
+		httpClient:    httpClient,
+	}
+}
+```
+
+Split request execution so `401` retries once:
+
+```go
+func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+	err := c.doOnce(ctx, method, path, body, out)
+	if statusCode(err) == http.StatusUnauthorized && c.tokenProvider != nil {
+		c.tokenProvider.Invalidate()
+		return c.doOnce(ctx, method, path, body, out)
+	}
+	return err
+}
+```
+
+Represent HTTP errors with a typed error:
+
+```go
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Excerpt    string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("%s %s: status %d: %s", e.Method, e.Path, e.StatusCode, e.Excerpt)
+}
+
+func statusCode(err error) int {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode
+	}
+	return 0
+}
+```
+
+In `doOnce`, before sending the request:
+
+```go
+if c.tokenProvider != nil {
+	token, err := c.tokenProvider.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("%s %s: get auth token: %w", method, path, err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+```
+
+On non-2xx:
+
+```go
+return &HTTPError{Method: method, Path: path, StatusCode: resp.StatusCode, Excerpt: strings.TrimSpace(string(excerpt))}
+```
+
+- [ ] **Step 4: Wire provider in main**
+
+Update `go/eval-mcp-service/cmd/eval-mcp/main.go` imports:
+
+```go
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authclient"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authprovider"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
+```
+
+Replace eval API construction:
+
+```go
+	httpClient := &http.Client{Timeout: cfg.WaitTimeout}
+	var api *evalapi.Client
+	if cfg.APIToken != "" {
+		api = evalapi.New(cfg.EvalAPIURL, cfg.APIToken, httpClient)
+	} else {
+		authClient := authclient.New(cfg.AuthServiceURL, httpClient)
+		cache := tokenstore.NewFileStore(cfg.TokenCachePath)
+		provider := authprovider.New(authClient, cache, authprovider.Config{
+			Email:          cfg.AuthEmail,
+			Password:       cfg.AuthPassword,
+			AuthServiceURL: cfg.AuthServiceURL,
+			RefreshSkew:    cfg.TokenRefreshSkew,
+		})
+		api = evalapi.NewWithTokenProvider(cfg.EvalAPIURL, provider, httpClient)
+	}
+```
+
+- [ ] **Step 5: Update command tests**
+
+In `go/eval-mcp-service/cmd/eval-mcp/main_test.go`, keep `EVAL_API_TOKEN` in `TestRunWiresDependenciesAndCallsServer`. Add:
+
+```go
+func TestRunAcceptsAuthServiceConfigWhenStaticTokenMissing(t *testing.T) {
+	apiServer := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(apiServer.Close)
+
+	t.Setenv("EVAL_MCP_DB_PATH", filepath.Join(t.TempDir(), "eval-mcp.db"))
+	t.Setenv("EVAL_API_URL", apiServer.URL)
+	t.Setenv("EVAL_API_TOKEN", "")
+	t.Setenv("AUTH_SERVICE_URL", "http://auth.local/auth")
+	t.Setenv("EVAL_MCP_AUTH_EMAIL", "smoke@example.com")
+	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "secret")
+	t.Setenv("EVAL_MCP_TOKEN_CACHE_PATH", filepath.Join(t.TempDir(), "auth.json"))
+	t.Setenv("EVAL_MCP_POLL_INTERVAL", "10ms")
+	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "2s")
+
+	called := false
+	err := run(context.Background(), log.New(&bytes.Buffer{}, "", 0), func(_ context.Context, application *app) error {
+		called = true
+		if application.service == nil {
+			t.Fatal("expected service")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected runner to be called")
+	}
+}
+```
+
+- [ ] **Step 6: Update README configuration**
+
+In `go/eval-mcp-service/README.md`, replace the configuration list with:
+
+```markdown
+- `EVAL_MCP_DB_PATH`: SQLite path, defaults to `data/eval-mcp.db`.
+- `EVAL_API_URL`: eval API base URL, defaults to `http://localhost:8000/eval`.
+- `EVAL_API_TOKEN`: optional bearer token override. When set, auth-service login is skipped.
+- `AUTH_SERVICE_URL`: auth-service base URL, defaults to `http://localhost:8091/auth`.
+- `EVAL_MCP_AUTH_EMAIL`: auth-service login email when `EVAL_API_TOKEN` is not set.
+- `EVAL_MCP_AUTH_PASSWORD`: auth-service login password when `EVAL_API_TOKEN` is not set.
+- `EVAL_MCP_TOKEN_CACHE_PATH`: auth token cache path, defaults to `data/eval-mcp-auth.json`.
+- `EVAL_MCP_TOKEN_REFRESH_SKEW`: token refresh-ahead duration, defaults to `60s`.
+- `EVAL_MCP_POLL_INTERVAL`: polling interval, defaults to `1s`.
+- `EVAL_MCP_WAIT_TIMEOUT`: wait timeout, defaults to `5m`.
+```
+
+Add this registration example:
+
+```bash
+EVAL_MCP_AUTH_EMAIL=smoke@kylebradshaw.dev \
+EVAL_MCP_AUTH_PASSWORD="$SMOKE_GO_PASSWORD" \
+AUTH_SERVICE_URL=https://api.kylebradshaw.dev/go-auth/auth \
+EVAL_API_URL=https://api.kylebradshaw.dev/eval \
+codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/eval-mcp-service && exec go run ./cmd/eval-mcp'
+```
+
+- [ ] **Step 7: Run eval MCP tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./... -count=1
+```
+
+Expected: all eval MCP service tests pass.
+
+- [ ] **Step 8: Commit eval MCP wiring**
+
+Run:
+
+```bash
+git add go/eval-mcp-service
+git commit -m "feat: authenticate eval mcp service with auth-service"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Verification And Pull Request
+
+**Files:**
+- No source files changed unless verification exposes a defect.
+
+- [ ] **Step 1: Run auth-service tests**
+
+Run:
+
+```bash
+cd go/auth-service
+go test ./... -count=1
+```
+
+Expected: all auth-service tests pass.
+
+- [ ] **Step 2: Run eval MCP tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service
+go test ./... -count=1
+```
+
+Expected: all eval MCP tests pass.
+
+- [ ] **Step 3: Run Go preflight**
+
+Run from repo root:
+
+```bash
+make preflight-go
+```
+
+Expected: Go preflight passes. If it fails because of an unrelated existing issue, record the failing command and exact package, then fix only failures caused by this branch.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git log --oneline --decorate -5
+```
+
+Expected: only auth-service, eval-mcp-service, and README files from this plan changed.
+
+- [ ] **Step 5: Push feature branch**
+
+Run:
+
+```bash
+git push -u origin feature/eval-mcp-auth-integration
+```
+
+Expected: branch pushes successfully.
+
+- [ ] **Step 6: Open PR to qa**
+
+Run:
+
+```bash
+gh pr create --base qa --head feature/eval-mcp-auth-integration --title "Authenticate eval MCP service with auth-service" --body "## Summary
+- add opt-in auth-service token responses for machine clients
+- add eval MCP auth client, token cache, and refresh/login provider
+- retry eval API requests once after token recovery
+
+## Verification
+- go test ./... in go/auth-service
+- go test ./... in go/eval-mcp-service
+- make preflight-go"
+```
+
+Expected: PR is created targeting `qa`. Do not watch CI unless Kyle asks.

--- a/docs/superpowers/specs/2026-05-15-eval-mcp-auth-integration-design.md
+++ b/docs/superpowers/specs/2026-05-15-eval-mcp-auth-integration-design.md
@@ -1,0 +1,239 @@
+# Eval MCP Auth Integration Design
+
+## Summary
+
+Wire `go/eval-mcp-service` into the existing `go/auth-service` JWT flow so the
+local MCP workflow can call the authenticated Python eval API without manually
+copying bearer tokens. The MCP service will authenticate with the seeded smoke
+user, cache token state outside experiment metadata, and attach access tokens to
+requests sent to `services/eval`.
+
+The Python eval API remains the backend for datasets, evaluation runs, scores,
+and experiment evidence. Auth-service remains the issuer of JWTs accepted by
+Python services through the shared JWT secret.
+
+## Goals
+
+- Let the eval MCP service authenticate through `go/auth-service`.
+- Use the existing seeded smoke user instead of adding a new application user in
+  this change.
+- Keep browser auth behavior intact while adding a machine-friendly token
+  response for service clients.
+- Store reusable auth state locally with restrictive permissions.
+- Retry a failed eval API call once after token refresh or re-login.
+- Keep credentials and tokens out of the eval MCP experiment SQLite database.
+- Make production documentation at `/ai/eval` backed by repeatable authenticated
+  evaluation workflows.
+
+## Non-Goals
+
+- Do not create a new auth service or bypass auth-service JWT issuance.
+- Do not add a new production Kubernetes deployment for the MCP service.
+- Do not store smoke-user credentials in ConfigMaps, source code, or local eval
+  experiment records.
+- Do not change the Python eval service's authorization model beyond relying on
+  bearer JWTs it already accepts.
+- Do not add role-based authorization in this slice.
+
+## Current State
+
+`go/eval-mcp-service` already accepts `EVAL_API_TOKEN` and sends it as
+`Authorization: Bearer <token>` through `internal/evalapi.Client`.
+
+`services/eval` requires authentication on dataset and evaluation endpoints via
+`shared.auth.create_auth_dependency(settings.jwt_secret)`. Bearer headers take
+precedence over cookies.
+
+`go/auth-service` has `POST /auth/login` and `POST /auth/refresh` and already
+generates access and refresh tokens internally. Its handlers set auth cookies
+and return user profile fields in JSON. The seeded smoke user is
+`smoke@kylebradshaw.dev`; the password is managed outside the repo as
+`SMOKE_GO_PASSWORD`.
+
+## Architecture
+
+Add an auth client inside `go/eval-mcp-service`:
+
+- `internal/authclient`: typed HTTP client for auth login and refresh.
+- `internal/tokenstore`: small local token cache abstraction.
+- `internal/evalapi`: request path gains an auth provider or retry hook instead
+  of accepting only a static token string.
+
+At runtime, the MCP process obtains a valid access token before making eval API
+requests. It uses cached token state when available, refreshes before expiry,
+and falls back to login when refresh fails or no cache exists.
+
+The eval API client remains responsible for eval endpoints. The auth client is
+responsible only for auth-service endpoints. The workflow layer should not
+manually construct auth headers.
+
+## Auth-Service Contract
+
+Extend auth request and response behavior without breaking browsers.
+
+Request shape:
+
+```json
+{
+  "email": "smoke@kylebradshaw.dev",
+  "password": "<secret>",
+  "includeTokens": true
+}
+```
+
+`includeTokens` defaults to `false`. When false, login and refresh continue to
+return the current browser-safe profile response and set cookies. When true, the
+JSON response includes:
+
+```json
+{
+  "userId": "...",
+  "email": "smoke@kylebradshaw.dev",
+  "name": "Smoke Test",
+  "avatarUrl": "",
+  "accessToken": "...",
+  "refreshToken": "...",
+  "expiresInSeconds": 900
+}
+```
+
+`refreshToken` is included for `POST /auth/login` and for JSON-body
+`POST /auth/refresh` requests that opt in to token output. The handler still
+sets cookies in both modes so existing browser and smoke-test flows remain
+compatible.
+
+The token TTL value should come from the existing auth-service access token TTL
+configuration rather than being guessed by the MCP service.
+
+## Eval MCP Configuration
+
+Add configuration keys:
+
+- `AUTH_SERVICE_URL`: auth-service base URL. Local default:
+  `http://localhost:8091/auth`; production API default can be documented as
+  `https://api.kylebradshaw.dev/go-auth/auth`.
+- `EVAL_MCP_AUTH_EMAIL`: auth email, expected to be
+  `smoke@kylebradshaw.dev` for this workflow.
+- `EVAL_MCP_AUTH_PASSWORD`: auth password, supplied from a secret such as
+  `SMOKE_GO_PASSWORD`.
+- `EVAL_MCP_TOKEN_CACHE_PATH`: token cache path, default
+  `data/eval-mcp-auth.json`.
+- `EVAL_MCP_TOKEN_REFRESH_SKEW`: refresh-ahead duration, default `60s`.
+- `EVAL_API_TOKEN`: remains supported as a manual override for local debugging.
+
+If `EVAL_API_TOKEN` is set, the MCP service uses it directly and does not call
+auth-service. If it is not set, all auth-service configuration must be present
+and valid.
+
+## Token Cache
+
+The token cache stores:
+
+- access token
+- access token expiry time
+- refresh token
+- auth email
+- auth-service URL
+- write timestamp
+
+The file must be created with owner-only permissions (`0600`) and parent
+directories should be created with non-world-writable permissions. The cache is
+not part of the SQLite experiment database and must not be displayed in MCP tool
+responses.
+
+The cache should be ignored by Git through the existing data directory ignore
+patterns or a targeted ignore entry if needed.
+
+## Data Flow
+
+1. MCP starts and loads config.
+2. First eval API operation requests an access token from the auth provider.
+3. Auth provider checks the token cache.
+4. If the cached access token is still valid beyond the refresh skew, it is
+   returned.
+5. If the access token is near expiry and a refresh token exists, the provider
+   calls `POST /auth/refresh` with `includeTokens: true`.
+6. If refresh fails, the provider calls `POST /auth/login` with
+   `includeTokens: true`.
+7. The eval API client sends `Authorization: Bearer <accessToken>`.
+8. If an eval API request returns `401`, the client invalidates cached access
+   state, refreshes or logs in once, and retries the original request once.
+
+Repeated `401` responses after retry should return a clear error that points to
+auth-service credentials, JWT secret mismatch, or expired/invalid token state.
+
+## Secret Handling
+
+Local MCP registration should pass secrets through environment variables, not
+command-line arguments that expose values in shell history or process listings.
+
+For CI or production-like automation, credentials must come from GitHub Actions
+secrets or Kubernetes SealedSecret-managed Secret data. `AUTH_SERVICE_URL` and
+other non-secret routing values can live in config. The smoke password and any
+persisted tokens must not be placed in ConfigMaps.
+
+No live Kubernetes mutation is required to implement this local MCP workflow. If
+a future task adds Kubernetes secret material, that task must use the
+`ops-as-code` workflow and committed sealed-secret manifests.
+
+## Error Handling
+
+- Missing auth config produces a startup/config error unless `EVAL_API_TOKEN` is
+  provided.
+- Login `401` reports invalid smoke-user credentials without logging the
+  password.
+- Refresh `401` clears refresh state and attempts one login.
+- Eval API `401` triggers one token recovery retry.
+- Auth-service `429` or `5xx` errors are returned with status code and a short
+  response excerpt.
+- Token cache read failures are non-fatal unless the file exists but has unsafe
+  permissions; unsafe permissions should fail closed with a corrective message.
+
+## Testing
+
+Go eval MCP tests:
+
+- config defaults and validation for auth-service settings
+- static `EVAL_API_TOKEN` override bypasses auth-service
+- auth client login parses token responses
+- auth client refresh parses token responses
+- token cache writes `0600` files and rejects unsafe existing files
+- auth provider refreshes before expiry
+- auth provider falls back to login after refresh failure
+- eval API client retries once after `401` and reuses the recovered token
+- eval API client does not retry non-auth failures
+
+Go auth-service tests:
+
+- login without `includeTokens` preserves current JSON shape and cookie behavior
+- login with `includeTokens` includes access token, refresh token, and expiry
+- refresh with `includeTokens` includes rotated token data
+- token fields are not emitted by default
+
+Python eval tests:
+
+- Existing bearer-token validation coverage remains sufficient unless
+  implementation changes eval auth wiring.
+
+Relevant verification before implementation commit:
+
+```bash
+make preflight-go
+```
+
+If Python eval auth wiring changes, also run:
+
+```bash
+make preflight-python
+```
+
+## Operational Notes
+
+The production-facing `/ai/eval` page can document experiments run through this
+authenticated MCP path because each run is still created in the Python eval API.
+The MCP service is a local orchestration surface, not a separate source of truth.
+
+The seeded smoke user is acceptable for this slice because the workflow already
+depends on that test user. A later hardening pass can introduce a dedicated
+service account or role claim if evaluation workflows need narrower permission
+boundaries.

--- a/go/auth-service/internal/handler/auth.go
+++ b/go/auth-service/internal/handler/auth.go
@@ -59,6 +59,21 @@ func (h *AuthHandler) clearAuthCookies(c *gin.Context) {
 	c.SetCookie("refresh_token", "", -1, "/go-auth/auth", h.cookieCfg.Domain, h.cookieCfg.Secure, true)
 }
 
+func authJSON(resp *model.AuthResponse, includeTokens bool) gin.H {
+	body := gin.H{
+		"userId":    resp.UserID,
+		"email":     resp.Email,
+		"name":      resp.Name,
+		"avatarUrl": resp.AvatarURL,
+	}
+	if includeTokens {
+		body["accessToken"] = resp.AccessToken
+		body["refreshToken"] = resp.RefreshToken
+		body["expiresInSeconds"] = resp.ExpiresInSeconds
+	}
+	return body
+}
+
 func (h *AuthHandler) Register(c *gin.Context) {
 	var req model.RegisterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -91,19 +106,14 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 	h.setAuthCookies(c, resp)
-	c.JSON(http.StatusOK, gin.H{
-		"userId":    resp.UserID,
-		"email":     resp.Email,
-		"name":      resp.Name,
-		"avatarUrl": resp.AvatarURL,
-	})
+	c.JSON(http.StatusOK, authJSON(resp, req.IncludeTokens))
 }
 
 func (h *AuthHandler) Refresh(c *gin.Context) {
+	var req model.RefreshRequest
 	refreshToken, err := c.Cookie("refresh_token")
 	if err != nil || refreshToken == "" {
 		// Fallback to JSON body for backward compatibility
-		var req model.RefreshRequest
 		if bindErr := c.ShouldBindJSON(&req); bindErr != nil {
 			_ = c.Error(apperror.Unauthorized("MISSING_TOKEN", "missing refresh token"))
 			return
@@ -116,12 +126,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 	h.setAuthCookies(c, resp)
-	c.JSON(http.StatusOK, gin.H{
-		"userId":    resp.UserID,
-		"email":     resp.Email,
-		"name":      resp.Name,
-		"avatarUrl": resp.AvatarURL,
-	})
+	c.JSON(http.StatusOK, authJSON(resp, req.IncludeTokens))
 }
 
 func (h *AuthHandler) GoogleLogin(c *gin.Context) {

--- a/go/auth-service/internal/handler/auth.go
+++ b/go/auth-service/internal/handler/auth.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -112,7 +113,18 @@ func (h *AuthHandler) Login(c *gin.Context) {
 func (h *AuthHandler) Refresh(c *gin.Context) {
 	var req model.RefreshRequest
 	refreshToken, err := c.Cookie("refresh_token")
-	if err != nil || refreshToken == "" {
+	if err == nil && refreshToken != "" {
+		var body struct {
+			IncludeTokens bool `json:"includeTokens"`
+		}
+		if c.Request.Body != nil && c.Request.Body != http.NoBody && c.Request.ContentLength != 0 {
+			if bindErr := json.NewDecoder(c.Request.Body).Decode(&body); bindErr != nil {
+				_ = c.Error(apperror.BadRequest("VALIDATION_ERROR", bindErr.Error()))
+				return
+			}
+			req.IncludeTokens = body.IncludeTokens
+		}
+	} else {
 		// Fallback to JSON body for backward compatibility
 		if bindErr := c.ShouldBindJSON(&req); bindErr != nil {
 			_ = c.Error(apperror.Unauthorized("MISSING_TOKEN", "missing refresh token"))

--- a/go/auth-service/internal/handler/auth_test.go
+++ b/go/auth-service/internal/handler/auth_test.go
@@ -246,6 +246,85 @@ func TestLoginHandler_IncludeTokensReturnsTokenFields(t *testing.T) {
 	}
 }
 
+func TestRefreshHandler_DefaultResponseOmitsTokensWithCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := newMockUserRepo()
+	svc := service.NewAuthService(repo, "test-secret", 900000, 604800000)
+	registered, err := svc.Register(context.Background(), "refresh@example.com", "password123456", "Refresh")
+	if err != nil {
+		t.Fatalf("register fixture: %v", err)
+	}
+	h := handler.NewAuthHandler(svc, nil, service.NewTokenDenylist(nil), 15*time.Minute, 7*24*time.Hour, defaultCookieCfg())
+
+	router := testRouter()
+	router.POST("/auth/refresh", h.Refresh)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: registered.RefreshToken})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := resp["accessToken"]; ok {
+		t.Fatal("accessToken must not appear without includeTokens")
+	}
+	if _, ok := resp["refreshToken"]; ok {
+		t.Fatal("refreshToken must not appear without includeTokens")
+	}
+	if _, ok := resp["expiresInSeconds"]; ok {
+		t.Fatal("expiresInSeconds must not appear without includeTokens")
+	}
+	if !hasCookie(w, "access_token") || !hasCookie(w, "refresh_token") {
+		t.Fatal("expected refreshed auth cookies")
+	}
+}
+
+func TestRefreshHandler_IncludeTokensReturnsTokenFieldsWithCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := newMockUserRepo()
+	svc := service.NewAuthService(repo, "test-secret", 900000, 604800000)
+	registered, err := svc.Register(context.Background(), "refresh@example.com", "password123456", "Refresh")
+	if err != nil {
+		t.Fatalf("register fixture: %v", err)
+	}
+	h := handler.NewAuthHandler(svc, nil, service.NewTokenDenylist(nil), 15*time.Minute, 7*24*time.Hour, defaultCookieCfg())
+
+	router := testRouter()
+	router.POST("/auth/refresh", h.Refresh)
+
+	body := strings.NewReader(`{"includeTokens":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "refresh_token", Value: registered.RefreshToken})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["accessToken"] == "" || resp["refreshToken"] == "" {
+		t.Fatalf("expected token fields, got %#v", resp)
+	}
+	if resp["expiresInSeconds"] != float64(900) {
+		t.Fatalf("expiresInSeconds = %#v", resp["expiresInSeconds"])
+	}
+	if !hasCookie(w, "access_token") || !hasCookie(w, "refresh_token") {
+		t.Fatal("expected refreshed auth cookies")
+	}
+}
+
 // --- fake auth service for Google handler tests ---
 
 type fakeAuthService struct {

--- a/go/auth-service/internal/handler/auth_test.go
+++ b/go/auth-service/internal/handler/auth_test.go
@@ -167,6 +167,85 @@ func TestRegisterHandler_InvalidEmail(t *testing.T) {
 	}
 }
 
+func TestLoginHandler_DefaultResponseOmitsTokens(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := newMockUserRepo()
+	svc := service.NewAuthService(repo, "test-secret", 900000, 604800000)
+	_, err := svc.Register(context.Background(), "smoke@example.com", "password123456", "Smoke")
+	if err != nil {
+		t.Fatalf("register fixture: %v", err)
+	}
+	h := handler.NewAuthHandler(svc, nil, service.NewTokenDenylist(nil), 15*time.Minute, 7*24*time.Hour, defaultCookieCfg())
+
+	router := testRouter()
+	router.POST("/auth/login", h.Login)
+
+	body := strings.NewReader(`{"email":"smoke@example.com","password":"password123456"}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := resp["accessToken"]; ok {
+		t.Fatal("accessToken must not appear without includeTokens")
+	}
+	if _, ok := resp["refreshToken"]; ok {
+		t.Fatal("refreshToken must not appear without includeTokens")
+	}
+	if _, ok := resp["expiresInSeconds"]; ok {
+		t.Fatal("expiresInSeconds must not appear without includeTokens")
+	}
+	if !hasCookie(w, "access_token") || !hasCookie(w, "refresh_token") {
+		t.Fatal("expected auth cookies")
+	}
+}
+
+func TestLoginHandler_IncludeTokensReturnsTokenFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := newMockUserRepo()
+	svc := service.NewAuthService(repo, "test-secret", 900000, 604800000)
+	_, err := svc.Register(context.Background(), "smoke@example.com", "password123456", "Smoke")
+	if err != nil {
+		t.Fatalf("register fixture: %v", err)
+	}
+	h := handler.NewAuthHandler(svc, nil, service.NewTokenDenylist(nil), 15*time.Minute, 7*24*time.Hour, defaultCookieCfg())
+
+	router := testRouter()
+	router.POST("/auth/login", h.Login)
+
+	body := strings.NewReader(`{"email":"smoke@example.com","password":"password123456","includeTokens":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["accessToken"] == "" || resp["refreshToken"] == "" {
+		t.Fatalf("expected token fields, got %#v", resp)
+	}
+	if resp["expiresInSeconds"] != float64(900) {
+		t.Fatalf("expiresInSeconds = %#v", resp["expiresInSeconds"])
+	}
+	if !hasCookie(w, "access_token") || !hasCookie(w, "refresh_token") {
+		t.Fatal("expected auth cookies")
+	}
+}
+
 // --- fake auth service for Google handler tests ---
 
 type fakeAuthService struct {

--- a/go/auth-service/internal/model/user.go
+++ b/go/auth-service/internal/model/user.go
@@ -22,12 +22,14 @@ type RegisterRequest struct {
 }
 
 type LoginRequest struct {
-	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required"`
+	Email         string `json:"email" binding:"required,email"`
+	Password      string `json:"password" binding:"required"`
+	IncludeTokens bool   `json:"includeTokens"`
 }
 
 type RefreshRequest struct {
-	RefreshToken string `json:"refreshToken" binding:"required"`
+	RefreshToken  string `json:"refreshToken" binding:"required"`
+	IncludeTokens bool   `json:"includeTokens"`
 }
 
 type GoogleLoginRequest struct {
@@ -36,10 +38,11 @@ type GoogleLoginRequest struct {
 }
 
 type AuthResponse struct {
-	AccessToken  string `json:"accessToken"`
-	RefreshToken string `json:"refreshToken"`
-	UserID       string `json:"userId"`
-	Email        string `json:"email"`
-	Name         string `json:"name"`
-	AvatarURL    string `json:"avatarUrl,omitempty"`
+	AccessToken      string `json:"accessToken"`
+	RefreshToken     string `json:"refreshToken"`
+	ExpiresInSeconds int64  `json:"expiresInSeconds"`
+	UserID           string `json:"userId"`
+	Email            string `json:"email"`
+	Name             string `json:"name"`
+	AvatarURL        string `json:"avatarUrl,omitempty"`
 }

--- a/go/auth-service/internal/service/auth.go
+++ b/go/auth-service/internal/service/auth.go
@@ -137,11 +137,12 @@ func (s *AuthService) generateTokens(user *model.User) (*model.AuthResponse, err
 	}
 
 	return &model.AuthResponse{
-		AccessToken:  accessToken,
-		RefreshToken: refreshToken,
-		UserID:       user.ID.String(),
-		Email:        user.Email,
-		Name:         user.Name,
-		AvatarURL:    avatar,
+		AccessToken:      accessToken,
+		RefreshToken:     refreshToken,
+		ExpiresInSeconds: int64(s.accessTokenTTL.Seconds()),
+		UserID:           user.ID.String(),
+		Email:            user.Email,
+		Name:             user.Name,
+		AvatarURL:        avatar,
 	}, nil
 }

--- a/go/eval-mcp-service/README.md
+++ b/go/eval-mcp-service/README.md
@@ -17,6 +17,10 @@ The service logs to stderr and reserves stdout for MCP protocol messages.
 ## Register With Codex
 
 ```bash
+export EVAL_MCP_AUTH_EMAIL='you@example.com'
+export EVAL_MCP_AUTH_PASSWORD='use-a-local-secret-source'
+export AUTH_SERVICE_URL='http://localhost:8091/auth'
+
 codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/eval-mcp-service && exec go run ./cmd/eval-mcp'
 ```
 
@@ -24,7 +28,18 @@ codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/e
 
 - `EVAL_MCP_DB_PATH`: SQLite path, defaults to `data/eval-mcp.db`.
 - `EVAL_API_URL`: eval API base URL, defaults to `http://localhost:8000/eval`.
-- `EVAL_API_TOKEN`: optional bearer token for authenticated eval API calls.
+- `EVAL_API_TOKEN`: optional bearer token override for eval API calls. When set,
+  the service skips auth-service login and token cache refresh.
+- `AUTH_SERVICE_URL`: auth-service base URL, defaults to
+  `http://localhost:8091/auth`.
+- `EVAL_MCP_AUTH_EMAIL`: auth-service email. Required when `EVAL_API_TOKEN` is
+  empty.
+- `EVAL_MCP_AUTH_PASSWORD`: auth-service password. Required when
+  `EVAL_API_TOKEN` is empty.
+- `EVAL_MCP_TOKEN_CACHE_PATH`: local token cache path, defaults to
+  `data/eval-mcp-auth.json`.
+- `EVAL_MCP_TOKEN_REFRESH_SKEW`: refresh lead time before access token expiry,
+  defaults to `1m`.
 - `EVAL_MCP_POLL_INTERVAL`: polling interval, defaults to `1s`.
 - `EVAL_MCP_WAIT_TIMEOUT`: wait timeout, defaults to `5m`.
 

--- a/go/eval-mcp-service/cmd/eval-mcp/main.go
+++ b/go/eval-mcp-service/cmd/eval-mcp/main.go
@@ -9,11 +9,14 @@ import (
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authclient"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authprovider"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/config"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalapi"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalworkflow"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/mcpserver"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/store"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
 )
 
 type app struct {
@@ -43,7 +46,21 @@ func run(ctx context.Context, logger *log.Logger, runServer serverRunner) error 
 	if err := db.Migrate(ctx); err != nil {
 		return fmt.Errorf("migrate store: %w", err)
 	}
-	api := evalapi.New(cfg.EvalAPIURL, cfg.APIToken, &http.Client{Timeout: cfg.WaitTimeout})
+	httpClient := &http.Client{Timeout: cfg.WaitTimeout}
+	var api *evalapi.Client
+	if cfg.APIToken != "" {
+		api = evalapi.New(cfg.EvalAPIURL, cfg.APIToken, httpClient)
+	} else {
+		authClient := authclient.New(cfg.AuthServiceURL, httpClient)
+		tokenStore := tokenstore.NewFileStore(cfg.TokenCachePath)
+		provider := authprovider.New(authClient, tokenStore, authprovider.Config{
+			Email:          cfg.AuthEmail,
+			Password:       cfg.AuthPassword,
+			AuthServiceURL: cfg.AuthServiceURL,
+			RefreshSkew:    cfg.TokenRefreshSkew,
+		})
+		api = evalapi.NewWithTokenProvider(cfg.EvalAPIURL, provider, httpClient)
+	}
 	service := evalworkflow.New(api, db, cfg.PollInterval, cfg.WaitTimeout)
 	logger.Printf("eval MCP server running on stdio eval_api_url=%s db_path=%s", cfg.EvalAPIURL, cfg.DBPath)
 	return runServer(ctx, &app{service: service, cfg: cfg})

--- a/go/eval-mcp-service/cmd/eval-mcp/main_test.go
+++ b/go/eval-mcp-service/cmd/eval-mcp/main_test.go
@@ -45,6 +45,44 @@ func TestRunWiresDependenciesAndCallsServer(t *testing.T) {
 	}
 }
 
+func TestRunAcceptsAuthServiceConfigWithoutStaticToken(t *testing.T) {
+	apiServer := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(apiServer.Close)
+	authServer := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(authServer.Close)
+
+	t.Setenv("EVAL_MCP_DB_PATH", filepath.Join(t.TempDir(), "eval-mcp.db"))
+	t.Setenv("EVAL_API_URL", apiServer.URL)
+	t.Setenv("EVAL_API_TOKEN", "")
+	t.Setenv("AUTH_SERVICE_URL", authServer.URL)
+	t.Setenv("EVAL_MCP_AUTH_EMAIL", "eval@example.test")
+	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "secret")
+	t.Setenv("EVAL_MCP_TOKEN_CACHE_PATH", filepath.Join(t.TempDir(), "tokens.json"))
+	t.Setenv("EVAL_MCP_POLL_INTERVAL", "10ms")
+	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "2s")
+
+	called := false
+	err := run(context.Background(), log.New(&bytes.Buffer{}, "", 0), func(_ context.Context, application *app) error {
+		called = true
+		if application.service == nil {
+			t.Fatal("expected service")
+		}
+		if application.cfg.APIToken != "" {
+			t.Fatalf("APIToken = %q", application.cfg.APIToken)
+		}
+		if application.cfg.AuthServiceURL != authServer.URL {
+			t.Fatalf("AuthServiceURL = %q", application.cfg.AuthServiceURL)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected runner to be called")
+	}
+}
+
 func TestRunReturnsConfigError(t *testing.T) {
 	t.Setenv("EVAL_MCP_POLL_INTERVAL", "nope")
 

--- a/go/eval-mcp-service/internal/authclient/client.go
+++ b/go/eval-mcp-service/internal/authclient/client.go
@@ -1,0 +1,120 @@
+package authclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultHTTPTimeout = 30 * time.Second
+	errorExcerptLimit  = 256
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type TokenResponse struct {
+	AccessToken      string `json:"accessToken"`
+	RefreshToken     string `json:"refreshToken"`
+	ExpiresInSeconds int64  `json:"expiresInSeconds"`
+}
+
+func New(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+func (c *Client) Login(ctx context.Context, email, password string) (TokenResponse, error) {
+	body := struct {
+		Email         string `json:"email"`
+		Password      string `json:"password"`
+		IncludeTokens bool   `json:"includeTokens"`
+	}{
+		Email:         email,
+		Password:      password,
+		IncludeTokens: true,
+	}
+
+	var response TokenResponse
+	if err := c.do(ctx, http.MethodPost, "/login", body, &response); err != nil {
+		return TokenResponse{}, err
+	}
+	if err := validateTokenResponse(response); err != nil {
+		return TokenResponse{}, fmt.Errorf("POST /login: %w", err)
+	}
+	return response, nil
+}
+
+func (c *Client) Refresh(ctx context.Context, refreshToken string) (TokenResponse, error) {
+	body := struct {
+		RefreshToken  string `json:"refreshToken"`
+		IncludeTokens bool   `json:"includeTokens"`
+	}{
+		RefreshToken:  refreshToken,
+		IncludeTokens: true,
+	}
+
+	var response TokenResponse
+	if err := c.do(ctx, http.MethodPost, "/refresh", body, &response); err != nil {
+		return TokenResponse{}, err
+	}
+	if err := validateTokenResponse(response); err != nil {
+		return TokenResponse{}, fmt.Errorf("POST /refresh: %w", err)
+	}
+	return response, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		return fmt.Errorf("%s %s: encode request: %w", method, path, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, &buf)
+	if err != nil {
+		return fmt.Errorf("%s %s: create request: %w", method, path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, errorExcerptLimit))
+		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(excerpt)))
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("%s %s: decode response: %w", method, path, err)
+	}
+	return nil
+}
+
+func validateTokenResponse(response TokenResponse) error {
+	switch {
+	case response.AccessToken == "":
+		return fmt.Errorf("missing access token")
+	case response.RefreshToken == "":
+		return fmt.Errorf("missing refresh token")
+	case response.ExpiresInSeconds <= 0:
+		return fmt.Errorf("expiresInSeconds must be positive")
+	default:
+		return nil
+	}
+}

--- a/go/eval-mcp-service/internal/authclient/client.go
+++ b/go/eval-mcp-service/internal/authclient/client.go
@@ -111,9 +111,30 @@ func redact(value string, redactions ...string) string {
 		if secret == "" {
 			continue
 		}
-		value = strings.ReplaceAll(value, secret, "[REDACTED]")
+		for _, variant := range secretVariants(secret) {
+			value = strings.ReplaceAll(value, variant, "[REDACTED]")
+			for prefixLen := len(variant) - 1; prefixLen >= 8; prefixLen-- {
+				value = strings.ReplaceAll(value, variant[:prefixLen], "[REDACTED]")
+			}
+		}
+	}
+	if len(value) > errorExcerptLimit {
+		return value[:errorExcerptLimit]
 	}
 	return value
+}
+
+func secretVariants(secret string) []string {
+	quoted, err := json.Marshal(secret)
+	if err != nil {
+		return []string{secret}
+	}
+
+	escaped := strings.Trim(string(quoted), `"`)
+	if escaped == secret {
+		return []string{secret}
+	}
+	return []string{secret, escaped}
 }
 
 func validateTokenResponse(response TokenResponse) error {

--- a/go/eval-mcp-service/internal/authclient/client.go
+++ b/go/eval-mcp-service/internal/authclient/client.go
@@ -49,7 +49,7 @@ func (c *Client) Login(ctx context.Context, email, password string) (TokenRespon
 	}
 
 	var response TokenResponse
-	if err := c.do(ctx, http.MethodPost, "/login", body, &response); err != nil {
+	if err := c.do(ctx, http.MethodPost, "/login", body, &response, password); err != nil {
 		return TokenResponse{}, err
 	}
 	if err := validateTokenResponse(response); err != nil {
@@ -68,7 +68,7 @@ func (c *Client) Refresh(ctx context.Context, refreshToken string) (TokenRespons
 	}
 
 	var response TokenResponse
-	if err := c.do(ctx, http.MethodPost, "/refresh", body, &response); err != nil {
+	if err := c.do(ctx, http.MethodPost, "/refresh", body, &response, refreshToken); err != nil {
 		return TokenResponse{}, err
 	}
 	if err := validateTokenResponse(response); err != nil {
@@ -77,7 +77,7 @@ func (c *Client) Refresh(ctx context.Context, refreshToken string) (TokenRespons
 	return response, nil
 }
 
-func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+func (c *Client) do(ctx context.Context, method, path string, body any, out any, redactions ...string) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(body); err != nil {
 		return fmt.Errorf("%s %s: encode request: %w", method, path, err)
@@ -97,13 +97,23 @@ func (c *Client) do(ctx context.Context, method, path string, body any, out any)
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, errorExcerptLimit))
-		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(excerpt)))
+		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, redact(strings.TrimSpace(string(excerpt)), redactions...))
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return fmt.Errorf("%s %s: decode response: %w", method, path, err)
 	}
 	return nil
+}
+
+func redact(value string, redactions ...string) string {
+	for _, secret := range redactions {
+		if secret == "" {
+			continue
+		}
+		value = strings.ReplaceAll(value, secret, "[REDACTED]")
+	}
+	return value
 }
 
 func validateTokenResponse(response TokenResponse) error {

--- a/go/eval-mcp-service/internal/authclient/client_test.go
+++ b/go/eval-mcp-service/internal/authclient/client_test.go
@@ -160,6 +160,61 @@ func TestRefreshHTTPErrorRedactsSubmittedRefreshToken(t *testing.T) {
 	}
 }
 
+func TestRefreshHTTPErrorRedactsLongSubmittedRefreshTokenPrefix(t *testing.T) {
+	refreshToken := strings.Repeat("refresh-token-prefix-", 30)
+	leakedPrefix := refreshToken[:120]
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "invalid refresh token "+refreshToken, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth", server.Client())
+	_, err := client.Refresh(context.Background(), refreshToken)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("error = %q, want redaction marker", got)
+	}
+	if strings.Contains(got, leakedPrefix) {
+		t.Fatalf("error leaked refresh token prefix: %q", got)
+	}
+	if len(got) > len("POST /refresh: status 401: ")+errorExcerptLimit {
+		t.Fatalf("error excerpt was not bounded after redaction: %q", got)
+	}
+}
+
+func TestLoginHTTPErrorRedactsJSONEscapedSubmittedPassword(t *testing.T) {
+	password := `json-"secret"\value`
+	escapedPasswordBytes, err := json.Marshal(password)
+	if err != nil {
+		t.Fatalf("marshal password: %v", err)
+	}
+	escapedPassword := strings.Trim(string(escapedPasswordBytes), `"`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid password ` + escapedPassword + `"}`))
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth", server.Client())
+	_, err = client.Login(context.Background(), "user@example.test", password)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("error = %q, want redaction marker", got)
+	}
+	for _, leaked := range []string{password, escapedPassword} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("error leaked password value %q: %q", leaked, got)
+		}
+	}
+}
+
 func TestRejectsInvalidTokenResponse(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/go/eval-mcp-service/internal/authclient/client_test.go
+++ b/go/eval-mcp-service/internal/authclient/client_test.go
@@ -1,0 +1,160 @@
+package authclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoginSendsIncludeTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/auth/login" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q", got)
+		}
+
+		var body struct {
+			Email         string `json:"email"`
+			Password      string `json:"password"`
+			IncludeTokens bool   `json:"includeTokens"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Email != "user@example.test" || body.Password != "secret" || !body.IncludeTokens {
+			t.Fatalf("body = %#v", body)
+		}
+
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:      "access-1",
+			RefreshToken:     "refresh-1",
+			ExpiresInSeconds: 3600,
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth/", server.Client())
+	got, err := client.Login(context.Background(), "user@example.test", "secret")
+	if err != nil {
+		t.Fatalf("Login error: %v", err)
+	}
+	if got.AccessToken != "access-1" || got.RefreshToken != "refresh-1" || got.ExpiresInSeconds != 3600 {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestRefreshSendsIncludeTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s", r.Method)
+		}
+		if r.URL.Path != "/auth/refresh" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+
+		var body struct {
+			RefreshToken  string `json:"refreshToken"`
+			IncludeTokens bool   `json:"includeTokens"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.RefreshToken != "refresh-old" || !body.IncludeTokens {
+			t.Fatalf("body = %#v", body)
+		}
+
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken:      "access-new",
+			RefreshToken:     "refresh-new",
+			ExpiresInSeconds: 1800,
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth", server.Client())
+	got, err := client.Refresh(context.Background(), "refresh-old")
+	if err != nil {
+		t.Fatalf("Refresh error: %v", err)
+	}
+	if got.AccessToken != "access-new" || got.RefreshToken != "refresh-new" || got.ExpiresInSeconds != 1800 {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestHTTPErrorIncludesStatusAndBoundedExcerpt(t *testing.T) {
+	body := strings.Repeat("x", 300)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, body, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth", server.Client())
+	_, err := client.Login(context.Background(), "user@example.test", "bad-password")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	for _, want := range []string{"POST", "/login", "status 401"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, strings.Repeat("x", 257)) {
+		t.Fatalf("error excerpt was not bounded: %q", got)
+	}
+	if !strings.Contains(got, strings.Repeat("x", 256)) {
+		t.Fatalf("error = %q, want 256-byte excerpt", got)
+	}
+}
+
+func TestRejectsInvalidTokenResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response TokenResponse
+		want     string
+	}{
+		{name: "missing access token", response: TokenResponse{RefreshToken: "refresh", ExpiresInSeconds: 1}, want: "missing access token"},
+		{name: "missing refresh token", response: TokenResponse{AccessToken: "access", ExpiresInSeconds: 1}, want: "missing refresh token"},
+		{name: "non-positive expiry", response: TokenResponse{AccessToken: "access", RefreshToken: "refresh"}, want: "expiresInSeconds must be positive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			client := New(server.URL, server.Client())
+			_, err := client.Login(context.Background(), "user@example.test", "secret")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewUsesDefaultHTTPClient(t *testing.T) {
+	client := New("http://example.test/auth/", nil)
+	if client.baseURL != "http://example.test/auth" {
+		t.Fatalf("baseURL = %q", client.baseURL)
+	}
+	if client.httpClient == nil {
+		t.Fatal("httpClient is nil")
+	}
+	if client.httpClient.Timeout != 30*time.Second {
+		t.Fatalf("timeout = %s", client.httpClient.Timeout)
+	}
+}

--- a/go/eval-mcp-service/internal/authclient/client_test.go
+++ b/go/eval-mcp-service/internal/authclient/client_test.go
@@ -116,6 +116,50 @@ func TestHTTPErrorIncludesStatusAndBoundedExcerpt(t *testing.T) {
 	}
 }
 
+func TestLoginHTTPErrorRedactsSubmittedPassword(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `invalid password "super-secret-password"`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth", server.Client())
+	_, err := client.Login(context.Background(), "user@example.test", "super-secret-password")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	for _, want := range []string{"POST", "/login", "status 401", "[REDACTED]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, "super-secret-password") {
+		t.Fatalf("error leaked password: %q", got)
+	}
+}
+
+func TestRefreshHTTPErrorRedactsSubmittedRefreshToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `invalid refresh token refresh-token-secret`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := New(server.URL+"/auth", server.Client())
+	_, err := client.Refresh(context.Background(), "refresh-token-secret")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	for _, want := range []string{"POST", "/refresh", "status 401", "[REDACTED]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	}
+	if strings.Contains(got, "refresh-token-secret") {
+		t.Fatalf("error leaked refresh token: %q", got)
+	}
+}
+
 func TestRejectsInvalidTokenResponse(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/go/eval-mcp-service/internal/authprovider/provider.go
+++ b/go/eval-mcp-service/internal/authprovider/provider.go
@@ -2,6 +2,7 @@ package authprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -62,17 +63,23 @@ func (p *Provider) Token(ctx context.Context) (string, error) {
 		return state.AccessToken, nil
 	}
 
-	p.invalidated = false
-
+	var refreshErr error
 	if ok && p.cacheIdentityMatches(state) && state.RefreshToken != "" {
 		response, err := p.client.Refresh(ctx, state.RefreshToken)
 		if err == nil {
 			return p.saveAndReturn(ctx, now, response)
 		}
+		refreshErr = err
 	}
 
 	response, err := p.client.Login(ctx, p.cfg.Email, p.cfg.Password)
 	if err != nil {
+		if refreshErr != nil {
+			return "", fmt.Errorf("replace token: %w", errors.Join(
+				fmt.Errorf("refresh: %w", refreshErr),
+				fmt.Errorf("login: %w", err),
+			))
+		}
 		return "", fmt.Errorf("login: %w", err)
 	}
 	return p.saveAndReturn(ctx, now, response)
@@ -106,5 +113,6 @@ func (p *Provider) saveAndReturn(ctx context.Context, now time.Time, response au
 	if err := p.store.Save(ctx, state); err != nil {
 		return "", fmt.Errorf("save token state: %w", err)
 	}
+	p.invalidated = false
 	return response.AccessToken, nil
 }

--- a/go/eval-mcp-service/internal/authprovider/provider.go
+++ b/go/eval-mcp-service/internal/authprovider/provider.go
@@ -1,0 +1,110 @@
+package authprovider
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authclient"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
+)
+
+type AuthClient interface {
+	Login(context.Context, string, string) (authclient.TokenResponse, error)
+	Refresh(context.Context, string) (authclient.TokenResponse, error)
+}
+
+type Store interface {
+	Load(context.Context) (tokenstore.State, bool, error)
+	Save(context.Context, tokenstore.State) error
+}
+
+type Config struct {
+	Email          string
+	Password       string
+	AuthServiceURL string
+	RefreshSkew    time.Duration
+	Now            func() time.Time
+}
+
+type Provider struct {
+	client AuthClient
+	store  Store
+	cfg    Config
+
+	mu          sync.Mutex
+	invalidated bool
+}
+
+func New(client AuthClient, store Store, cfg Config) *Provider {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Provider{
+		client: client,
+		store:  store,
+		cfg:    cfg,
+	}
+}
+
+func (p *Provider) Token(ctx context.Context) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	state, ok, err := p.store.Load(ctx)
+	if err != nil {
+		return "", fmt.Errorf("load token state: %w", err)
+	}
+
+	now := p.cfg.Now().UTC()
+	if ok && p.cacheCanReuseAccess(state) && !p.invalidated && now.Add(p.cfg.RefreshSkew).Before(state.AccessTokenExp) {
+		return state.AccessToken, nil
+	}
+
+	p.invalidated = false
+
+	if ok && p.cacheIdentityMatches(state) && state.RefreshToken != "" {
+		response, err := p.client.Refresh(ctx, state.RefreshToken)
+		if err == nil {
+			return p.saveAndReturn(ctx, now, response)
+		}
+	}
+
+	response, err := p.client.Login(ctx, p.cfg.Email, p.cfg.Password)
+	if err != nil {
+		return "", fmt.Errorf("login: %w", err)
+	}
+	return p.saveAndReturn(ctx, now, response)
+}
+
+func (p *Provider) Invalidate() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.invalidated = true
+}
+
+func (p *Provider) cacheCanReuseAccess(state tokenstore.State) bool {
+	return p.cacheIdentityMatches(state) && state.AccessToken != ""
+}
+
+func (p *Provider) cacheIdentityMatches(state tokenstore.State) bool {
+	return state.AuthEmail == p.cfg.Email &&
+		state.AuthServiceURL == p.cfg.AuthServiceURL
+}
+
+func (p *Provider) saveAndReturn(ctx context.Context, now time.Time, response authclient.TokenResponse) (string, error) {
+	state := tokenstore.State{
+		AccessToken:    response.AccessToken,
+		RefreshToken:   response.RefreshToken,
+		AccessTokenExp: now.Add(time.Duration(response.ExpiresInSeconds) * time.Second),
+		AuthEmail:      p.cfg.Email,
+		AuthServiceURL: p.cfg.AuthServiceURL,
+		WrittenAt:      now,
+	}
+	if err := p.store.Save(ctx, state); err != nil {
+		return "", fmt.Errorf("save token state: %w", err)
+	}
+	return response.AccessToken, nil
+}

--- a/go/eval-mcp-service/internal/authprovider/provider_test.go
+++ b/go/eval-mcp-service/internal/authprovider/provider_test.go
@@ -1,0 +1,253 @@
+package authprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/authclient"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
+)
+
+func TestTokenReusesValidCachedAccessToken(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		state: tokenstore.State{
+			AccessToken:    "access-cached",
+			RefreshToken:   "refresh-cached",
+			AccessTokenExp: now.Add(2 * time.Minute),
+			AuthEmail:      "user@example.test",
+			AuthServiceURL: "http://auth.test/auth",
+		},
+		ok: true,
+	}
+	client := &fakeClient{}
+	provider := New(client, store, testConfig(now))
+
+	got, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if got != "access-cached" {
+		t.Fatalf("token = %q", got)
+	}
+	if client.loginCalls != 0 || client.refreshCalls != 0 {
+		t.Fatalf("client calls: login=%d refresh=%d", client.loginCalls, client.refreshCalls)
+	}
+	if len(store.saves) != 0 {
+		t.Fatalf("saves = %#v", store.saves)
+	}
+}
+
+func TestTokenRefreshesNearExpiryAndSavesNewExpiry(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		state: tokenstore.State{
+			AccessToken:    "access-old",
+			RefreshToken:   "refresh-old",
+			AccessTokenExp: now.Add(30 * time.Second),
+			AuthEmail:      "user@example.test",
+			AuthServiceURL: "http://auth.test/auth",
+		},
+		ok: true,
+	}
+	client := &fakeClient{
+		refreshResponse: authclient.TokenResponse{
+			AccessToken:      "access-new",
+			RefreshToken:     "refresh-new",
+			ExpiresInSeconds: 120,
+		},
+	}
+	provider := New(client, store, testConfig(now))
+
+	got, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if got != "access-new" {
+		t.Fatalf("token = %q", got)
+	}
+	if client.refreshCalls != 1 || client.loginCalls != 0 {
+		t.Fatalf("client calls: login=%d refresh=%d", client.loginCalls, client.refreshCalls)
+	}
+	if client.refreshToken != "refresh-old" {
+		t.Fatalf("refresh token = %q", client.refreshToken)
+	}
+	assertSavedState(t, store, tokenstore.State{
+		AccessToken:    "access-new",
+		RefreshToken:   "refresh-new",
+		AccessTokenExp: now.Add(120 * time.Second),
+		AuthEmail:      "user@example.test",
+		AuthServiceURL: "http://auth.test/auth",
+		WrittenAt:      now,
+	})
+}
+
+func TestTokenFallsBackToLoginWhenRefreshFails(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		state: tokenstore.State{
+			AccessToken:    "access-old",
+			RefreshToken:   "refresh-old",
+			AccessTokenExp: now.Add(-time.Second),
+			AuthEmail:      "user@example.test",
+			AuthServiceURL: "http://auth.test/auth",
+		},
+		ok: true,
+	}
+	client := &fakeClient{
+		refreshErr: errors.New("refresh failed"),
+		loginResponse: authclient.TokenResponse{
+			AccessToken:      "access-login",
+			RefreshToken:     "refresh-login",
+			ExpiresInSeconds: 300,
+		},
+	}
+	provider := New(client, store, testConfig(now))
+
+	got, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if got != "access-login" {
+		t.Fatalf("token = %q", got)
+	}
+	if client.refreshCalls != 1 || client.loginCalls != 1 {
+		t.Fatalf("client calls: login=%d refresh=%d", client.loginCalls, client.refreshCalls)
+	}
+	if client.loginEmail != "user@example.test" || client.loginPassword != "secret" {
+		t.Fatalf("login credentials: email=%q password=%q", client.loginEmail, client.loginPassword)
+	}
+	assertSavedState(t, store, tokenstore.State{
+		AccessToken:    "access-login",
+		RefreshToken:   "refresh-login",
+		AccessTokenExp: now.Add(300 * time.Second),
+		AuthEmail:      "user@example.test",
+		AuthServiceURL: "http://auth.test/auth",
+		WrittenAt:      now,
+	})
+}
+
+func TestInvalidateForcesRefreshForValidCachedAccessToken(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		state: tokenstore.State{
+			AccessToken:    "access-cached",
+			RefreshToken:   "refresh-cached",
+			AccessTokenExp: now.Add(2 * time.Minute),
+			AuthEmail:      "user@example.test",
+			AuthServiceURL: "http://auth.test/auth",
+		},
+		ok: true,
+	}
+	client := &fakeClient{
+		refreshResponse: authclient.TokenResponse{
+			AccessToken:      "access-refreshed",
+			RefreshToken:     "refresh-refreshed",
+			ExpiresInSeconds: 180,
+		},
+	}
+	provider := New(client, store, testConfig(now))
+
+	provider.Invalidate()
+	got, err := provider.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token error: %v", err)
+	}
+	if got != "access-refreshed" {
+		t.Fatalf("token = %q", got)
+	}
+	if client.refreshCalls != 1 || client.loginCalls != 0 {
+		t.Fatalf("client calls: login=%d refresh=%d", client.loginCalls, client.refreshCalls)
+	}
+	assertSavedState(t, store, tokenstore.State{
+		AccessToken:    "access-refreshed",
+		RefreshToken:   "refresh-refreshed",
+		AccessTokenExp: now.Add(180 * time.Second),
+		AuthEmail:      "user@example.test",
+		AuthServiceURL: "http://auth.test/auth",
+		WrittenAt:      now,
+	})
+}
+
+func testConfig(now time.Time) Config {
+	return Config{
+		Email:          "user@example.test",
+		Password:       "secret",
+		AuthServiceURL: "http://auth.test/auth",
+		RefreshSkew:    time.Minute,
+		Now: func() time.Time {
+			return now
+		},
+	}
+}
+
+func assertSavedState(t *testing.T, store *fakeStore, want tokenstore.State) {
+	t.Helper()
+
+	if len(store.saves) != 1 {
+		t.Fatalf("save count = %d", len(store.saves))
+	}
+	got := store.saves[0]
+	if got.AccessToken != want.AccessToken ||
+		got.RefreshToken != want.RefreshToken ||
+		!got.AccessTokenExp.Equal(want.AccessTokenExp) ||
+		got.AuthEmail != want.AuthEmail ||
+		got.AuthServiceURL != want.AuthServiceURL ||
+		!got.WrittenAt.Equal(want.WrittenAt) {
+		t.Fatalf("saved state = %#v, want %#v", got, want)
+	}
+}
+
+type fakeClient struct {
+	loginResponse   authclient.TokenResponse
+	loginErr        error
+	loginCalls      int
+	loginEmail      string
+	loginPassword   string
+	refreshResponse authclient.TokenResponse
+	refreshErr      error
+	refreshCalls    int
+	refreshToken    string
+}
+
+func (c *fakeClient) Login(_ context.Context, email, password string) (authclient.TokenResponse, error) {
+	c.loginCalls++
+	c.loginEmail = email
+	c.loginPassword = password
+	if c.loginErr != nil {
+		return authclient.TokenResponse{}, c.loginErr
+	}
+	return c.loginResponse, nil
+}
+
+func (c *fakeClient) Refresh(_ context.Context, refreshToken string) (authclient.TokenResponse, error) {
+	c.refreshCalls++
+	c.refreshToken = refreshToken
+	if c.refreshErr != nil {
+		return authclient.TokenResponse{}, c.refreshErr
+	}
+	return c.refreshResponse, nil
+}
+
+type fakeStore struct {
+	state tokenstore.State
+	ok    bool
+	err   error
+	saves []tokenstore.State
+}
+
+func (s *fakeStore) Load(context.Context) (tokenstore.State, bool, error) {
+	if s.err != nil {
+		return tokenstore.State{}, false, s.err
+	}
+	return s.state, s.ok, nil
+}
+
+func (s *fakeStore) Save(_ context.Context, state tokenstore.State) error {
+	s.saves = append(s.saves, state)
+	s.state = state
+	s.ok = true
+	return nil
+}

--- a/go/eval-mcp-service/internal/authprovider/provider_test.go
+++ b/go/eval-mcp-service/internal/authprovider/provider_test.go
@@ -3,6 +3,7 @@ package authprovider
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,6 +130,41 @@ func TestTokenFallsBackToLoginWhenRefreshFails(t *testing.T) {
 	})
 }
 
+func TestTokenReportsRefreshContextWhenFallbackLoginFails(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	store := &fakeStore{
+		state: tokenstore.State{
+			AccessToken:    "access-old",
+			RefreshToken:   "refresh-old",
+			AccessTokenExp: now.Add(-time.Second),
+			AuthEmail:      "user@example.test",
+			AuthServiceURL: "http://auth.test/auth",
+		},
+		ok: true,
+	}
+	client := &fakeClient{
+		refreshErr: errors.New("auth service rejected refresh"),
+		loginErr:   errors.New("auth service rejected login"),
+	}
+	provider := New(client, store, testConfig(now))
+
+	_, err := provider.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	for _, want := range []string{"refresh", "auth service rejected refresh", "login", "auth service rejected login"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error = %q, want %q", got, want)
+		}
+	}
+	for _, sensitive := range []string{"refresh-old", "secret"} {
+		if strings.Contains(got, sensitive) {
+			t.Fatalf("error leaked sensitive value %q: %q", sensitive, got)
+		}
+	}
+}
+
 func TestInvalidateForcesRefreshForValidCachedAccessToken(t *testing.T) {
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	store := &fakeStore{
@@ -169,6 +205,70 @@ func TestInvalidateForcesRefreshForValidCachedAccessToken(t *testing.T) {
 		AuthServiceURL: "http://auth.test/auth",
 		WrittenAt:      now,
 	})
+}
+
+func TestInvalidatePersistsWhenReplacementFails(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		client      *fakeClient
+		saveErr     error
+		wantRefresh int
+		wantLogin   int
+	}{
+		{
+			name: "refresh and login fail",
+			client: &fakeClient{
+				refreshErr: errors.New("refresh unavailable"),
+				loginErr:   errors.New("login unavailable"),
+			},
+			wantRefresh: 2,
+			wantLogin:   2,
+		},
+		{
+			name: "save fails after refresh",
+			client: &fakeClient{
+				refreshResponse: authclient.TokenResponse{
+					AccessToken:      "access-refreshed",
+					RefreshToken:     "refresh-refreshed",
+					ExpiresInSeconds: 180,
+				},
+			},
+			saveErr:     errors.New("disk unavailable"),
+			wantRefresh: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fakeStore{
+				state: tokenstore.State{
+					AccessToken:    "access-cached",
+					RefreshToken:   "refresh-cached",
+					AccessTokenExp: now.Add(2 * time.Minute),
+					AuthEmail:      "user@example.test",
+					AuthServiceURL: "http://auth.test/auth",
+				},
+				ok:      true,
+				saveErr: tt.saveErr,
+			}
+			provider := New(tt.client, store, testConfig(now))
+
+			provider.Invalidate()
+			for i := 0; i < 2; i++ {
+				got, err := provider.Token(context.Background())
+				if err == nil {
+					t.Fatalf("Token call %d returned token %q, expected error", i+1, got)
+				}
+				if got == "access-cached" {
+					t.Fatalf("Token call %d reused invalidated cached token", i+1)
+				}
+			}
+			if tt.client.refreshCalls != tt.wantRefresh || tt.client.loginCalls != tt.wantLogin {
+				t.Fatalf("client calls: login=%d refresh=%d, want login=%d refresh=%d", tt.client.loginCalls, tt.client.refreshCalls, tt.wantLogin, tt.wantRefresh)
+			}
+		})
+	}
 }
 
 func testConfig(now time.Time) Config {
@@ -232,10 +332,11 @@ func (c *fakeClient) Refresh(_ context.Context, refreshToken string) (authclient
 }
 
 type fakeStore struct {
-	state tokenstore.State
-	ok    bool
-	err   error
-	saves []tokenstore.State
+	state   tokenstore.State
+	ok      bool
+	err     error
+	saveErr error
+	saves   []tokenstore.State
 }
 
 func (s *fakeStore) Load(context.Context) (tokenstore.State, bool, error) {
@@ -246,6 +347,9 @@ func (s *fakeStore) Load(context.Context) (tokenstore.State, bool, error) {
 }
 
 func (s *fakeStore) Save(_ context.Context, state tokenstore.State) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
 	s.saves = append(s.saves, state)
 	s.state = state
 	s.ok = true

--- a/go/eval-mcp-service/internal/config/config.go
+++ b/go/eval-mcp-service/internal/config/config.go
@@ -7,18 +7,26 @@ import (
 )
 
 const (
-	defaultDBPath       = "data/eval-mcp.db"
-	defaultEvalAPIURL   = "http://localhost:8000/eval"
-	defaultPollInterval = time.Second
-	defaultWaitTimeout  = 5 * time.Minute
+	defaultDBPath           = "data/eval-mcp.db"
+	defaultEvalAPIURL       = "http://localhost:8000/eval"
+	defaultAuthServiceURL   = "http://localhost:8091/auth"
+	defaultTokenCachePath   = "data/eval-mcp-auth.json"
+	defaultPollInterval     = time.Second
+	defaultWaitTimeout      = 5 * time.Minute
+	defaultTokenRefreshSkew = time.Minute
 )
 
 type Config struct {
-	DBPath       string
-	EvalAPIURL   string
-	APIToken     string
-	PollInterval time.Duration
-	WaitTimeout  time.Duration
+	DBPath           string
+	EvalAPIURL       string
+	APIToken         string
+	AuthServiceURL   string
+	AuthEmail        string
+	AuthPassword     string
+	TokenCachePath   string
+	PollInterval     time.Duration
+	WaitTimeout      time.Duration
+	TokenRefreshSkew time.Duration
 }
 
 func FromEnv() (Config, error) {
@@ -30,18 +38,43 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	tokenRefreshSkew, err := durationEnv("EVAL_MCP_TOKEN_REFRESH_SKEW", defaultTokenRefreshSkew)
+	if err != nil {
+		return Config{}, err
+	}
 	if pollInterval <= 0 {
 		return Config{}, fmt.Errorf("EVAL_MCP_POLL_INTERVAL must be positive")
 	}
 	if waitTimeout <= 0 {
 		return Config{}, fmt.Errorf("EVAL_MCP_WAIT_TIMEOUT must be positive")
 	}
+	if tokenRefreshSkew <= 0 {
+		return Config{}, fmt.Errorf("EVAL_MCP_TOKEN_REFRESH_SKEW must be positive")
+	}
+
+	apiToken := os.Getenv("EVAL_API_TOKEN")
+	authEmail := os.Getenv("EVAL_MCP_AUTH_EMAIL")
+	authPassword := os.Getenv("EVAL_MCP_AUTH_PASSWORD")
+	if apiToken == "" {
+		if authEmail == "" {
+			return Config{}, fmt.Errorf("EVAL_MCP_AUTH_EMAIL is required when EVAL_API_TOKEN is empty")
+		}
+		if authPassword == "" {
+			return Config{}, fmt.Errorf("EVAL_MCP_AUTH_PASSWORD is required when EVAL_API_TOKEN is empty")
+		}
+	}
+
 	return Config{
-		DBPath:       getenv("EVAL_MCP_DB_PATH", defaultDBPath),
-		EvalAPIURL:   getenv("EVAL_API_URL", defaultEvalAPIURL),
-		APIToken:     os.Getenv("EVAL_API_TOKEN"),
-		PollInterval: pollInterval,
-		WaitTimeout:  waitTimeout,
+		DBPath:           getenv("EVAL_MCP_DB_PATH", defaultDBPath),
+		EvalAPIURL:       getenv("EVAL_API_URL", defaultEvalAPIURL),
+		APIToken:         apiToken,
+		AuthServiceURL:   getenv("AUTH_SERVICE_URL", defaultAuthServiceURL),
+		AuthEmail:        authEmail,
+		AuthPassword:     authPassword,
+		TokenCachePath:   getenv("EVAL_MCP_TOKEN_CACHE_PATH", defaultTokenCachePath),
+		PollInterval:     pollInterval,
+		WaitTimeout:      waitTimeout,
+		TokenRefreshSkew: tokenRefreshSkew,
 	}, nil
 }
 

--- a/go/eval-mcp-service/internal/config/config_test.go
+++ b/go/eval-mcp-service/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -97,16 +98,19 @@ func TestFromEnvStaticTokenBypassesAuthCredentials(t *testing.T) {
 func TestFromEnvRequiresAuthConfigWithoutStaticToken(t *testing.T) {
 	tests := []struct {
 		name     string
+		envVar   string
 		email    string
 		password string
 	}{
 		{
 			name:     "missing email",
+			envVar:   "EVAL_MCP_AUTH_EMAIL",
 			password: "secret",
 		},
 		{
-			name:  "missing password",
-			email: "user@example.test",
+			name:   "missing password",
+			envVar: "EVAL_MCP_AUTH_PASSWORD",
+			email:  "user@example.test",
 		},
 	}
 
@@ -115,10 +119,16 @@ func TestFromEnvRequiresAuthConfigWithoutStaticToken(t *testing.T) {
 			t.Setenv("EVAL_API_TOKEN", "")
 			t.Setenv("EVAL_MCP_AUTH_EMAIL", tt.email)
 			t.Setenv("EVAL_MCP_AUTH_PASSWORD", tt.password)
+			t.Setenv("EVAL_MCP_POLL_INTERVAL", "")
+			t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "")
+			t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "")
 
 			_, err := FromEnv()
 			if err == nil {
 				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.envVar) {
+				t.Fatalf("error = %q, want %q", err, tt.envVar)
 			}
 		})
 	}

--- a/go/eval-mcp-service/internal/config/config_test.go
+++ b/go/eval-mcp-service/internal/config/config_test.go
@@ -9,8 +9,13 @@ func TestFromEnvDefaults(t *testing.T) {
 	t.Setenv("EVAL_MCP_DB_PATH", "")
 	t.Setenv("EVAL_API_URL", "")
 	t.Setenv("EVAL_API_TOKEN", "")
+	t.Setenv("AUTH_SERVICE_URL", "")
+	t.Setenv("EVAL_MCP_AUTH_EMAIL", "user@example.test")
+	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "secret")
+	t.Setenv("EVAL_MCP_TOKEN_CACHE_PATH", "")
 	t.Setenv("EVAL_MCP_POLL_INTERVAL", "")
 	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "")
+	t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "")
 
 	cfg, err := FromEnv()
 	if err != nil {
@@ -25,11 +30,26 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.APIToken != "" {
 		t.Fatalf("APIToken = %q", cfg.APIToken)
 	}
+	if cfg.AuthServiceURL != "http://localhost:8091/auth" {
+		t.Fatalf("AuthServiceURL = %q", cfg.AuthServiceURL)
+	}
+	if cfg.AuthEmail != "user@example.test" {
+		t.Fatalf("AuthEmail = %q", cfg.AuthEmail)
+	}
+	if cfg.AuthPassword != "secret" {
+		t.Fatalf("AuthPassword = %q", cfg.AuthPassword)
+	}
+	if cfg.TokenCachePath != "data/eval-mcp-auth.json" {
+		t.Fatalf("TokenCachePath = %q", cfg.TokenCachePath)
+	}
 	if cfg.PollInterval != time.Second {
 		t.Fatalf("PollInterval = %s", cfg.PollInterval)
 	}
 	if cfg.WaitTimeout != 5*time.Minute {
 		t.Fatalf("WaitTimeout = %s", cfg.WaitTimeout)
+	}
+	if cfg.TokenRefreshSkew != time.Minute {
+		t.Fatalf("TokenRefreshSkew = %s", cfg.TokenRefreshSkew)
 	}
 }
 
@@ -37,18 +57,70 @@ func TestFromEnvOverrides(t *testing.T) {
 	t.Setenv("EVAL_MCP_DB_PATH", "/tmp/eval.db")
 	t.Setenv("EVAL_API_URL", "http://127.0.0.1:9000/eval")
 	t.Setenv("EVAL_API_TOKEN", "token-123")
+	t.Setenv("AUTH_SERVICE_URL", "http://127.0.0.1:8091/auth")
+	t.Setenv("EVAL_MCP_AUTH_EMAIL", "user@example.test")
+	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "secret")
+	t.Setenv("EVAL_MCP_TOKEN_CACHE_PATH", "/tmp/tokens.json")
 	t.Setenv("EVAL_MCP_POLL_INTERVAL", "250ms")
 	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "30s")
+	t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "2m")
 
 	cfg, err := FromEnv()
 	if err != nil {
 		t.Fatalf("FromEnv returned error: %v", err)
 	}
-	if cfg.DBPath != "/tmp/eval.db" || cfg.EvalAPIURL != "http://127.0.0.1:9000/eval" || cfg.APIToken != "token-123" {
+	if cfg.DBPath != "/tmp/eval.db" || cfg.EvalAPIURL != "http://127.0.0.1:9000/eval" || cfg.APIToken != "token-123" || cfg.AuthServiceURL != "http://127.0.0.1:8091/auth" || cfg.AuthEmail != "user@example.test" || cfg.AuthPassword != "secret" || cfg.TokenCachePath != "/tmp/tokens.json" {
 		t.Fatalf("unexpected config: %#v", cfg)
 	}
-	if cfg.PollInterval != 250*time.Millisecond || cfg.WaitTimeout != 30*time.Second {
+	if cfg.PollInterval != 250*time.Millisecond || cfg.WaitTimeout != 30*time.Second || cfg.TokenRefreshSkew != 2*time.Minute {
 		t.Fatalf("unexpected durations: %#v", cfg)
+	}
+}
+
+func TestFromEnvStaticTokenBypassesAuthCredentials(t *testing.T) {
+	t.Setenv("EVAL_API_TOKEN", "token-123")
+	t.Setenv("EVAL_MCP_AUTH_EMAIL", "")
+	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv returned error: %v", err)
+	}
+	if cfg.APIToken != "token-123" {
+		t.Fatalf("APIToken = %q", cfg.APIToken)
+	}
+	if cfg.AuthEmail != "" || cfg.AuthPassword != "" {
+		t.Fatalf("unexpected auth credentials: %#v", cfg)
+	}
+}
+
+func TestFromEnvRequiresAuthConfigWithoutStaticToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		email    string
+		password string
+	}{
+		{
+			name:     "missing email",
+			password: "secret",
+		},
+		{
+			name:  "missing password",
+			email: "user@example.test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EVAL_API_TOKEN", "")
+			t.Setenv("EVAL_MCP_AUTH_EMAIL", tt.email)
+			t.Setenv("EVAL_MCP_AUTH_PASSWORD", tt.password)
+
+			_, err := FromEnv()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }
 
@@ -65,12 +137,18 @@ func TestFromEnvRejectsBadDuration(t *testing.T) {
 			name: "wait timeout",
 			key:  "EVAL_MCP_WAIT_TIMEOUT",
 		},
+		{
+			name: "token refresh skew",
+			key:  "EVAL_MCP_TOKEN_REFRESH_SKEW",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EVAL_API_TOKEN", "token-123")
 			t.Setenv("EVAL_MCP_POLL_INTERVAL", "")
 			t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "")
+			t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "")
 			t.Setenv(tt.key, "not-a-duration")
 
 			_, err := FromEnv()
@@ -94,12 +172,18 @@ func TestFromEnvRejectsNonPositiveDurations(t *testing.T) {
 			name: "wait timeout",
 			key:  "EVAL_MCP_WAIT_TIMEOUT",
 		},
+		{
+			name: "token refresh skew",
+			key:  "EVAL_MCP_TOKEN_REFRESH_SKEW",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EVAL_API_TOKEN", "token-123")
 			t.Setenv("EVAL_MCP_POLL_INTERVAL", "")
 			t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "")
+			t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "")
 			t.Setenv(tt.key, "0s")
 
 			_, err := FromEnv()

--- a/go/eval-mcp-service/internal/config/config_test.go
+++ b/go/eval-mcp-service/internal/config/config_test.go
@@ -82,6 +82,9 @@ func TestFromEnvStaticTokenBypassesAuthCredentials(t *testing.T) {
 	t.Setenv("EVAL_API_TOKEN", "token-123")
 	t.Setenv("EVAL_MCP_AUTH_EMAIL", "")
 	t.Setenv("EVAL_MCP_AUTH_PASSWORD", "")
+	t.Setenv("EVAL_MCP_POLL_INTERVAL", "")
+	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "")
+	t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "")
 
 	cfg, err := FromEnv()
 	if err != nil {

--- a/go/eval-mcp-service/internal/evalapi/client.go
+++ b/go/eval-mcp-service/internal/evalapi/client.go
@@ -19,9 +19,10 @@ const (
 )
 
 type Client struct {
-	baseURL       string
-	tokenProvider TokenProvider
-	httpClient    *http.Client
+	baseURL           string
+	tokenProvider     TokenProvider
+	retryUnauthorized bool
+	httpClient        *http.Client
 }
 
 type TokenProvider interface {
@@ -110,7 +111,14 @@ func New(baseURL, token string, httpClient *http.Client) *Client {
 	if token != "" {
 		provider = staticTokenProvider{token: token}
 	}
-	return NewWithTokenProvider(baseURL, provider, httpClient)
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &Client{
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		tokenProvider: provider,
+		httpClient:    httpClient,
+	}
 }
 
 func NewWithTokenProvider(baseURL string, tokenProvider TokenProvider, httpClient *http.Client) *Client {
@@ -118,9 +126,10 @@ func NewWithTokenProvider(baseURL string, tokenProvider TokenProvider, httpClien
 		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
 	return &Client{
-		baseURL:       strings.TrimRight(baseURL, "/"),
-		tokenProvider: tokenProvider,
-		httpClient:    httpClient,
+		baseURL:           strings.TrimRight(baseURL, "/"),
+		tokenProvider:     tokenProvider,
+		retryUnauthorized: tokenProvider != nil,
+		httpClient:        httpClient,
 	}
 }
 
@@ -174,7 +183,7 @@ func (c *Client) do(ctx context.Context, method, path string, body any, out any)
 	}
 
 	err := c.doOnce(ctx, method, path, payload, body != nil, out)
-	if err == nil || c.tokenProvider == nil {
+	if err == nil || c.tokenProvider == nil || !c.retryUnauthorized {
 		return err
 	}
 

--- a/go/eval-mcp-service/internal/evalapi/client.go
+++ b/go/eval-mcp-service/internal/evalapi/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,9 +19,35 @@ const (
 )
 
 type Client struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
+	baseURL       string
+	tokenProvider TokenProvider
+	httpClient    *http.Client
+}
+
+type TokenProvider interface {
+	Token(context.Context) (string, error)
+	Invalidate()
+}
+
+type staticTokenProvider struct {
+	token string
+}
+
+func (p staticTokenProvider) Token(context.Context) (string, error) {
+	return p.token, nil
+}
+
+func (p staticTokenProvider) Invalidate() {}
+
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Excerpt    string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("%s %s: status %d: %s", e.Method, e.Path, e.StatusCode, e.Excerpt)
 }
 
 type Dataset struct {
@@ -79,13 +106,21 @@ type Comparison struct {
 }
 
 func New(baseURL, token string, httpClient *http.Client) *Client {
+	var provider TokenProvider
+	if token != "" {
+		provider = staticTokenProvider{token: token}
+	}
+	return NewWithTokenProvider(baseURL, provider, httpClient)
+}
+
+func NewWithTokenProvider(baseURL string, tokenProvider TokenProvider, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
 	return &Client{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		token:      token,
-		httpClient: httpClient,
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		tokenProvider: tokenProvider,
+		httpClient:    httpClient,
 	}
 }
 
@@ -129,24 +164,50 @@ func (c *Client) CompareEvaluations(ctx context.Context, ids []string) (Comparis
 }
 
 func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
-	var reader io.Reader
+	var payload []byte
 	if body != nil {
 		var buf bytes.Buffer
 		if err := json.NewEncoder(&buf).Encode(body); err != nil {
 			return fmt.Errorf("%s %s: encode request: %w", method, path, err)
 		}
-		reader = &buf
+		payload = buf.Bytes()
+	}
+
+	err := c.doOnce(ctx, method, path, payload, body != nil, out)
+	if err == nil || c.tokenProvider == nil {
+		return err
+	}
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		return err
+	}
+
+	c.tokenProvider.Invalidate()
+	return c.doOnce(ctx, method, path, payload, body != nil, out)
+}
+
+func (c *Client) doOnce(ctx context.Context, method, path string, payload []byte, hasBody bool, out any) error {
+	var reader io.Reader
+	if hasBody {
+		reader = bytes.NewReader(payload)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
 	if err != nil {
 		return fmt.Errorf("%s %s: create request: %w", method, path, err)
 	}
-	if body != nil {
+	if hasBody {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if c.tokenProvider != nil {
+		token, err := c.tokenProvider.Token(ctx)
+		if err != nil {
+			return fmt.Errorf("%s %s: token: %w", method, path, err)
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
 	}
 
 	resp, err := c.httpClient.Do(req)
@@ -157,7 +218,12 @@ func (c *Client) do(ctx context.Context, method, path string, body any, out any)
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		excerpt, _ := io.ReadAll(io.LimitReader(resp.Body, errorExcerptLimit))
-		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(excerpt)))
+		return &HTTPError{
+			Method:     method,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Excerpt:    strings.TrimSpace(string(excerpt)),
+		}
 	}
 
 	if out == nil {

--- a/go/eval-mcp-service/internal/evalapi/client_test.go
+++ b/go/eval-mcp-service/internal/evalapi/client_test.go
@@ -131,6 +131,72 @@ func TestHTTPErrorIncludesStatusAndExcerpt(t *testing.T) {
 	}
 }
 
+func TestListDatasetsRetriesOnceAfterUnauthorized(t *testing.T) {
+	provider := &sequenceTokenProvider{tokens: []string{"expired-token", "fresh-token"}}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch requests {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "Bearer expired-token" {
+				t.Fatalf("first Authorization = %q", got)
+			}
+			http.Error(w, "expired", http.StatusUnauthorized)
+		case 2:
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh-token" {
+				t.Fatalf("retry Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"datasets": []Dataset{{ID: "ds-retry", Name: "rag"}}})
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+
+	client := NewWithTokenProvider(server.URL, provider, server.Client())
+	got, err := client.ListDatasets(context.Background())
+	if err != nil {
+		t.Fatalf("ListDatasets error: %v", err)
+	}
+	if provider.invalidations != 1 {
+		t.Fatalf("invalidations = %d", provider.invalidations)
+	}
+	if provider.calls != 2 {
+		t.Fatalf("token calls = %d", provider.calls)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+	if len(got) != 1 || got[0].ID != "ds-retry" {
+		t.Fatalf("datasets = %#v", got)
+	}
+}
+
+func TestListDatasetsDoesNotRetryNonUnauthorizedError(t *testing.T) {
+	provider := &sequenceTokenProvider{tokens: []string{"token-1"}}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, "broken", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	client := NewWithTokenProvider(server.URL, provider, server.Client())
+	_, err := client.ListDatasets(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
+	}
+	if provider.invalidations != 0 {
+		t.Fatalf("invalidations = %d", provider.invalidations)
+	}
+	if !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestNewUsesDefaultHTTPClient(t *testing.T) {
 	client := New("http://example.test/eval", "", nil)
 	if client.httpClient == nil {
@@ -139,4 +205,23 @@ func TestNewUsesDefaultHTTPClient(t *testing.T) {
 	if client.httpClient.Timeout != 30*time.Second {
 		t.Fatalf("timeout = %s", client.httpClient.Timeout)
 	}
+}
+
+type sequenceTokenProvider struct {
+	tokens        []string
+	calls         int
+	invalidations int
+}
+
+func (p *sequenceTokenProvider) Token(context.Context) (string, error) {
+	if p.calls >= len(p.tokens) {
+		return "", nil
+	}
+	token := p.tokens[p.calls]
+	p.calls++
+	return token, nil
+}
+
+func (p *sequenceTokenProvider) Invalidate() {
+	p.invalidations++
 }

--- a/go/eval-mcp-service/internal/evalapi/client_test.go
+++ b/go/eval-mcp-service/internal/evalapi/client_test.go
@@ -131,6 +131,30 @@ func TestHTTPErrorIncludesStatusAndExcerpt(t *testing.T) {
 	}
 }
 
+func TestListDatasetsStaticTokenDoesNotRetryUnauthorized(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if got := r.Header.Get("Authorization"); got != "Bearer static-token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		http.Error(w, "expired", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := New(server.URL, "static-token", server.Client())
+	_, err := client.ListDatasets(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d", requests)
+	}
+	if !strings.Contains(err.Error(), "status 401") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestListDatasetsRetriesOnceAfterUnauthorized(t *testing.T) {
 	provider := &sequenceTokenProvider{tokens: []string{"expired-token", "fresh-token"}}
 	requests := 0
@@ -169,6 +193,62 @@ func TestListDatasetsRetriesOnceAfterUnauthorized(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ID != "ds-retry" {
 		t.Fatalf("datasets = %#v", got)
+	}
+}
+
+func TestStartEvaluationRetriesUnauthorizedWithOriginalBody(t *testing.T) {
+	provider := &sequenceTokenProvider{tokens: []string{"expired-token", "fresh-token"}}
+	wantBody := StartEvaluationRequest{
+		DatasetID:      "ds-1",
+		Collection:     "documents",
+		Notes:          "candidate",
+		BaselineEvalID: "eval-base",
+		Rerank:         true,
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path != "/evaluations" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		var gotBody StartEvaluationRequest
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body request %d: %v", requests, err)
+		}
+		if gotBody != wantBody {
+			t.Fatalf("body request %d = %#v", requests, gotBody)
+		}
+		switch requests {
+		case 1:
+			if got := r.Header.Get("Authorization"); got != "Bearer expired-token" {
+				t.Fatalf("first Authorization = %q", got)
+			}
+			http.Error(w, "expired", http.StatusUnauthorized)
+		case 2:
+			if got := r.Header.Get("Authorization"); got != "Bearer fresh-token" {
+				t.Fatalf("retry Authorization = %q", got)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(StartEvaluationResponse{ID: "eval-2", Status: "running"})
+		default:
+			t.Fatalf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+
+	client := NewWithTokenProvider(server.URL, provider, server.Client())
+	got, err := client.StartEvaluation(context.Background(), wantBody)
+	if err != nil {
+		t.Fatalf("StartEvaluation error: %v", err)
+	}
+	if provider.invalidations != 1 {
+		t.Fatalf("invalidations = %d", provider.invalidations)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+	if got.ID != "eval-2" || got.Status != "running" {
+		t.Fatalf("response = %#v", got)
 	}
 }
 

--- a/go/eval-mcp-service/internal/tokenstore/file.go
+++ b/go/eval-mcp-service/internal/tokenstore/file.go
@@ -1,0 +1,108 @@
+package tokenstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	dirMode  os.FileMode = 0o700
+	fileMode os.FileMode = 0o600
+)
+
+type State struct {
+	AccessToken    string    `json:"accessToken"`
+	RefreshToken   string    `json:"refreshToken"`
+	AccessTokenExp time.Time `json:"accessTokenExp"`
+	AuthEmail      string    `json:"authEmail"`
+	AuthServiceURL string    `json:"authServiceURL"`
+	WrittenAt      time.Time `json:"writtenAt"`
+}
+
+type FileStore struct {
+	path string
+}
+
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path: path}
+}
+
+func (s *FileStore) Load(ctx context.Context) (State, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return State{}, false, err
+	}
+
+	info, err := os.Stat(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{}, false, nil
+		}
+		return State{}, false, fmt.Errorf("stat token state: %w", err)
+	}
+	if info.Mode().Perm() != fileMode {
+		return State{}, false, fmt.Errorf("token state file has unsafe permissions %s, want %s: %w", info.Mode().Perm(), fileMode, os.ErrPermission)
+	}
+
+	file, err := os.Open(s.path)
+	if err != nil {
+		return State{}, false, fmt.Errorf("open token state: %w", err)
+	}
+	defer file.Close()
+
+	var state State
+	if err := json.NewDecoder(file).Decode(&state); err != nil {
+		return State{}, false, fmt.Errorf("decode token state: %w", err)
+	}
+	return state, true, nil
+}
+
+func (s *FileStore) Save(ctx context.Context, state State) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, dirMode); err != nil {
+		return fmt.Errorf("create token state dir: %w", err)
+	}
+	if err := os.Chmod(dir, dirMode); err != nil {
+		return fmt.Errorf("chmod token state dir: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp(dir, ".tokens-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp token state: %w", err)
+	}
+	tempPath := tempFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := os.Chmod(tempPath, fileMode); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("chmod temp token state: %w", err)
+	}
+	if err := json.NewEncoder(tempFile).Encode(state); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write token state: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temp token state: %w", err)
+	}
+	if err := os.Chmod(tempPath, fileMode); err != nil {
+		return fmt.Errorf("chmod temp token state: %w", err)
+	}
+	if err := os.Rename(tempPath, s.path); err != nil {
+		return fmt.Errorf("rename token state: %w", err)
+	}
+	cleanup = false
+	return nil
+}

--- a/go/eval-mcp-service/internal/tokenstore/file_test.go
+++ b/go/eval-mcp-service/internal/tokenstore/file_test.go
@@ -1,0 +1,87 @@
+package tokenstore
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveThenLoadRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "auth", "tokens.json")
+	store := NewFileStore(path)
+	state := State{
+		AccessToken:    "access-1",
+		RefreshToken:   "refresh-1",
+		AccessTokenExp: time.Date(2026, 5, 15, 12, 30, 0, 0, time.UTC),
+		AuthEmail:      "user@example.test",
+		AuthServiceURL: "http://auth.test/auth",
+		WrittenAt:      time.Date(2026, 5, 15, 11, 30, 0, 0, time.UTC),
+	}
+
+	if err := store.Save(ctx, state); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+	got, ok, err := store.Load(ctx)
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Load ok = false")
+	}
+	if got.AccessToken != state.AccessToken || got.RefreshToken != state.RefreshToken || !got.AccessTokenExp.Equal(state.AccessTokenExp) || got.AuthEmail != state.AuthEmail || got.AuthServiceURL != state.AuthServiceURL || !got.WrittenAt.Equal(state.WrittenAt) {
+		t.Fatalf("state = %#v, want %#v", got, state)
+	}
+}
+
+func TestSaveWritesFileMode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	store := NewFileStore(path)
+
+	if err := store.Save(context.Background(), State{AccessToken: "access"}); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != fileMode {
+		t.Fatalf("mode = %s, want %s", got, fileMode)
+	}
+}
+
+func TestLoadMissingFileReturnsNotOK(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "missing.json"))
+
+	got, ok, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if ok {
+		t.Fatal("Load ok = true")
+	}
+	if got != (State{}) {
+		t.Fatalf("state = %#v", got)
+	}
+}
+
+func TestLoadRejectsUnsafePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	_, ok, err := NewFileStore(path).Load(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if ok {
+		t.Fatal("Load ok = true")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add opt-in auth-service token responses for machine clients while preserving cookie-first browser behavior
- add eval MCP auth client, token cache, and refresh/login provider with secret-safe error redaction
- wire eval API bearer auth through auth-service and retry provider-backed 401s once without retrying static tokens

## Verification
- go test ./... -count=1 in go/auth-service
- go test ./... -count=1 in go/eval-mcp-service
- make preflight-go
- final branch review: no blocking findings