### PR TITLE
Improve eval MCP dataset workflow reliability

### DIFF
--- a/go/eval-mcp-service/README.md
+++ b/go/eval-mcp-service/README.md
@@ -27,6 +27,8 @@ codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/e
 ## Configuration
 
 - `EVAL_API_URL`: eval API base URL, defaults to `http://localhost:8000/eval`.
+- `EVAL_MCP_INGESTION_URL`: ingestion API base URL for collection discovery,
+  defaults to `http://localhost:8000/ingestion`.
 - `EVAL_API_TOKEN`: optional bearer token override for eval API calls. When set,
   the service skips auth-service login and token cache refresh.
 - `AUTH_SERVICE_URL`: auth-service base URL, defaults to
@@ -41,6 +43,8 @@ codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/e
   defaults to `1m`.
 - `EVAL_MCP_POLL_INTERVAL`: polling interval, defaults to `1s`.
 - `EVAL_MCP_WAIT_TIMEOUT`: wait timeout, defaults to `5m`.
+- `EVAL_MCP_DATASET_FIXTURE_ROOTS`: path-list of curated eval fixture roots,
+  defaults to the repo `docs/product-catalog` directory.
 
 ## Tools
 
@@ -48,6 +52,10 @@ codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/e
 - `list_eval_experiments`
 - `get_eval_experiment`
 - `list_eval_datasets`
+- `list_eval_dataset_fixtures`
+- `create_eval_dataset`
+- `list_rag_collections`
+- `get_rag_collection_config`
 - `start_eval_run`
 - `wait_for_eval_run`
 - `attach_eval_run`
@@ -56,3 +64,8 @@ codex mcp add eval -- zsh -lc 'cd /Users/kylebradshaw/repos/gen_ai_engineer/go/e
 - `get_worst_eval_cases`
 - `summarize_eval_experiment`
 - `record_eval_experiment_conclusion`
+
+Eval datasets and RAG collections are separate concepts. Datasets contain
+golden questions and expected answers. Collections are Qdrant retrieval corpora.
+Use curated fixture tools to create missing datasets, then validate the chosen
+RAG collection before starting baseline and rerank runs.

--- a/go/eval-mcp-service/cmd/eval-mcp/main.go
+++ b/go/eval-mcp-service/cmd/eval-mcp/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/config"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalapi"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalworkflow"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/fixturecatalog"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/ingestionapi"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/mcpserver"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/tokenstore"
 )
@@ -52,8 +54,10 @@ func run(ctx context.Context, logger *log.Logger, runServer serverRunner) error 
 		})
 		api = evalapi.NewWithTokenProvider(cfg.EvalAPIURL, provider, httpClient)
 	}
-	service := evalworkflow.New(api, cfg.PollInterval, cfg.WaitTimeout)
-	logger.Printf("eval MCP server running on stdio eval_api_url=%s", cfg.EvalAPIURL)
+	ingestion := ingestionapi.New(cfg.IngestionURL, cfg.APIToken, httpClient)
+	fixtures := fixturecatalog.New(cfg.DatasetFixtureRoots)
+	service := evalworkflow.New(api, ingestion, fixtures, cfg.PollInterval, cfg.WaitTimeout)
+	logger.Printf("eval MCP server running on stdio eval_api_url=%s ingestion_url=%s", cfg.EvalAPIURL, cfg.IngestionURL)
 	return runServer(ctx, &app{service: service, cfg: cfg})
 }
 

--- a/go/eval-mcp-service/internal/config/config.go
+++ b/go/eval-mcp-service/internal/config/config.go
@@ -3,11 +3,14 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
 const (
 	defaultEvalAPIURL       = "http://localhost:8000/eval"
+	defaultIngestionURL     = "http://localhost:8000/ingestion"
 	defaultAuthServiceURL   = "http://localhost:8091/auth"
 	defaultTokenCachePath   = "data/eval-mcp-auth.json"
 	defaultPollInterval     = time.Second
@@ -16,15 +19,17 @@ const (
 )
 
 type Config struct {
-	EvalAPIURL       string
-	APIToken         string
-	AuthServiceURL   string
-	AuthEmail        string
-	AuthPassword     string
-	TokenCachePath   string
-	PollInterval     time.Duration
-	WaitTimeout      time.Duration
-	TokenRefreshSkew time.Duration
+	EvalAPIURL          string
+	IngestionURL        string
+	APIToken            string
+	AuthServiceURL      string
+	AuthEmail           string
+	AuthPassword        string
+	TokenCachePath      string
+	PollInterval        time.Duration
+	WaitTimeout         time.Duration
+	TokenRefreshSkew    time.Duration
+	DatasetFixtureRoots []string
 }
 
 func FromEnv() (Config, error) {
@@ -63,15 +68,17 @@ func FromEnv() (Config, error) {
 	}
 
 	return Config{
-		EvalAPIURL:       getenv("EVAL_API_URL", defaultEvalAPIURL),
-		APIToken:         apiToken,
-		AuthServiceURL:   getenv("AUTH_SERVICE_URL", defaultAuthServiceURL),
-		AuthEmail:        authEmail,
-		AuthPassword:     authPassword,
-		TokenCachePath:   getenv("EVAL_MCP_TOKEN_CACHE_PATH", defaultTokenCachePath),
-		PollInterval:     pollInterval,
-		WaitTimeout:      waitTimeout,
-		TokenRefreshSkew: tokenRefreshSkew,
+		EvalAPIURL:          getenv("EVAL_API_URL", defaultEvalAPIURL),
+		IngestionURL:        getenv("EVAL_MCP_INGESTION_URL", defaultIngestionURL),
+		APIToken:            apiToken,
+		AuthServiceURL:      getenv("AUTH_SERVICE_URL", defaultAuthServiceURL),
+		AuthEmail:           authEmail,
+		AuthPassword:        authPassword,
+		TokenCachePath:      getenv("EVAL_MCP_TOKEN_CACHE_PATH", defaultTokenCachePath),
+		PollInterval:        pollInterval,
+		WaitTimeout:         waitTimeout,
+		TokenRefreshSkew:    tokenRefreshSkew,
+		DatasetFixtureRoots: datasetFixtureRoots(),
 	}, nil
 }
 
@@ -92,4 +99,19 @@ func durationEnv(key string, fallback time.Duration) (time.Duration, error) {
 		return 0, fmt.Errorf("%s: %w", key, err)
 	}
 	return parsed, nil
+}
+
+func datasetFixtureRoots() []string {
+	value := os.Getenv("EVAL_MCP_DATASET_FIXTURE_ROOTS")
+	if value != "" {
+		parts := strings.Split(value, string(os.PathListSeparator))
+		roots := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if strings.TrimSpace(part) != "" {
+				roots = append(roots, part)
+			}
+		}
+		return roots
+	}
+	return []string{filepath.Clean(filepath.Join("..", "..", "docs", "product-catalog"))}
 }

--- a/go/eval-mcp-service/internal/config/config_test.go
+++ b/go/eval-mcp-service/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +18,8 @@ func TestFromEnvDefaults(t *testing.T) {
 	t.Setenv("EVAL_MCP_POLL_INTERVAL", "")
 	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "")
 	t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "")
+	t.Setenv("EVAL_MCP_INGESTION_URL", "")
+	t.Setenv("EVAL_MCP_DATASET_FIXTURE_ROOTS", "")
 
 	cfg, err := FromEnv()
 	if err != nil {
@@ -23,6 +27,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	}
 	if cfg.EvalAPIURL != "http://localhost:8000/eval" {
 		t.Fatalf("EvalAPIURL = %q", cfg.EvalAPIURL)
+	}
+	if cfg.IngestionURL != "http://localhost:8000/ingestion" {
+		t.Fatalf("IngestionURL = %q", cfg.IngestionURL)
 	}
 	if cfg.APIToken != "" {
 		t.Fatalf("APIToken = %q", cfg.APIToken)
@@ -48,6 +55,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.TokenRefreshSkew != time.Minute {
 		t.Fatalf("TokenRefreshSkew = %s", cfg.TokenRefreshSkew)
 	}
+	if !slices.Equal(cfg.DatasetFixtureRoots, []string{"../../docs/product-catalog"}) {
+		t.Fatalf("DatasetFixtureRoots = %#v", cfg.DatasetFixtureRoots)
+	}
 }
 
 func TestFromEnvOverrides(t *testing.T) {
@@ -60,6 +70,8 @@ func TestFromEnvOverrides(t *testing.T) {
 	t.Setenv("EVAL_MCP_POLL_INTERVAL", "250ms")
 	t.Setenv("EVAL_MCP_WAIT_TIMEOUT", "30s")
 	t.Setenv("EVAL_MCP_TOKEN_REFRESH_SKEW", "2m")
+	t.Setenv("EVAL_MCP_INGESTION_URL", "http://127.0.0.1:8000/ingestion")
+	t.Setenv("EVAL_MCP_DATASET_FIXTURE_ROOTS", "/tmp/a"+string(os.PathListSeparator)+"/tmp/b")
 
 	cfg, err := FromEnv()
 	if err != nil {
@@ -70,6 +82,12 @@ func TestFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.PollInterval != 250*time.Millisecond || cfg.WaitTimeout != 30*time.Second || cfg.TokenRefreshSkew != 2*time.Minute {
 		t.Fatalf("unexpected durations: %#v", cfg)
+	}
+	if cfg.IngestionURL != "http://127.0.0.1:8000/ingestion" {
+		t.Fatalf("IngestionURL = %q", cfg.IngestionURL)
+	}
+	if !slices.Equal(cfg.DatasetFixtureRoots, []string{"/tmp/a", "/tmp/b"}) {
+		t.Fatalf("DatasetFixtureRoots = %#v", cfg.DatasetFixtureRoots)
 	}
 }
 

--- a/go/eval-mcp-service/internal/evalapi/client.go
+++ b/go/eval-mcp-service/internal/evalapi/client.go
@@ -58,6 +58,21 @@ type Dataset struct {
 	ItemCount int    `json:"item_count"`
 }
 
+type GoldenItem struct {
+	Query           string   `json:"query"`
+	ExpectedAnswer  string   `json:"expected_answer"`
+	ExpectedSources []string `json:"expected_sources"`
+}
+
+type CreateDatasetRequest struct {
+	Name  string       `json:"name"`
+	Items []GoldenItem `json:"items"`
+}
+
+type CreateDatasetResponse struct {
+	ID string `json:"id"`
+}
+
 type StartEvaluationRequest struct {
 	DatasetID       string `json:"dataset_id"`
 	Collection      string `json:"collection,omitempty"`
@@ -197,6 +212,14 @@ func (c *Client) ListDatasets(ctx context.Context) ([]Dataset, error) {
 		return nil, err
 	}
 	return response.Datasets, nil
+}
+
+func (c *Client) CreateDataset(ctx context.Context, body CreateDatasetRequest) (CreateDatasetResponse, error) {
+	var response CreateDatasetResponse
+	if err := c.do(ctx, http.MethodPost, "/datasets", body, &response); err != nil {
+		return CreateDatasetResponse{}, err
+	}
+	return response, nil
 }
 
 func (c *Client) StartEvaluation(ctx context.Context, body StartEvaluationRequest) (StartEvaluationResponse, error) {

--- a/go/eval-mcp-service/internal/evalapi/client_test.go
+++ b/go/eval-mcp-service/internal/evalapi/client_test.go
@@ -32,6 +32,39 @@ func TestListDatasetsAddsBearerToken(t *testing.T) {
 	}
 }
 
+func TestClientCreateDataset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/datasets" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body CreateDatasetRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Name != "product-docs-rag-v1" || len(body.Items) != 1 || body.Items[0].ExpectedSources[0] != "laptop-pro-15-specs.pdf" {
+			t.Fatalf("unexpected body: %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "ds-123"})
+	}))
+	defer server.Close()
+
+	client := New(server.URL, "", server.Client())
+	got, err := client.CreateDataset(context.Background(), CreateDatasetRequest{
+		Name: "product-docs-rag-v1",
+		Items: []GoldenItem{{
+			Query:           "How long?",
+			ExpectedAnswer:  "Up to 10 hours.",
+			ExpectedSources: []string{"laptop-pro-15-specs.pdf"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDataset returned error: %v", err)
+	}
+	if got.ID != "ds-123" {
+		t.Fatalf("ID = %q", got.ID)
+	}
+}
+
 func TestStartEvaluationSendsOptionalFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body StartEvaluationRequest

--- a/go/eval-mcp-service/internal/evalworkflow/service.go
+++ b/go/eval-mcp-service/internal/evalworkflow/service.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalapi"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/fixturecatalog"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/ingestionapi"
 )
 
 const (
@@ -22,6 +24,7 @@ const (
 
 type API interface {
 	ListDatasets(context.Context) ([]evalapi.Dataset, error)
+	CreateDataset(context.Context, evalapi.CreateDatasetRequest) (evalapi.CreateDatasetResponse, error)
 	StartEvaluation(context.Context, evalapi.StartEvaluationRequest) (evalapi.StartEvaluationResponse, error)
 	GetEvaluation(context.Context, string) (evalapi.EvaluationDetail, error)
 	CompareEvaluations(context.Context, []string) (evalapi.Comparison, error)
@@ -32,8 +35,20 @@ type API interface {
 	UpdateExperiment(context.Context, string, evalapi.UpdateExperimentRequest) (evalapi.Experiment, error)
 }
 
+type Ingestion interface {
+	ListCollections(context.Context) ([]ingestionapi.Collection, error)
+	GetCollectionConfig(context.Context, string) (map[string]any, error)
+}
+
+type Fixtures interface {
+	List() ([]fixturecatalog.Fixture, error)
+	Load(string) (fixturecatalog.Fixture, error)
+}
+
 type Service struct {
 	api          API
+	ingestion    Ingestion
+	fixtures     Fixtures
 	pollInterval time.Duration
 	waitTimeout  time.Duration
 }
@@ -61,6 +76,11 @@ type StartRunInput struct {
 type StartRunResult struct {
 	EvalID string
 	Status string
+}
+
+type CreateDatasetResult struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type WaitResult struct {
@@ -116,9 +136,11 @@ type RecordConclusionInput struct {
 	Evidence     map[string]any
 }
 
-func New(api API, pollInterval, waitTimeout time.Duration) *Service {
+func New(api API, ingestion Ingestion, fixtures Fixtures, pollInterval, waitTimeout time.Duration) *Service {
 	return &Service{
 		api:          api,
+		ingestion:    ingestion,
+		fixtures:     fixtures,
 		pollInterval: pollInterval,
 		waitTimeout:  waitTimeout,
 	}
@@ -134,6 +156,9 @@ func (s *Service) StartExperiment(ctx context.Context, in StartExperimentInput) 
 		focusMetric = DefaultFocusMetric
 	}
 	if err := validateMetric(focusMetric); err != nil {
+		return evalapi.Experiment{}, err
+	}
+	if err := s.validateCollectionExists(ctx, collection); err != nil {
 		return evalapi.Experiment{}, err
 	}
 
@@ -161,7 +186,42 @@ func (s *Service) ListDatasets(ctx context.Context) ([]evalapi.Dataset, error) {
 	return s.api.ListDatasets(ctx)
 }
 
+func (s *Service) ListDatasetFixtures(context.Context) ([]fixturecatalog.Fixture, error) {
+	return s.fixtures.List()
+}
+
+func (s *Service) CreateDatasetFromFixture(ctx context.Context, fixtureID string) (CreateDatasetResult, error) {
+	fixture, err := s.fixtures.Load(fixtureID)
+	if err != nil {
+		return CreateDatasetResult{}, err
+	}
+	items := make([]evalapi.GoldenItem, 0, len(fixture.Items))
+	for _, item := range fixture.Items {
+		items = append(items, evalapi.GoldenItem{
+			Query:           item.Query,
+			ExpectedAnswer:  item.ExpectedAnswer,
+			ExpectedSources: item.ExpectedSources,
+		})
+	}
+	created, err := s.api.CreateDataset(ctx, evalapi.CreateDatasetRequest{Name: fixture.Name, Items: items})
+	if err != nil {
+		return CreateDatasetResult{}, err
+	}
+	return CreateDatasetResult{ID: created.ID, Name: fixture.Name}, nil
+}
+
+func (s *Service) ListRAGCollections(ctx context.Context) ([]ingestionapi.Collection, error) {
+	return s.ingestion.ListCollections(ctx)
+}
+
+func (s *Service) GetRAGCollectionConfig(ctx context.Context, name string) (map[string]any, error) {
+	return s.ingestion.GetCollectionConfig(ctx, name)
+}
+
 func (s *Service) StartRun(ctx context.Context, in StartRunInput) (StartRunResult, error) {
+	if err := s.validateCollectionExists(ctx, in.Collection); err != nil {
+		return StartRunResult{}, err
+	}
 	resp, err := s.api.StartEvaluation(ctx, evalapi.StartEvaluationRequest{
 		DatasetID:       in.DatasetID,
 		Collection:      in.Collection,
@@ -260,6 +320,9 @@ func (s *Service) Compare(ctx context.Context, in CompareInput) (evalapi.Compari
 	if err := validateCompareIDs(ids); err != nil {
 		return evalapi.Comparison{}, err
 	}
+	if err := s.requireCompletedRuns(ctx, ids); err != nil {
+		return evalapi.Comparison{}, err
+	}
 	return s.api.CompareEvaluations(ctx, ids)
 }
 
@@ -310,6 +373,9 @@ func (s *Service) SummarizeExperiment(ctx context.Context, experimentID string) 
 		run, err := s.api.GetEvaluation(ctx, runLabel.EvaluationID)
 		if err != nil {
 			return ExperimentSummary{}, fmt.Errorf("get run %q (%s): %w", runLabel.Label, runLabel.EvaluationID, err)
+		}
+		if run.Status != "completed" {
+			return ExperimentSummary{}, fmt.Errorf("summarize requires completed runs; %s=%s", run.ID, run.Status)
 		}
 		labeledRun := LabeledRun{Label: runLabel.Label, Run: run}
 		if i == 0 {
@@ -362,6 +428,36 @@ func waitTimeoutError(evalID string, timeout time.Duration, latestStatus string)
 func validateCompareIDs(ids []string) error {
 	if len(ids) < minCompareEvalIDs || len(ids) > maxCompareEvalIDs {
 		return fmt.Errorf("compare requires %d to %d eval IDs, got %d", minCompareEvalIDs, maxCompareEvalIDs, len(ids))
+	}
+	return nil
+}
+
+func (s *Service) validateCollectionExists(ctx context.Context, collection string) error {
+	collections, err := s.ingestion.ListCollections(ctx)
+	if err != nil {
+		return fmt.Errorf("list RAG collections: %w", err)
+	}
+	for _, candidate := range collections {
+		if candidate.Name == collection {
+			return nil
+		}
+	}
+	return fmt.Errorf("retrieval collection %q does not exist; call list_rag_collections and choose an existing collection", collection)
+}
+
+func (s *Service) requireCompletedRuns(ctx context.Context, ids []string) error {
+	var invalid []string
+	for _, id := range ids {
+		run, err := s.api.GetEvaluation(ctx, id)
+		if err != nil {
+			return fmt.Errorf("get run %q: %w", id, err)
+		}
+		if run.Status != "completed" {
+			invalid = append(invalid, fmt.Sprintf("%s=%s", id, run.Status))
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("compare requires completed runs; invalid statuses: %s", strings.Join(invalid, ", "))
 	}
 	return nil
 }

--- a/go/eval-mcp-service/internal/evalworkflow/service_test.go
+++ b/go/eval-mcp-service/internal/evalworkflow/service_test.go
@@ -10,12 +10,14 @@ import (
 	"time"
 
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalapi"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/fixturecatalog"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/ingestionapi"
 )
 
 func TestStartExperimentDefaultsCollectionAndFocusMetric(t *testing.T) {
 	ctx := context.Background()
 	api := &fakeAPI{}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	got, err := svc.StartExperiment(ctx, StartExperimentInput{
 		Name:      "rerank trial",
@@ -38,7 +40,7 @@ func TestStartExperimentDefaultsCollectionAndFocusMetric(t *testing.T) {
 func TestStartRunSendsExperimentAttachmentToEvalAPI(t *testing.T) {
 	ctx := context.Background()
 	api := &fakeAPI{startResponse: evalapi.StartEvaluationResponse{ID: "eval-123", Status: "queued"}}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	got, err := svc.StartRun(ctx, StartRunInput{
 		DatasetID:      "dataset-1",
@@ -64,10 +66,54 @@ func TestStartRunSendsExperimentAttachmentToEvalAPI(t *testing.T) {
 	}
 }
 
+func TestCreateDatasetFromFixture(t *testing.T) {
+	api := &fakeAPI{}
+	fixture := fixturecatalog.Fixture{
+		Name: "product-docs-rag-v1",
+		Items: []fixturecatalog.GoldenItem{{
+			Query: "q", ExpectedAnswer: "a", ExpectedSources: []string{"doc.pdf"},
+		}},
+		Valid: true,
+	}
+	service := New(api, fakeIngestion{}, fakeFixtures{fixture: fixture}, time.Second, time.Minute)
+
+	got, err := service.CreateDatasetFromFixture(context.Background(), "rag-eval-dataset-product-docs.json")
+	if err != nil {
+		t.Fatalf("CreateDatasetFromFixture returned error: %v", err)
+	}
+	if got.ID != "ds-created" || got.Name != "product-docs-rag-v1" {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+	if api.createDatasetRequest.Name != "product-docs-rag-v1" || len(api.createDatasetRequest.Items) != 1 {
+		t.Fatalf("unexpected request: %#v", api.createDatasetRequest)
+	}
+}
+
+func TestStartRunRejectsMissingCollection(t *testing.T) {
+	api := &fakeAPI{}
+	service := New(api, fakeIngestion{collections: []ingestionapi.Collection{{Name: "documents"}}}, fakeFixtures{}, time.Second, time.Minute)
+	_, err := service.StartRun(context.Background(), StartRunInput{DatasetID: "ds-1", Collection: "missing"})
+	if err == nil || !strings.Contains(err.Error(), `retrieval collection "missing" does not exist`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCompareRejectsNonCompletedRuns(t *testing.T) {
+	api := &fakeAPI{detailsByID: map[string][]evalapi.EvaluationDetail{
+		"base": {{ID: "base", Status: "completed"}},
+		"bad":  {{ID: "bad", Status: "failed"}},
+	}}
+	service := New(api, fakeIngestion{}, fakeFixtures{}, time.Second, time.Minute)
+	_, err := service.Compare(context.Background(), CompareInput{EvalIDs: []string{"base", "bad"}})
+	if err == nil || !strings.Contains(err.Error(), `bad=failed`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestRecordConclusionCompletesExperimentWithEvidence(t *testing.T) {
 	ctx := context.Background()
 	api := &fakeAPI{}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 	evidence := map[string]any{"baseline_eval_id": "eval-base"}
 
 	if err := svc.RecordConclusion(ctx, RecordConclusionInput{
@@ -94,7 +140,7 @@ func TestWaitForRunReturnsCompletedRun(t *testing.T) {
 			{ID: "eval-1", Status: "completed"},
 		},
 	}}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	got, err := svc.WaitForRun(ctx, "eval-1")
 	if err != nil {
@@ -113,7 +159,7 @@ func TestWaitForRunTimesOutWithLatestStatus(t *testing.T) {
 			{ID: "eval-1", Status: "running"},
 		},
 	}}
-	svc := New(api, time.Millisecond, 3*time.Millisecond)
+	svc := newTestServiceWithTiming(api, time.Millisecond, 3*time.Millisecond)
 
 	got, err := svc.WaitForRun(ctx, "eval-1")
 	if err == nil {
@@ -129,7 +175,7 @@ func TestWaitForRunCancelsGetEvaluationWithWaitTimeout(t *testing.T) {
 	defer cancelParent()
 
 	api := &blockingGetEvaluationAPI{entered: make(chan struct{})}
-	svc := New(api, time.Hour, 5*time.Millisecond)
+	svc := newTestServiceWithTiming(api, time.Hour, 5*time.Millisecond)
 
 	type waitOutcome struct {
 		result WaitResult
@@ -175,7 +221,7 @@ func TestWaitForRunParentDeadlineIsNotServiceTimeout(t *testing.T) {
 	defer cancelParent()
 
 	api := &blockingGetEvaluationAPI{entered: make(chan struct{})}
-	svc := New(api, time.Hour, time.Minute)
+	svc := newTestServiceWithTiming(api, time.Hour, time.Minute)
 
 	type waitOutcome struct {
 		result WaitResult
@@ -222,7 +268,7 @@ func TestWorstCasesSortsAscendingByMetric(t *testing.T) {
 			},
 		}},
 	}}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	got, err := svc.WorstCases(ctx, WorstCasesInput{
 		EvalID: "eval-1",
@@ -253,7 +299,11 @@ func TestCompareResolvesExperimentLabels(t *testing.T) {
 			},
 		},
 	}
-	svc := New(api, time.Millisecond, time.Second)
+	api.detailsByID = map[string][]evalapi.EvaluationDetail{
+		"eval-base":      {{ID: "eval-base", Status: "completed"}},
+		"eval-candidate": {{ID: "eval-candidate", Status: "completed"}},
+	}
+	svc := newTestService(api)
 
 	if _, err := svc.Compare(ctx, CompareInput{ExperimentID: "exp-9", Labels: []string{"baseline", "missing"}}); err == nil || !strings.Contains(err.Error(), "known labels: baseline, candidate") {
 		t.Fatalf("Compare missing label error = %v", err)
@@ -270,7 +320,7 @@ func TestCompareResolvesExperimentLabels(t *testing.T) {
 func TestCompareRequiresTwoToFiveIDs(t *testing.T) {
 	ctx := context.Background()
 	api := &fakeAPI{}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	if _, err := svc.Compare(ctx, CompareInput{EvalIDs: []string{"eval-1"}}); err == nil || !strings.Contains(err.Error(), "requires 2 to 5 eval IDs") {
 		t.Fatalf("Compare one ID error = %v", err)
@@ -313,7 +363,7 @@ func TestSummarizeExperimentReturnsBaselineCandidateAndWorstCases(t *testing.T) 
 			},
 		},
 	}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	got, err := svc.SummarizeExperiment(ctx, "exp-3")
 	if err != nil {
@@ -354,7 +404,7 @@ func TestSummarizeExperimentComparesFirstFiveRuns(t *testing.T) {
 		}}
 	}
 	api.experiments = map[string]evalapi.Experiment{"exp-4": exp}
-	svc := New(api, time.Millisecond, time.Second)
+	svc := newTestService(api)
 
 	got, err := svc.SummarizeExperiment(ctx, "exp-4")
 	if err != nil {
@@ -379,6 +429,8 @@ func queryResult(query string, contextPrecision float64) evalapi.QueryResult {
 
 type fakeAPI struct {
 	datasets                 []evalapi.Dataset
+	createDatasetRequest     evalapi.CreateDatasetRequest
+	createdDatasetID         string
 	startResponse            evalapi.StartEvaluationResponse
 	startRequests            []evalapi.StartEvaluationRequest
 	detailsByID              map[string][]evalapi.EvaluationDetail
@@ -392,6 +444,15 @@ type fakeAPI struct {
 
 func (f *fakeAPI) ListDatasets(context.Context) ([]evalapi.Dataset, error) {
 	return f.datasets, nil
+}
+
+func (f *fakeAPI) CreateDataset(_ context.Context, req evalapi.CreateDatasetRequest) (evalapi.CreateDatasetResponse, error) {
+	f.createDatasetRequest = req
+	id := f.createdDatasetID
+	if id == "" {
+		id = "ds-created"
+	}
+	return evalapi.CreateDatasetResponse{ID: id}, nil
 }
 
 func (f *fakeAPI) StartEvaluation(_ context.Context, in evalapi.StartEvaluationRequest) (evalapi.StartEvaluationResponse, error) {
@@ -474,12 +535,48 @@ func (f *fakeAPI) UpdateExperiment(_ context.Context, id string, in evalapi.Upda
 	return exp, nil
 }
 
+type fakeIngestion struct {
+	collections []ingestionapi.Collection
+	configs     map[string]map[string]any
+}
+
+func (f fakeIngestion) ListCollections(context.Context) ([]ingestionapi.Collection, error) {
+	if f.collections != nil {
+		return f.collections, nil
+	}
+	return []ingestionapi.Collection{{Name: "documents"}, {Name: "kb"}}, nil
+}
+
+func (f fakeIngestion) GetCollectionConfig(_ context.Context, name string) (map[string]any, error) {
+	return f.configs[name], nil
+}
+
+type fakeFixtures struct {
+	fixtures []fixturecatalog.Fixture
+	fixture  fixturecatalog.Fixture
+}
+
+func (f fakeFixtures) List() ([]fixturecatalog.Fixture, error)     { return f.fixtures, nil }
+func (f fakeFixtures) Load(string) (fixturecatalog.Fixture, error) { return f.fixture, nil }
+
+func newTestService(api API) *Service {
+	return newTestServiceWithTiming(api, time.Millisecond, time.Second)
+}
+
+func newTestServiceWithTiming(api API, pollInterval, waitTimeout time.Duration) *Service {
+	return New(api, fakeIngestion{}, fakeFixtures{}, pollInterval, waitTimeout)
+}
+
 type blockingGetEvaluationAPI struct {
 	entered chan struct{}
 }
 
 func (b *blockingGetEvaluationAPI) ListDatasets(context.Context) ([]evalapi.Dataset, error) {
 	return nil, nil
+}
+
+func (b *blockingGetEvaluationAPI) CreateDataset(context.Context, evalapi.CreateDatasetRequest) (evalapi.CreateDatasetResponse, error) {
+	return evalapi.CreateDatasetResponse{}, nil
 }
 
 func (b *blockingGetEvaluationAPI) StartEvaluation(context.Context, evalapi.StartEvaluationRequest) (evalapi.StartEvaluationResponse, error) {

--- a/go/eval-mcp-service/internal/fixturecatalog/catalog.go
+++ b/go/eval-mcp-service/internal/fixturecatalog/catalog.go
@@ -1,0 +1,204 @@
+package fixturecatalog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	maxNameLen   = 100
+	maxItems     = 100
+	maxQueryLen  = 2000
+	maxAnswerLen = 5000
+)
+
+var datasetNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+type Catalog struct {
+	roots []string
+}
+
+type Fixture struct {
+	ID                string       `json:"id"`
+	Name              string       `json:"name"`
+	Path              string       `json:"path"`
+	DocumentRoot      string       `json:"document_root"`
+	ItemCount         int          `json:"item_count"`
+	ReferencedSources []string     `json:"referenced_sources"`
+	Valid             bool         `json:"valid"`
+	Errors            []string     `json:"errors,omitempty"`
+	Items             []GoldenItem `json:"-"`
+}
+
+type GoldenItem struct {
+	Query           string   `json:"query"`
+	ExpectedAnswer  string   `json:"expected_answer"`
+	ExpectedSources []string `json:"expected_sources"`
+}
+
+type fixtureFile struct {
+	Name  string       `json:"name"`
+	Items []GoldenItem `json:"items"`
+}
+
+func New(roots []string) *Catalog {
+	cleaned := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if strings.TrimSpace(root) != "" {
+			cleaned = append(cleaned, root)
+		}
+	}
+	return &Catalog{roots: cleaned}
+}
+
+func (c *Catalog) List() ([]Fixture, error) {
+	var fixtures []Fixture
+	for _, root := range c.roots {
+		matches, err := filepath.Glob(filepath.Join(root, "*.json"))
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(matches)
+		for _, path := range matches {
+			fixture, err := c.Load(path)
+			if err != nil {
+				fixtures = append(fixtures, Fixture{
+					ID:           filepath.Base(path),
+					Path:         path,
+					DocumentRoot: root,
+					Valid:        false,
+					Errors:       []string{err.Error()},
+				})
+				continue
+			}
+			fixtures = append(fixtures, fixture)
+		}
+	}
+	sort.Slice(fixtures, func(i, j int) bool { return fixtures[i].ID < fixtures[j].ID })
+	return fixtures, nil
+}
+
+func (c *Catalog) Load(idOrPath string) (Fixture, error) {
+	path, root, err := c.resolve(idOrPath)
+	if err != nil {
+		return Fixture{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Fixture{}, fmt.Errorf("read fixture %q: %w", path, err)
+	}
+	var raw fixtureFile
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Fixture{}, fmt.Errorf("parse fixture %q: %w", path, err)
+	}
+	fixture := Fixture{
+		ID:           filepath.Base(path),
+		Name:         raw.Name,
+		Path:         path,
+		DocumentRoot: root,
+		ItemCount:    len(raw.Items),
+		Items:        raw.Items,
+	}
+	fixture.Errors = validateFixture(raw, root)
+	fixture.ReferencedSources = referencedSources(raw.Items)
+	fixture.Valid = len(fixture.Errors) == 0
+	if !fixture.Valid {
+		return fixture, fmt.Errorf("invalid fixture %q: %s", path, strings.Join(fixture.Errors, "; "))
+	}
+	return fixture, nil
+}
+
+func (c *Catalog) resolve(idOrPath string) (string, string, error) {
+	for _, root := range c.roots {
+		candidate := idOrPath
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(root, idOrPath)
+		}
+		absRoot, err := filepath.Abs(root)
+		if err != nil {
+			return "", "", err
+		}
+		absCandidate, err := filepath.Abs(candidate)
+		if err != nil {
+			return "", "", err
+		}
+		rel, err := filepath.Rel(absRoot, absCandidate)
+		if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+			continue
+		}
+		if _, err := os.Stat(absCandidate); err == nil {
+			return absCandidate, absRoot, nil
+		}
+	}
+	return "", "", fmt.Errorf("fixture %q not found", idOrPath)
+}
+
+func validateFixture(raw fixtureFile, root string) []string {
+	var errs []string
+	if raw.Name == "" || len(raw.Name) > maxNameLen || !datasetNamePattern.MatchString(raw.Name) {
+		errs = append(errs, "name must match ^[a-zA-Z0-9_-]+$ and be 1-100 characters")
+	}
+	if len(raw.Items) == 0 || len(raw.Items) > maxItems {
+		errs = append(errs, "items must contain 1-100 entries")
+	}
+	for i, item := range raw.Items {
+		if strings.TrimSpace(item.Query) == "" || len(item.Query) > maxQueryLen {
+			errs = append(errs, fmt.Sprintf("items[%d].query must be 1-2000 characters", i))
+		}
+		if strings.TrimSpace(item.ExpectedAnswer) == "" || len(item.ExpectedAnswer) > maxAnswerLen {
+			errs = append(errs, fmt.Sprintf("items[%d].expected_answer must be 1-5000 characters", i))
+		}
+		for _, source := range item.ExpectedSources {
+			if err := validateSource(root, source); err != nil {
+				errs = append(errs, fmt.Sprintf("items[%d].expected_sources %q: %v", i, source, err))
+			}
+		}
+	}
+	return errs
+}
+
+func validateSource(root, source string) error {
+	if source == "" || filepath.IsAbs(source) {
+		return fmt.Errorf("must be a relative path")
+	}
+	ext := strings.ToLower(filepath.Ext(source))
+	if ext != ".pdf" && ext != ".md" {
+		return fmt.Errorf("must reference a .pdf or .md file")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	absSource, err := filepath.Abs(filepath.Join(root, source))
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(absRoot, absSource)
+	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return fmt.Errorf("must stay under document root")
+	}
+	if _, err := os.Stat(absSource); err != nil {
+		return err
+	}
+	return nil
+}
+
+func referencedSources(items []GoldenItem) []string {
+	seen := map[string]struct{}{}
+	for _, item := range items {
+		for _, source := range item.ExpectedSources {
+			seen[source] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for source := range seen {
+		out = append(out, source)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/go/eval-mcp-service/internal/fixturecatalog/catalog_test.go
+++ b/go/eval-mcp-service/internal/fixturecatalog/catalog_test.go
@@ -1,0 +1,92 @@
+package fixturecatalog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCatalogListsValidFixture(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "laptop-pro-15-specs.pdf", "%PDF-1.4")
+	writeFile(t, root, "rag-eval-dataset-product-docs.json", `{
+		"name": "product-docs-rag-v1",
+		"items": [{
+			"query": "How long does the battery last?",
+			"expected_answer": "Up to 10 hours of mixed use.",
+			"expected_sources": ["laptop-pro-15-specs.pdf"]
+		}]
+	}`)
+
+	catalog := New([]string{root})
+	fixtures, err := catalog.List()
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(fixtures) != 1 {
+		t.Fatalf("fixtures len = %d", len(fixtures))
+	}
+	got := fixtures[0]
+	if got.ID != "rag-eval-dataset-product-docs.json" || got.Name != "product-docs-rag-v1" || got.ItemCount != 1 || !got.Valid {
+		t.Fatalf("unexpected fixture: %#v", got)
+	}
+	if len(got.ReferencedSources) != 1 || got.ReferencedSources[0] != "laptop-pro-15-specs.pdf" {
+		t.Fatalf("unexpected sources: %#v", got.ReferencedSources)
+	}
+}
+
+func TestCatalogRejectsPathTraversalSource(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "fixture.json", `{
+		"name": "bad",
+		"items": [{
+			"query": "q",
+			"expected_answer": "a",
+			"expected_sources": ["../secret.pdf"]
+		}]
+	}`)
+
+	_, err := New([]string{root}).Load("fixture.json")
+	if err == nil || !strings.Contains(err.Error(), "must stay under document root") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCatalogRejectsMissingSource(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "fixture.json", `{
+		"name": "bad",
+		"items": [{
+			"query": "q",
+			"expected_answer": "a",
+			"expected_sources": ["missing.pdf"]
+		}]
+	}`)
+
+	_, err := New([]string{root}).Load("fixture.json")
+	if err == nil || !strings.Contains(err.Error(), "missing.pdf") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCatalogRejectsInvalidShape(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "fixture.json", `{"name": "bad name", "items": []}`)
+
+	_, err := New([]string{root}).Load("fixture.json")
+	if err == nil || !strings.Contains(err.Error(), "name must match") || !strings.Contains(err.Error(), "items must contain") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func writeFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}

--- a/go/eval-mcp-service/internal/ingestionapi/client.go
+++ b/go/eval-mcp-service/internal/ingestionapi/client.go
@@ -1,0 +1,97 @@
+package ingestionapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const errorExcerptLimit = 256
+
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+type Collection struct {
+	Name        string `json:"name"`
+	PointsCount int    `json:"points_count"`
+}
+
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Excerpt    string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("%s %s: status %d: %s", e.Method, e.Path, e.StatusCode, e.Excerpt)
+}
+
+func New(baseURL, token string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), token: token, httpClient: httpClient}
+}
+
+func (c *Client) ListCollections(ctx context.Context) ([]Collection, error) {
+	var response struct {
+		Collections []Collection `json:"collections"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/collections", nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Collections, nil
+}
+
+func (c *Client) GetCollectionConfig(ctx context.Context, name string) (map[string]any, error) {
+	var response map[string]any
+	path := "/collections/" + url.PathEscape(name) + "/config"
+	if err := c.do(ctx, http.MethodGet, path, nil, &response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, errorExcerptLimit))
+		return &HTTPError{Method: method, Path: path, StatusCode: resp.StatusCode, Excerpt: string(data)}
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/go/eval-mcp-service/internal/ingestionapi/client_test.go
+++ b/go/eval-mcp-service/internal/ingestionapi/client_test.go
@@ -1,0 +1,47 @@
+package ingestionapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientListCollections(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/collections" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"collections": []map[string]any{{"name": "documents", "points_count": 15}},
+		})
+	}))
+	defer server.Close()
+
+	got, err := New(server.URL, "", server.Client()).ListCollections(context.Background())
+	if err != nil {
+		t.Fatalf("ListCollections returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "documents" || got[0].PointsCount != 15 {
+		t.Fatalf("unexpected collections: %#v", got)
+	}
+}
+
+func TestClientGetCollectionConfig(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/collections/documents/config" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"chunk_size": 1000, "embedding_model": "nomic-embed-text"})
+	}))
+	defer server.Close()
+
+	got, err := New(server.URL, "", server.Client()).GetCollectionConfig(context.Background(), "documents")
+	if err != nil {
+		t.Fatalf("GetCollectionConfig returned error: %v", err)
+	}
+	if got["embedding_model"] != "nomic-embed-text" {
+		t.Fatalf("unexpected config: %#v", got)
+	}
+}

--- a/go/eval-mcp-service/internal/mcpserver/server.go
+++ b/go/eval-mcp-service/internal/mcpserver/server.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalapi"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalworkflow"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/fixturecatalog"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/ingestionapi"
 )
 
 const workflowResourceURI = "eval://workflow"
@@ -25,6 +27,10 @@ type EvalService interface {
 	ListExperiments(context.Context) ([]evalapi.Experiment, error)
 	GetExperiment(context.Context, string) (evalapi.Experiment, error)
 	ListDatasets(context.Context) ([]evalapi.Dataset, error)
+	ListDatasetFixtures(context.Context) ([]fixturecatalog.Fixture, error)
+	CreateDatasetFromFixture(context.Context, string) (evalworkflow.CreateDatasetResult, error)
+	ListRAGCollections(context.Context) ([]ingestionapi.Collection, error)
+	GetRAGCollectionConfig(context.Context, string) (map[string]any, error)
 	StartRun(context.Context, evalworkflow.StartRunInput) (evalworkflow.StartRunResult, error)
 	WaitForRun(context.Context, string) (evalworkflow.WaitResult, error)
 	AttachRun(context.Context, string, string, string, string) error
@@ -43,6 +49,10 @@ func New(service EvalService) *sdkmcp.Server {
 	addTool(srv, "list_eval_experiments", "List local eval experiment sessions.", emptySchema(), listEvalExperimentsHandler(service))
 	addTool(srv, "get_eval_experiment", "Get one local eval experiment with run labels.", experimentIDSchema(), getEvalExperimentHandler(service))
 	addTool(srv, "list_eval_datasets", "List datasets from the eval API.", emptySchema(), listEvalDatasetsHandler(service))
+	addTool(srv, "list_eval_dataset_fixtures", "List curated eval dataset fixtures available in the repo.", emptySchema(), listEvalDatasetFixturesHandler(service))
+	addTool(srv, "create_eval_dataset", "Create an eval API dataset from a curated repo fixture.", createEvalDatasetSchema(), createEvalDatasetHandler(service))
+	addTool(srv, "list_rag_collections", "List Qdrant retrieval collections from ingestion.", emptySchema(), listRAGCollectionsHandler(service))
+	addTool(srv, "get_rag_collection_config", "Fetch ingestion metadata for one RAG collection.", ragCollectionConfigSchema(), getRAGCollectionConfigHandler(service))
 	addTool(srv, "start_eval_run", "Start an eval API run and optionally attach it to an experiment label.", startEvalRunSchema(), startEvalRunHandler(service))
 	addTool(srv, "wait_for_eval_run", "Poll one eval run until completion, failure, or timeout.", waitEvalRunSchema(), waitForEvalRunHandler(service))
 	addTool(srv, "attach_eval_run", "Attach an existing eval run ID to a local experiment label.", attachEvalRunSchema(), attachEvalRunHandler(service))
@@ -126,6 +136,52 @@ func getEvalExperimentHandler(service EvalService) sdkmcp.ToolHandler {
 func listEvalDatasetsHandler(service EvalService) sdkmcp.ToolHandler {
 	return func(ctx context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
 		result, err := service.ListDatasets(ctx)
+		return resultOrError(result, err), nil
+	}
+}
+
+func listEvalDatasetFixturesHandler(service EvalService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		result, err := service.ListDatasetFixtures(ctx)
+		return resultOrError(result, err), nil
+	}
+}
+
+func createEvalDatasetHandler(service EvalService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args struct {
+			Fixture string `json:"fixture"`
+		}
+		if err := decodeArgs(req, &args); err != nil {
+			return toolError(err.Error()), nil
+		}
+		if strings.TrimSpace(args.Fixture) == "" {
+			return toolError("fixture is required"), nil
+		}
+		result, err := service.CreateDatasetFromFixture(ctx, args.Fixture)
+		return resultOrError(result, err), nil
+	}
+}
+
+func listRAGCollectionsHandler(service EvalService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		result, err := service.ListRAGCollections(ctx)
+		return resultOrError(result, err), nil
+	}
+}
+
+func getRAGCollectionConfigHandler(service EvalService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args struct {
+			Name string `json:"name"`
+		}
+		if err := decodeArgs(req, &args); err != nil {
+			return toolError(err.Error()), nil
+		}
+		if strings.TrimSpace(args.Name) == "" {
+			return toolError("name is required"), nil
+		}
+		result, err := service.GetRAGCollectionConfig(ctx, args.Name)
 		return resultOrError(result, err), nil
 	}
 }
@@ -339,7 +395,7 @@ func evalPromptHandler() sdkmcp.PromptHandler {
 			Description: "Start an agent-led RAG eval experiment.",
 			Messages: []*sdkmcp.PromptMessage{{
 				Role:    sdkmcp.Role("user"),
-				Content: &sdkmcp.TextContent{Text: "Start or resume a RAG eval experiment. Use start_eval_experiment for local experiment state, list_eval_datasets to choose data, start_eval_run and wait_for_eval_run for baseline and candidate runs, compare_eval_runs to measure deltas, get_worst_eval_cases to inspect failures, summarize_eval_experiment for the final evidence packet, and record_eval_experiment_conclusion once the user approves the conclusion."},
+				Content: &sdkmcp.TextContent{Text: "Start or resume a RAG eval experiment. Datasets are golden questions and expected answers. Collections are Qdrant retrieval corpora. Never infer a collection from a dataset name. Use list_eval_dataset_fixtures and create_eval_dataset for curated repo fixtures, list_eval_datasets to choose existing API data, then use list_rag_collections and get_rag_collection_config before start_eval_experiment or start_eval_run. Run baseline to completion with wait_for_eval_run before starting rerank while runtime hardening is pending. Compare only completed runs with compare_eval_runs, inspect failures with get_worst_eval_cases, summarize_eval_experiment for the final evidence packet, and record_eval_experiment_conclusion once the user approves the conclusion."},
 			}},
 		}, nil
 	}
@@ -364,12 +420,15 @@ func evalWorkflowInstructions() string {
 Use this local MCP server to keep RAG eval experiments explicit and reproducible.
 
 1. Start or resume local experiment state with start_eval_experiment, list_eval_experiments, or get_eval_experiment.
-2. Call list_eval_datasets before choosing a dataset unless the user already named a dataset ID.
-3. Start baseline and candidate runs with start_eval_run, then call wait_for_eval_run until each run completes or fails.
-4. Attach externally created runs with attach_eval_run when needed.
-5. Use get_eval_run for individual run inspection, compare_eval_runs for metric deltas, and get_worst_eval_cases for the lowest-scoring per-query cases.
-6. Call summarize_eval_experiment before presenting a recommendation.
-7. Only call record_eval_experiment_conclusion after the user approves the conclusion.
+2. Datasets are golden questions and expected answers. Collections are Qdrant retrieval corpora. Never infer a collection from a dataset name.
+3. Use list_eval_dataset_fixtures and create_eval_dataset for curated repo fixtures, or call list_eval_datasets before choosing an existing dataset unless the user already named a dataset ID.
+4. Use list_rag_collections and get_rag_collection_config before start_eval_experiment or start_eval_run.
+5. Start baseline with start_eval_run and wait_for_eval_run. Run baseline to completion before starting rerank while runtime hardening is pending.
+6. Start candidate runs with start_eval_run, then call wait_for_eval_run until each run completes or fails.
+7. Attach externally created runs with attach_eval_run when needed.
+8. Use get_eval_run for individual run inspection, compare_eval_runs for metric deltas, and get_worst_eval_cases for the lowest-scoring per-query cases. Compare only completed runs.
+9. Call summarize_eval_experiment before presenting a recommendation.
+10. Only call record_eval_experiment_conclusion after the user approves the conclusion.
 `)
 }
 
@@ -447,6 +506,14 @@ func attachEvalRunSchema() json.RawMessage {
 
 func evalIDSchema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"eval_id":{"type":"string"}},"required":["eval_id"],"additionalProperties":false}`)
+}
+
+func createEvalDatasetSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"fixture":{"type":"string","minLength":1}},"required":["fixture"],"additionalProperties":false}`)
+}
+
+func ragCollectionConfigSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"name":{"type":"string","minLength":1}},"required":["name"],"additionalProperties":false}`)
 }
 
 func compareEvalRunsSchema() json.RawMessage {

--- a/go/eval-mcp-service/internal/mcpserver/server_test.go
+++ b/go/eval-mcp-service/internal/mcpserver/server_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalapi"
 	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/evalworkflow"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/fixturecatalog"
+	"github.com/kabradshaw1/portfolio/go/eval-mcp-service/internal/ingestionapi"
 )
 
 type fakeEvalService struct {
@@ -50,6 +52,22 @@ func (f *fakeEvalService) GetExperiment(context.Context, string) (evalapi.Experi
 
 func (f *fakeEvalService) ListDatasets(context.Context) ([]evalapi.Dataset, error) {
 	return []evalapi.Dataset{{ID: "ds-1", Name: "RAG Smoke", ItemCount: 3}}, nil
+}
+
+func (f *fakeEvalService) ListDatasetFixtures(context.Context) ([]fixturecatalog.Fixture, error) {
+	return []fixturecatalog.Fixture{{ID: "rag-eval-dataset-product-docs.json", Name: "product-docs-rag-v1", Valid: true}}, nil
+}
+
+func (f *fakeEvalService) CreateDatasetFromFixture(context.Context, string) (evalworkflow.CreateDatasetResult, error) {
+	return evalworkflow.CreateDatasetResult{ID: "ds-created", Name: "product-docs-rag-v1"}, nil
+}
+
+func (f *fakeEvalService) ListRAGCollections(context.Context) ([]ingestionapi.Collection, error) {
+	return []ingestionapi.Collection{{Name: "documents", PointsCount: 15}}, nil
+}
+
+func (f *fakeEvalService) GetRAGCollectionConfig(context.Context, string) (map[string]any, error) {
+	return map[string]any{"chunk_size": 1000}, nil
 }
 
 func (f *fakeEvalService) StartRun(_ context.Context, in evalworkflow.StartRunInput) (evalworkflow.StartRunResult, error) {
@@ -110,11 +128,15 @@ func TestServerRegistersPromptResourceAndTools(t *testing.T) {
 	wantTools := []string{
 		"attach_eval_run",
 		"compare_eval_runs",
+		"create_eval_dataset",
 		"get_eval_experiment",
 		"get_eval_run",
+		"get_rag_collection_config",
 		"get_worst_eval_cases",
+		"list_eval_dataset_fixtures",
 		"list_eval_datasets",
 		"list_eval_experiments",
+		"list_rag_collections",
 		"record_eval_experiment_conclusion",
 		"start_eval_experiment",
 		"start_eval_run",
@@ -166,6 +188,28 @@ func TestStartEvalRunValidationError(t *testing.T) {
 	}
 	if fake.startRunCalls != 0 {
 		t.Fatalf("service should not be called on validation error, got %d calls", fake.startRunCalls)
+	}
+}
+
+func TestCreateEvalDatasetHandlerRequiresFixture(t *testing.T) {
+	result, err := createEvalDatasetHandler(&fakeEvalService{})(context.Background(), callReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected MCP tool error")
+	}
+}
+
+func TestListRAGCollectionsHandler(t *testing.T) {
+	result, err := listRAGCollectionsHandler(&fakeEvalService{})(context.Background(), callReq(map[string]any{}))
+	if err != nil || result.IsError {
+		t.Fatalf("handler failed: result=%#v err=%v", result, err)
+	}
+	var payload []ingestionapi.Collection
+	unmarshalTextResult(t, result, &payload)
+	if len(payload) != 1 || payload[0].Name != "documents" {
+		t.Fatalf("unexpected payload: %#v", payload)
 	}
 }
 
@@ -315,7 +359,7 @@ func TestEvalPromptHandler(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected text prompt content, got %T", result.Messages[0].Content)
 	}
-	for _, want := range []string{"start_eval_experiment", "list_eval_datasets", "start_eval_run", "wait_for_eval_run", "compare_eval_runs", "get_worst_eval_cases", "record_eval_experiment_conclusion"} {
+	for _, want := range []string{"start_eval_experiment", "list_eval_dataset_fixtures", "create_eval_dataset", "list_eval_datasets", "list_rag_collections", "get_rag_collection_config", "start_eval_run", "wait_for_eval_run", "compare_eval_runs", "get_worst_eval_cases", "record_eval_experiment_conclusion", "Never infer a collection from a dataset name", "Compare only completed runs"} {
 		if !strings.Contains(text.Text, want) {
 			t.Fatalf("expected prompt to mention %s, got %q", want, text.Text)
 		}
@@ -337,7 +381,7 @@ func TestWorkflowResourceHandler(t *testing.T) {
 	if content.MIMEType != "text/markdown" {
 		t.Fatalf("unexpected resource MIME type: %q", content.MIMEType)
 	}
-	for _, want := range []string{"start_eval_experiment", "list_eval_datasets", "start_eval_run", "wait_for_eval_run", "compare_eval_runs", "get_worst_eval_cases", "record_eval_experiment_conclusion"} {
+	for _, want := range []string{"start_eval_experiment", "list_eval_dataset_fixtures", "create_eval_dataset", "list_eval_datasets", "list_rag_collections", "get_rag_collection_config", "start_eval_run", "wait_for_eval_run", "compare_eval_runs", "get_worst_eval_cases", "record_eval_experiment_conclusion", "Never infer a collection from a dataset name", "Compare only completed runs"} {
 		if !strings.Contains(content.Text, want) {
 			t.Fatalf("expected workflow resource to mention %s, got %q", want, content.Text)
 		}


### PR DESCRIPTION
## Summary
- Add curated dataset fixture discovery plus eval dataset creation and ingestion collection clients.
- Wire fixture and collection validation into eval MCP workflow runs, summaries, and comparisons.
- Expose MCP tools for fixtures/collections and document the dataset vs collection workflow.

## Test Plan
- go test ./... (from go/eval-mcp-service)
- make preflight-go