### PR TITLE
Harden eval runtime metadata handling

### DIFF
--- a/services/eval/app/collection_validation.py
+++ b/services/eval/app/collection_validation.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import httpx
+from fastapi import HTTPException
+
+
+async def validate_collection_exists(ingestion_url: str, collection: str) -> None:
+    """Raise HTTPException if the requested Qdrant collection is unavailable."""
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{ingestion_url}/collections", timeout=5.0)
+            resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"unable to validate retrieval collection {collection!r}: {exc}",
+        ) from exc
+
+    collections = resp.json().get("collections", [])
+    names = {item.get("name") for item in collections if isinstance(item, dict)}
+    if collection not in names:
+        raise HTTPException(
+            status_code=422,
+            detail=f'retrieval collection "{collection}" does not exist',
+        )

--- a/services/eval/app/config_capture.py
+++ b/services/eval/app/config_capture.py
@@ -27,6 +27,7 @@ async def capture_run_config(
     chat_url: str,
     ingestion_url: str,
     collection: str,
+    requested_rerank: bool,
 ) -> dict:
     """Return a merged RAG config snapshot. Always returns a dict.
 
@@ -42,7 +43,11 @@ async def capture_run_config(
             return_exceptions=True,
         )
 
-    out: dict = {"captured_at": captured_at}
+    out: dict = {
+        "captured_at": captured_at,
+        "effective_collection": collection,
+        "requested_rerank": requested_rerank,
+    }
     errors: list[str] = []
 
     if isinstance(chat_res, Exception):

--- a/services/eval/app/main.py
+++ b/services/eval/app/main.py
@@ -570,6 +570,18 @@ async def compare_evaluations(
             status_code=400, detail="all runs must belong to the same dataset"
         )
 
+    invalid_statuses = [
+        f"{r['id']}={r.get('status')}" for r in runs if r.get("status") != "completed"
+    ]
+    if invalid_statuses:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "compare requires completed runs; invalid statuses: "
+                + ", ".join(invalid_statuses)
+            ),
+        )
+
     deltas: dict[str, list[float]] = {}
     for metric in _EVAL_METRICS:
         baseline = (runs[0].get("aggregate_scores") or {}).get(metric)

--- a/services/eval/app/main.py
+++ b/services/eval/app/main.py
@@ -94,11 +94,12 @@ async def health():
     except Exception:
         chat_ok = False
 
-    status = "healthy" if chat_ok else "degraded"
-    code = 200 if chat_ok else 503
     return JSONResponse(
-        status_code=code,
-        content={"status": status, "chat_service": "ok" if chat_ok else "unreachable"},
+        status_code=200,
+        content={
+            "status": "healthy",
+            "chat_service": "ok" if chat_ok else "unreachable",
+        },
     )
 
 

--- a/services/eval/app/main.py
+++ b/services/eval/app/main.py
@@ -15,6 +15,7 @@ from slowapi.util import get_remote_address
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from app.collection_validation import validate_collection_exists
 from app.config import settings
 from app.config_capture import capture_run_config
 from app.db import EvalDB
@@ -266,6 +267,8 @@ async def start_evaluation(
             db, body.experiment_id, body.dataset_id, collection
         )
 
+    await validate_collection_exists(settings.ingestion_service_url, collection)
+
     eval_id = await db.create_evaluation(
         dataset_id=body.dataset_id,
         collection=collection,
@@ -286,7 +289,7 @@ async def start_evaluation(
             raise HTTPException(status_code=status_code, detail=detail) from exc
 
     background_tasks.add_task(
-        _run_evaluation_task, eval_id, dataset["items"], body.collection, body.rerank
+        _run_evaluation_task, eval_id, dataset["items"], collection, body.rerank
     )
 
     return {"id": eval_id, "status": "running"}

--- a/services/eval/app/main.py
+++ b/services/eval/app/main.py
@@ -149,6 +149,7 @@ async def _run_evaluation_task(
             chat_url=settings.chat_service_url,
             ingestion_url=settings.ingestion_service_url,
             collection=coll_name,
+            requested_rerank=rerank,
         )
         await db.set_evaluation_config(eval_id, config)
 

--- a/services/eval/tests/test_collection_validation.py
+++ b/services/eval/tests/test_collection_validation.py
@@ -1,0 +1,49 @@
+import httpx
+import pytest
+import respx
+from app.collection_validation import validate_collection_exists
+from fastapi import HTTPException
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_validate_collection_exists_accepts_existing_collection():
+    respx.get("http://ingestion/collections").mock(
+        return_value=httpx.Response(
+            200,
+            json={"collections": [{"name": "documents", "points_count": 15}]},
+        )
+    )
+
+    await validate_collection_exists("http://ingestion", "documents")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_validate_collection_exists_rejects_missing_collection():
+    respx.get("http://ingestion/collections").mock(
+        return_value=httpx.Response(
+            200,
+            json={"collections": [{"name": "documents", "points_count": 15}]},
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await validate_collection_exists("http://ingestion", "missing")
+
+    assert exc.value.status_code == 422
+    assert 'retrieval collection "missing" does not exist' in exc.value.detail
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_validate_collection_exists_reports_dependency_failure():
+    respx.get("http://ingestion/collections").mock(
+        side_effect=httpx.ConnectError("boom")
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await validate_collection_exists("http://ingestion", "documents")
+
+    assert exc.value.status_code == 503
+    assert "unable to validate retrieval collection" in exc.value.detail

--- a/services/eval/tests/test_config_capture.py
+++ b/services/eval/tests/test_config_capture.py
@@ -41,12 +41,38 @@ async def test_capture_merges_chat_and_collection():
         chat_url="http://chat",
         ingestion_url="http://ingestion",
         collection="documents",
+        requested_rerank=True,
     )
 
     assert cfg["chat"] == expected_chat_config
     assert cfg["collection"]["chunk_size"] == 1000
+    assert cfg["requested_rerank"] is True
+    assert cfg["effective_collection"] == "documents"
     assert "captured_at" in cfg
     assert "_capture_error" not in cfg
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_capture_records_baseline_rerank_intent():
+    respx.get("http://chat/config").mock(
+        return_value=httpx.Response(200, json={"rerank_enabled": True})
+    )
+    respx.get("http://ingestion/collections/documents/config").mock(
+        return_value=httpx.Response(404, json={"detail": "not found"})
+    )
+
+    cfg = await capture_run_config(
+        chat_url="http://chat",
+        ingestion_url="http://ingestion",
+        collection="documents",
+        requested_rerank=False,
+    )
+
+    assert cfg["requested_rerank"] is False
+    assert cfg["effective_collection"] == "documents"
+    assert cfg["chat"]["rerank_enabled"] is True
+    assert "_capture_error" in cfg
 
 
 @pytest.mark.asyncio
@@ -68,6 +94,7 @@ async def test_capture_records_error_when_chat_fails():
         chat_url="http://chat",
         ingestion_url="http://ingestion",
         collection="documents",
+        requested_rerank=False,
     )
 
     assert "_capture_error" in cfg
@@ -98,6 +125,7 @@ async def test_capture_records_error_when_collection_unknown():
         chat_url="http://chat",
         ingestion_url="http://ingestion",
         collection="nope",
+        requested_rerank=False,
     )
 
     assert "_capture_error" in cfg
@@ -117,6 +145,7 @@ async def test_capture_records_both_errors_when_both_fail():
         chat_url="http://chat",
         ingestion_url="http://ingestion",
         collection="documents",
+        requested_rerank=False,
     )
 
     assert "_capture_error" in cfg

--- a/services/eval/tests/test_main.py
+++ b/services/eval/tests/test_main.py
@@ -715,6 +715,36 @@ def test_start_evaluation_passes_rerank_to_background_run(
 
     assert response.status_code == 202
     assert mock_run_evaluation.await_args.kwargs["rerank"] is True
+    assert mock_capture.await_args.kwargs["requested_rerank"] is True
+    assert mock_capture.await_args.kwargs["collection"] == "documents"
+
+
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
+@patch("app.main.run_evaluation", new_callable=AsyncMock)
+@patch("app.main.capture_run_config", new_callable=AsyncMock)
+@patch("app.main.get_db")
+def test_start_evaluation_records_baseline_rerank_metadata(
+    mock_get_db, mock_capture, mock_run_evaluation, mock_validate_collection
+):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-base",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.create_evaluation.return_value = "eval-base"
+    mock_get_db.return_value = mock_db
+    mock_capture.return_value = {"captured_at": "x", "requested_rerank": False}
+    mock_run_evaluation.return_value = ({"faithfulness": 0.7}, [])
+
+    response = client.post("/evaluations", json={"dataset_id": "ds-base"})
+
+    assert response.status_code == 202
+    assert mock_capture.await_args.kwargs["requested_rerank"] is False
+    mock_db.set_evaluation_config.assert_awaited_once_with(
+        "eval-base", mock_capture.return_value
+    )
 
 
 @patch("app.main.validate_collection_exists", new_callable=AsyncMock)

--- a/services/eval/tests/test_main.py
+++ b/services/eval/tests/test_main.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from app.config import settings
 from app.main import app
@@ -1526,13 +1527,15 @@ def test_attach_experiment_run_duplicate_label_returns_409(mock_get_db):
 
 
 @patch("app.main.httpx.AsyncClient")
-def test_health_degraded_when_chat_unreachable(mock_client_cls):
+def test_health_returns_200_when_chat_degraded(mock_client_cls):
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.get.side_effect = Exception("connection refused")
+    mock_client.get.side_effect = httpx.ConnectError("boom")
     mock_client_cls.return_value = mock_client
 
     response = client.get("/health")
-    assert response.status_code == 503
-    assert response.json()["status"] == "degraded"
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["chat_service"] == "unreachable"

--- a/services/eval/tests/test_main.py
+++ b/services/eval/tests/test_main.py
@@ -1027,6 +1027,36 @@ def test_compare_400_on_mixed_datasets(mock_get_db):
 
 
 @patch("app.main.get_db")
+def test_compare_rejects_running_runs(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_evaluations_by_ids.return_value = [
+        _stub_run("base", "ds-1", {"faithfulness": 0.8}) | {"status": "completed"},
+        _stub_run("candidate", "ds-1", None) | {"status": "running"},
+    ]
+    mock_get_db.return_value = mock_db
+
+    response = client.get("/evaluations/compare?ids=base,candidate")
+
+    assert response.status_code == 400
+    assert "candidate=running" in response.json()["detail"]
+
+
+@patch("app.main.get_db")
+def test_compare_rejects_failed_runs(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_evaluations_by_ids.return_value = [
+        _stub_run("base", "ds-1", {"faithfulness": 0.8}) | {"status": "completed"},
+        _stub_run("candidate", "ds-1", None) | {"status": "failed"},
+    ]
+    mock_get_db.return_value = mock_db
+
+    response = client.get("/evaluations/compare?ids=base,candidate")
+
+    assert response.status_code == 400
+    assert "candidate=failed" in response.json()["detail"]
+
+
+@patch("app.main.get_db")
 def test_compare_404_on_unknown_id(mock_get_db):
     mock_db = AsyncMock()
     mock_db.get_evaluations_by_ids.return_value = []

--- a/services/eval/tests/test_main.py
+++ b/services/eval/tests/test_main.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from app.config import settings
 from app.main import app
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 client = TestClient(app)
@@ -111,8 +113,9 @@ def test_list_datasets(mock_get_db):
 # --- Evaluation endpoints ---
 
 
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
-def test_start_evaluation(mock_get_db):
+def test_start_evaluation(mock_get_db, mock_validate_collection):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
         "id": "ds-123",
@@ -228,8 +231,11 @@ def test_list_evaluations(mock_get_db):
     assert len(response.json()["evaluations"]) == 1
 
 
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
-def test_start_evaluation_persists_notes_and_baseline(mock_get_db):
+def test_start_evaluation_persists_notes_and_baseline(
+    mock_get_db, mock_validate_collection
+):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
         "id": "ds-123",
@@ -377,8 +383,11 @@ def test_start_evaluation_rejects_baseline_for_different_collection(mock_get_db)
     mock_db.create_evaluation.assert_not_awaited()
 
 
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
-def test_start_evaluation_accepts_valid_baseline_for_custom_collection(mock_get_db):
+def test_start_evaluation_accepts_valid_baseline_for_custom_collection(
+    mock_get_db, mock_validate_collection
+):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
         "id": "ds-123",
@@ -406,6 +415,34 @@ def test_start_evaluation_accepts_valid_baseline_for_custom_collection(mock_get_
         notes=None,
         baseline_eval_id="eval-prev",
     )
+
+
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
+@patch("app.main.get_db")
+def test_start_evaluation_rejects_missing_collection_before_create(
+    mock_get_db, mock_validate_collection
+):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-123",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_get_db.return_value = mock_db
+    mock_validate_collection.side_effect = HTTPException(
+        status_code=422,
+        detail='retrieval collection "missing" does not exist',
+    )
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-123", "collection": "missing"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == 'retrieval collection "missing" does not exist'
+    mock_db.create_evaluation.assert_not_awaited()
 
 
 @patch("app.main.get_db")
@@ -591,8 +628,11 @@ def test_update_experiment_rejects_completed_without_decision_conclusion_or_evid
 
 @patch("app.main.run_evaluation", new_callable=AsyncMock)
 @patch("app.main.capture_run_config", new_callable=AsyncMock)
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
-def test_run_persists_config_snapshot(mock_get_db, mock_capture, mock_run_evaluation):
+def test_run_persists_config_snapshot(
+    mock_get_db, mock_validate_collection, mock_capture, mock_run_evaluation
+):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
         "id": "ds-cfg",
@@ -627,9 +667,10 @@ def test_run_persists_config_snapshot(mock_get_db, mock_capture, mock_run_evalua
 
 @patch("app.main.run_evaluation", new_callable=AsyncMock)
 @patch("app.main.capture_run_config", new_callable=AsyncMock)
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
 def test_run_uses_default_collection_when_none_provided(
-    mock_get_db, mock_capture, mock_run_evaluation
+    mock_get_db, mock_validate_collection, mock_capture, mock_run_evaluation
 ):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
@@ -650,9 +691,10 @@ def test_run_uses_default_collection_when_none_provided(
 
 @patch("app.main.run_evaluation", new_callable=AsyncMock)
 @patch("app.main.capture_run_config", new_callable=AsyncMock)
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
 def test_start_evaluation_passes_rerank_to_background_run(
-    mock_get_db, mock_capture, mock_run_evaluation
+    mock_get_db, mock_validate_collection, mock_capture, mock_run_evaluation
 ):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
@@ -675,8 +717,9 @@ def test_start_evaluation_passes_rerank_to_background_run(
     assert mock_run_evaluation.await_args.kwargs["rerank"] is True
 
 
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
-def test_start_evaluation_omits_optional_fields(mock_get_db):
+def test_start_evaluation_omits_optional_fields(mock_get_db, mock_validate_collection):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
         "id": "ds-123",
@@ -695,10 +738,16 @@ def test_start_evaluation_omits_optional_fields(mock_get_db):
         notes=None,
         baseline_eval_id=None,
     )
+    mock_validate_collection.assert_awaited_once_with(
+        settings.ingestion_service_url, "documents"
+    )
 
 
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.get_db")
-def test_start_evaluation_attaches_run_to_experiment(mock_get_db):
+def test_start_evaluation_attaches_run_to_experiment(
+    mock_get_db, mock_validate_collection
+):
     mock_db = AsyncMock()
     mock_db.get_dataset.return_value = {
         "id": "ds-123",


### PR DESCRIPTION
## Summary
- Validate eval retrieval collections before creating runs.
- Capture requested rerank and effective collection metadata with eval configs.
- Keep eval health ready when chat is unreachable and reject incomplete run comparisons.

## Test Plan
- [x] PYTHONPATH=services:services/eval .venv-eval/bin/python -m pytest services/eval/tests -q
- [x] PYTHONPATH=services PATH=\"/opt/homebrew/opt/python@3.13/libexec/bin:$PATH\" make preflight-python
- [x] make preflight-security