### PR TITLE
Add private Grafana gateway for observability MCP

### DIFF
--- a/docs/ops/observability-api-cloudflare-access.md
+++ b/docs/ops/observability-api-cloudflare-access.md
@@ -1,0 +1,68 @@
+# Observability API Cloudflare Access Setup
+
+## Purpose
+
+`observability-api.kylebradshaw.dev` is the authenticated API entry point for
+local Observability MCP access. `grafana.kylebradshaw.dev` remains public for
+portfolio dashboard viewing.
+
+## Required Cloudflare Configuration
+
+Create a Cloudflare Access application for:
+
+```text
+observability-api.kylebradshaw.dev
+```
+
+Policy:
+
+- Allow only Kyle's account and the Observability MCP service token.
+- Deny unauthenticated requests.
+- Leave `grafana.kylebradshaw.dev` outside this Access policy so public
+  dashboards continue to load.
+
+## Service Token
+
+Create a service token named:
+
+```text
+observability-mcp-local
+```
+
+Store the token only on the development machine:
+
+```text
+~/.codex/env/observability-mcp.env
+```
+
+Expected local file shape:
+
+```bash
+export OBS_GRAFANA_URL="https://observability-api.kylebradshaw.dev"
+export OBS_GRAFANA_ACCESS_CLIENT_ID="<cloudflare-access-client-id>"
+export OBS_GRAFANA_ACCESS_CLIENT_SECRET="<cloudflare-access-client-secret>"
+```
+
+Do not commit token values.
+
+## Verification
+
+Without service-token headers:
+
+```bash
+curl -I https://observability-api.kylebradshaw.dev/api/health
+```
+
+Expected: Cloudflare Access denies or redirects the request.
+
+With service-token headers:
+
+```bash
+source ~/.codex/env/observability-mcp.env
+curl -fsS \
+  -H "CF-Access-Client-Id: ${OBS_GRAFANA_ACCESS_CLIENT_ID}" \
+  -H "CF-Access-Client-Secret: ${OBS_GRAFANA_ACCESS_CLIENT_SECRET}" \
+  "${OBS_GRAFANA_URL}/api/health"
+```
+
+Expected: Grafana health JSON.

--- a/go/observability-mcp-service/README.md
+++ b/go/observability-mcp-service/README.md
@@ -30,6 +30,8 @@ codex mcp add observability -- zsh -lc 'source ~/.codex/env/observability-mcp.en
 | `OBS_GRAFANA_TOKEN` | unset | Optional Grafana service account token. |
 | `OBS_GRAFANA_ACCESS_CLIENT_ID` | unset | Cloudflare Access service-token client ID for Grafana gateway mode. |
 | `OBS_GRAFANA_ACCESS_CLIENT_SECRET` | unset | Cloudflare Access service-token client secret for Grafana gateway mode. |
+| `OBS_GRAFANA_PROMETHEUS_DS_UID` | `PBFA97CFB590B2093` | Grafana Prometheus datasource UID for gateway mode. |
+| `OBS_GRAFANA_LOKI_DS_UID` | `loki` | Grafana Loki datasource UID for gateway mode. |
 | `OBS_QUERY_TIMEOUT` | `5s` | Shared HTTP client timeout. |
 | `OBS_DEFAULT_WINDOW` | `15m` | Default investigation window. |
 | `OBS_MAX_WINDOW` | `1h` | Maximum accepted investigation window. |

--- a/go/observability-mcp-service/README.md
+++ b/go/observability-mcp-service/README.md
@@ -26,11 +26,46 @@ codex mcp add observability -- go run /Users/kylebradshaw/repos/gen_ai_engineer/
 | `OBS_PROMETHEUS_URL` | `http://localhost:9090` | Prometheus HTTP API endpoint. |
 | `OBS_LOKI_URL` | `http://localhost:3100` | Loki HTTP API endpoint. |
 | `OBS_JAEGER_URL` | `http://localhost:16686` | Jaeger query API endpoint. |
+| `OBS_GRAFANA_URL` | unset | Grafana gateway endpoint for Prometheus and Loki datasource proxy mode. |
+| `OBS_GRAFANA_TOKEN` | unset | Optional Grafana service account token. |
+| `OBS_GRAFANA_ACCESS_CLIENT_ID` | unset | Cloudflare Access service-token client ID for Grafana gateway mode. |
+| `OBS_GRAFANA_ACCESS_CLIENT_SECRET` | unset | Cloudflare Access service-token client secret for Grafana gateway mode. |
 | `OBS_QUERY_TIMEOUT` | `5s` | Shared HTTP client timeout. |
 | `OBS_DEFAULT_WINDOW` | `15m` | Default investigation window. |
 | `OBS_MAX_WINDOW` | `1h` | Maximum accepted investigation window. |
 | `OBS_MAX_LOG_LINES` | `100` | Maximum log lines per Loki query. |
 | `OBS_MAX_TRACE_SPANS` | `100` | Maximum spans returned per trace. |
+
+## Grafana Gateway Mode
+
+For normal development-machine usage, prefer Grafana gateway mode instead of
+direct local Prometheus/Loki/Jaeger ports.
+
+Create an uncommitted local env file:
+
+```bash
+mkdir -p ~/.codex/env
+$EDITOR ~/.codex/env/observability-mcp.env
+```
+
+Expected shape:
+
+```bash
+export OBS_GRAFANA_URL="https://observability-api.kylebradshaw.dev"
+export OBS_GRAFANA_ACCESS_CLIENT_ID="<cloudflare-access-client-id>"
+export OBS_GRAFANA_ACCESS_CLIENT_SECRET="<cloudflare-access-client-secret>"
+```
+
+Optional, if Grafana itself requires a service account token in addition to
+Cloudflare Access:
+
+```bash
+export OBS_GRAFANA_TOKEN="<grafana-service-account-token>"
+```
+
+The MCP remains read-only. SSH-based diagnostics remain available through the
+`debug-observability` skill for break-glass cases and when the observability
+gateway is unavailable.
 
 ## Tools
 

--- a/go/observability-mcp-service/README.md
+++ b/go/observability-mcp-service/README.md
@@ -16,7 +16,7 @@ HTTP listener in v1.
 ## Codex Registration
 
 ```bash
-codex mcp add observability -- go run /Users/kylebradshaw/repos/gen_ai_engineer/go/observability-mcp-service/cmd/observability-mcp
+codex mcp add observability -- zsh -lc 'source ~/.codex/env/observability-mcp.env && cd /Users/kylebradshaw/repos/gen_ai_engineer/go/observability-mcp-service && exec go run ./cmd/observability-mcp'
 ```
 
 ## Configuration
@@ -38,8 +38,9 @@ codex mcp add observability -- go run /Users/kylebradshaw/repos/gen_ai_engineer/
 
 ## Grafana Gateway Mode
 
-For normal development-machine usage, prefer Grafana gateway mode instead of
-direct local Prometheus/Loki/Jaeger ports.
+For normal development-machine usage, prefer Grafana gateway mode for
+Prometheus and Loki instead of direct local ports. Jaeger trace lookup still
+uses `OBS_JAEGER_URL` until Grafana trace proxy support is validated.
 
 Create an uncommitted local env file:
 

--- a/go/observability-mcp-service/cmd/observability-mcp/main.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main.go
@@ -35,11 +35,25 @@ func run(ctx context.Context, logger *log.Logger, runServer serverRunner) error 
 		return fmt.Errorf("config: %w", err)
 	}
 	httpClient := &http.Client{Timeout: cfg.QueryTimeout}
-	prom := observability.NewPrometheus(cfg.PrometheusURL, httpClient)
-	loki := observability.NewLoki(cfg.LokiURL, httpClient)
+	var prom workflows.Prometheus
+	var loki workflows.Loki
 	jaeger := observability.NewJaeger(cfg.JaegerURL, httpClient, cfg.MaxTraceSpans)
+	if cfg.UseGrafanaGateway() {
+		grafana := observability.NewGrafana(observability.GrafanaConfig{
+			BaseURL:            cfg.GrafanaURL,
+			Token:              cfg.GrafanaToken,
+			AccessClientID:     cfg.GrafanaAccessClientID,
+			AccessClientSecret: cfg.GrafanaAccessClientSecret,
+		}, httpClient)
+		prom = grafana
+		loki = grafana
+		logger.Printf("observability MCP server running on stdio grafana=%s jaeger=%s", cfg.GrafanaURL, cfg.JaegerURL)
+	} else {
+		prom = observability.NewPrometheus(cfg.PrometheusURL, httpClient)
+		loki = observability.NewLoki(cfg.LokiURL, httpClient)
+		logger.Printf("observability MCP server running on stdio prometheus=%s loki=%s jaeger=%s", cfg.PrometheusURL, cfg.LokiURL, cfg.JaegerURL)
+	}
 	service := workflows.NewService(prom, loki, jaeger, cfg.MaxLogLines)
-	logger.Printf("observability MCP server running on stdio prometheus=%s loki=%s jaeger=%s", cfg.PrometheusURL, cfg.LokiURL, cfg.JaegerURL)
 	return runServer(ctx, &app{service: service, cfg: cfg})
 }
 

--- a/go/observability-mcp-service/cmd/observability-mcp/main.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main.go
@@ -40,14 +40,19 @@ func run(ctx context.Context, logger *log.Logger, runServer serverRunner) error 
 	jaeger := observability.NewJaeger(cfg.JaegerURL, httpClient, cfg.MaxTraceSpans)
 	if cfg.UseGrafanaGateway() {
 		grafana := observability.NewGrafana(observability.GrafanaConfig{
-			BaseURL:            cfg.GrafanaURL,
-			Token:              cfg.GrafanaToken,
-			AccessClientID:     cfg.GrafanaAccessClientID,
-			AccessClientSecret: cfg.GrafanaAccessClientSecret,
+			BaseURL:                 cfg.GrafanaURL,
+			Token:                   cfg.GrafanaToken,
+			AccessClientID:          cfg.GrafanaAccessClientID,
+			AccessClientSecret:      cfg.GrafanaAccessClientSecret,
+			PrometheusDatasourceUID: cfg.GrafanaPrometheusDatasourceUID,
+			LokiDatasourceUID:       cfg.GrafanaLokiDatasourceUID,
 		}, httpClient)
 		prom = grafana
 		loki = grafana
 		logger.Printf("observability MCP server running on stdio grafana=%s jaeger=%s", cfg.GrafanaURL, cfg.JaegerURL)
+		if cfg.UsesDefaultJaegerURL() {
+			logger.Printf("observability MCP grafana mode leaves jaeger on default direct URL; set OBS_JAEGER_URL if trace lookup should use a reachable endpoint")
+		}
 	} else {
 		prom = observability.NewPrometheus(cfg.PrometheusURL, httpClient)
 		loki = observability.NewLoki(cfg.LokiURL, httpClient)

--- a/go/observability-mcp-service/cmd/observability-mcp/main_test.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -54,5 +55,24 @@ func TestRunRejectsInvalidConfigBeforeServerStartup(t *testing.T) {
 	}
 	if called {
 		t.Fatal("runner should not be called")
+	}
+}
+
+func TestRunUsesGrafanaGatewayMode(t *testing.T) {
+	t.Setenv("OBS_GRAFANA_URL", "https://observability-api.kylebradshaw.dev")
+	t.Setenv("OBS_GRAFANA_TOKEN", "token")
+	var got *app
+	err := run(context.Background(), log.New(io.Discard, "", 0), func(_ context.Context, application *app) error {
+		got = application
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if got == nil || got.service == nil {
+		t.Fatal("expected app service")
+	}
+	if !got.cfg.UseGrafanaGateway() {
+		t.Fatal("expected Grafana gateway mode")
 	}
 }

--- a/go/observability-mcp-service/cmd/observability-mcp/main_test.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -113,7 +112,8 @@ func TestRunUsesGrafanaGatewayMode(t *testing.T) {
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "cf-id")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "cf-secret")
 	var got *app
-	err := run(context.Background(), log.New(io.Discard, "", 0), func(_ context.Context, application *app) error {
+	var logs bytes.Buffer
+	err := run(context.Background(), log.New(&logs, "", 0), func(_ context.Context, application *app) error {
 		got = application
 		bundle := application.service.GetServiceEvidence(context.Background(), "go-order-service", time.Minute, "")
 		if len(bundle.Errors) > 0 {
@@ -129,6 +129,9 @@ func TestRunUsesGrafanaGatewayMode(t *testing.T) {
 	}
 	if !got.cfg.UseGrafanaGateway() {
 		t.Fatal("expected Grafana gateway mode")
+	}
+	if !strings.Contains(logs.String(), "grafana mode leaves jaeger on default direct URL") {
+		t.Fatalf("expected default Jaeger warning, got %q", logs.String())
 	}
 
 	prometheusPath := "/api/datasources/proxy/uid/PBFA97CFB590B2093/api/v1/query"
@@ -160,4 +163,6 @@ func clearEnv(t *testing.T) {
 	t.Setenv("OBS_GRAFANA_TOKEN", "")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
+	t.Setenv("OBS_GRAFANA_PROMETHEUS_DS_UID", "")
+	t.Setenv("OBS_GRAFANA_LOKI_DS_UID", "")
 }

--- a/go/observability-mcp-service/cmd/observability-mcp/main_test.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main_test.go
@@ -5,11 +5,16 @@ import (
 	"context"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestRunWiresConfigClientsAndRunner(t *testing.T) {
+	clearEnv(t)
 	t.Setenv("OBS_PROMETHEUS_URL", "")
 	t.Setenv("OBS_LOKI_URL", "")
 	t.Setenv("OBS_JAEGER_URL", "")
@@ -44,6 +49,7 @@ func TestRunWiresConfigClientsAndRunner(t *testing.T) {
 }
 
 func TestRunRejectsInvalidConfigBeforeServerStartup(t *testing.T) {
+	clearEnv(t)
 	t.Setenv("OBS_QUERY_TIMEOUT", "nope")
 	called := false
 	err := run(context.Background(), log.New(&bytes.Buffer{}, "", 0), func(context.Context, *app) error {
@@ -59,11 +65,47 @@ func TestRunRejectsInvalidConfigBeforeServerStartup(t *testing.T) {
 }
 
 func TestRunUsesGrafanaGatewayMode(t *testing.T) {
-	t.Setenv("OBS_GRAFANA_URL", "https://observability-api.kylebradshaw.dev")
+	clearEnv(t)
+
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Id"); got != "cf-id" {
+			t.Fatalf("CF-Access-Client-Id = %q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Secret"); got != "cf-secret" {
+			t.Fatalf("CF-Access-Client-Secret = %q", got)
+		}
+
+		mu.Lock()
+		seen[r.URL.Path] = true
+		mu.Unlock()
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/api/v1/query"):
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"prometheus"},"value":[1710000000,"0"]}]}}`))
+		case strings.HasSuffix(r.URL.Path, "/loki/api/v1/query_range"):
+			_, _ = w.Write([]byte(`{"status":"success","data":{"result":[{"stream":{"service":"go-order-service"},"values":[["1710000000000000000","order error"]]}]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("OBS_GRAFANA_URL", server.URL)
 	t.Setenv("OBS_GRAFANA_TOKEN", "token")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "cf-id")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "cf-secret")
 	var got *app
 	err := run(context.Background(), log.New(io.Discard, "", 0), func(_ context.Context, application *app) error {
 		got = application
+		bundle := application.service.GetServiceEvidence(context.Background(), "go-order-service", time.Minute, "")
+		if len(bundle.Errors) > 0 {
+			t.Fatalf("service evidence errors = %+v", bundle.Errors)
+		}
 		return nil
 	})
 	if err != nil {
@@ -75,4 +117,31 @@ func TestRunUsesGrafanaGatewayMode(t *testing.T) {
 	if !got.cfg.UseGrafanaGateway() {
 		t.Fatal("expected Grafana gateway mode")
 	}
+
+	prometheusPath := "/api/datasources/proxy/uid/PBFA97CFB590B2093/api/v1/query"
+	lokiPath := "/api/datasources/proxy/uid/loki/loki/api/v1/query_range"
+	mu.Lock()
+	defer mu.Unlock()
+	if !seen[prometheusPath] {
+		t.Fatalf("expected Prometheus datasource proxy request; saw paths %+v", seen)
+	}
+	if !seen[lokiPath] {
+		t.Fatalf("expected Loki datasource proxy request; saw paths %+v", seen)
+	}
+}
+
+func clearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("OBS_PROMETHEUS_URL", "")
+	t.Setenv("OBS_LOKI_URL", "")
+	t.Setenv("OBS_JAEGER_URL", "")
+	t.Setenv("OBS_QUERY_TIMEOUT", "")
+	t.Setenv("OBS_DEFAULT_WINDOW", "")
+	t.Setenv("OBS_MAX_WINDOW", "")
+	t.Setenv("OBS_MAX_LOG_LINES", "")
+	t.Setenv("OBS_MAX_TRACE_SPANS", "")
+	t.Setenv("OBS_GRAFANA_URL", "")
+	t.Setenv("OBS_GRAFANA_TOKEN", "")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
 }

--- a/go/observability-mcp-service/cmd/observability-mcp/main_test.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main_test.go
@@ -69,15 +69,28 @@ func TestRunUsesGrafanaGatewayMode(t *testing.T) {
 
 	var mu sync.Mutex
 	seen := map[string]bool{}
+	var handlerErrors []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer token" {
-			t.Fatalf("Authorization = %q", got)
+			mu.Lock()
+			handlerErrors = append(handlerErrors, "Authorization = "+got)
+			mu.Unlock()
+			http.Error(w, "bad authorization", http.StatusUnauthorized)
+			return
 		}
 		if got := r.Header.Get("CF-Access-Client-Id"); got != "cf-id" {
-			t.Fatalf("CF-Access-Client-Id = %q", got)
+			mu.Lock()
+			handlerErrors = append(handlerErrors, "CF-Access-Client-Id = "+got)
+			mu.Unlock()
+			http.Error(w, "bad access client id", http.StatusUnauthorized)
+			return
 		}
 		if got := r.Header.Get("CF-Access-Client-Secret"); got != "cf-secret" {
-			t.Fatalf("CF-Access-Client-Secret = %q", got)
+			mu.Lock()
+			handlerErrors = append(handlerErrors, "CF-Access-Client-Secret = "+got)
+			mu.Unlock()
+			http.Error(w, "bad access client secret", http.StatusUnauthorized)
+			return
 		}
 
 		mu.Lock()
@@ -122,6 +135,9 @@ func TestRunUsesGrafanaGatewayMode(t *testing.T) {
 	lokiPath := "/api/datasources/proxy/uid/loki/loki/api/v1/query_range"
 	mu.Lock()
 	defer mu.Unlock()
+	if len(handlerErrors) > 0 {
+		t.Fatalf("handler errors = %+v", handlerErrors)
+	}
 	if !seen[prometheusPath] {
 		t.Fatalf("expected Prometheus datasource proxy request; saw paths %+v", seen)
 	}

--- a/go/observability-mcp-service/internal/config/config.go
+++ b/go/observability-mcp-service/internal/config/config.go
@@ -14,14 +14,18 @@ const (
 )
 
 type Config struct {
-	PrometheusURL string
-	LokiURL       string
-	JaegerURL     string
-	QueryTimeout  time.Duration
-	DefaultWindow time.Duration
-	MaxWindow     time.Duration
-	MaxLogLines   int
-	MaxTraceSpans int
+	PrometheusURL             string
+	LokiURL                   string
+	JaegerURL                 string
+	GrafanaURL                string
+	GrafanaToken              string
+	GrafanaAccessClientID     string
+	GrafanaAccessClientSecret string
+	QueryTimeout              time.Duration
+	DefaultWindow             time.Duration
+	MaxWindow                 time.Duration
+	MaxLogLines               int
+	MaxTraceSpans             int
 }
 
 func FromEnv() (Config, error) {
@@ -47,14 +51,18 @@ func FromEnv() (Config, error) {
 	}
 
 	cfg := Config{
-		PrometheusURL: getenv("OBS_PROMETHEUS_URL", defaultPrometheusURL),
-		LokiURL:       getenv("OBS_LOKI_URL", defaultLokiURL),
-		JaegerURL:     getenv("OBS_JAEGER_URL", defaultJaegerURL),
-		QueryTimeout:  queryTimeout,
-		DefaultWindow: defaultWindow,
-		MaxWindow:     maxWindow,
-		MaxLogLines:   maxLogLines,
-		MaxTraceSpans: maxTraceSpans,
+		PrometheusURL:             getenv("OBS_PROMETHEUS_URL", defaultPrometheusURL),
+		LokiURL:                   getenv("OBS_LOKI_URL", defaultLokiURL),
+		JaegerURL:                 getenv("OBS_JAEGER_URL", defaultJaegerURL),
+		GrafanaURL:                getenv("OBS_GRAFANA_URL", ""),
+		GrafanaToken:              os.Getenv("OBS_GRAFANA_TOKEN"),
+		GrafanaAccessClientID:     os.Getenv("OBS_GRAFANA_ACCESS_CLIENT_ID"),
+		GrafanaAccessClientSecret: os.Getenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET"),
+		QueryTimeout:              queryTimeout,
+		DefaultWindow:             defaultWindow,
+		MaxWindow:                 maxWindow,
+		MaxLogLines:               maxLogLines,
+		MaxTraceSpans:             maxTraceSpans,
 	}
 	if cfg.QueryTimeout <= 0 {
 		return Config{}, fmt.Errorf("OBS_QUERY_TIMEOUT must be positive")
@@ -74,7 +82,14 @@ func FromEnv() (Config, error) {
 	if cfg.MaxTraceSpans <= 0 {
 		return Config{}, fmt.Errorf("OBS_MAX_TRACE_SPANS must be positive")
 	}
+	if (cfg.GrafanaAccessClientID == "") != (cfg.GrafanaAccessClientSecret == "") {
+		return Config{}, fmt.Errorf("OBS_GRAFANA_ACCESS_CLIENT_ID and OBS_GRAFANA_ACCESS_CLIENT_SECRET must be set together")
+	}
 	return cfg, nil
+}
+
+func (c Config) UseGrafanaGateway() bool {
+	return c.GrafanaURL != ""
 }
 
 func (c Config) WindowOrDefault(raw string) (time.Duration, error) {

--- a/go/observability-mcp-service/internal/config/config.go
+++ b/go/observability-mcp-service/internal/config/config.go
@@ -8,24 +8,28 @@ import (
 )
 
 const (
-	defaultPrometheusURL = "http://localhost:9090"
-	defaultLokiURL       = "http://localhost:3100"
-	defaultJaegerURL     = "http://localhost:16686"
+	defaultPrometheusURL                  = "http://localhost:9090"
+	defaultLokiURL                        = "http://localhost:3100"
+	defaultJaegerURL                      = "http://localhost:16686"
+	defaultGrafanaPrometheusDatasourceUID = "PBFA97CFB590B2093"
+	defaultGrafanaLokiDatasourceUID       = "loki"
 )
 
 type Config struct {
-	PrometheusURL             string
-	LokiURL                   string
-	JaegerURL                 string
-	GrafanaURL                string
-	GrafanaToken              string
-	GrafanaAccessClientID     string
-	GrafanaAccessClientSecret string
-	QueryTimeout              time.Duration
-	DefaultWindow             time.Duration
-	MaxWindow                 time.Duration
-	MaxLogLines               int
-	MaxTraceSpans             int
+	PrometheusURL                  string
+	LokiURL                        string
+	JaegerURL                      string
+	GrafanaURL                     string
+	GrafanaToken                   string
+	GrafanaAccessClientID          string
+	GrafanaAccessClientSecret      string
+	GrafanaPrometheusDatasourceUID string
+	GrafanaLokiDatasourceUID       string
+	QueryTimeout                   time.Duration
+	DefaultWindow                  time.Duration
+	MaxWindow                      time.Duration
+	MaxLogLines                    int
+	MaxTraceSpans                  int
 }
 
 func FromEnv() (Config, error) {
@@ -51,18 +55,20 @@ func FromEnv() (Config, error) {
 	}
 
 	cfg := Config{
-		PrometheusURL:             getenv("OBS_PROMETHEUS_URL", defaultPrometheusURL),
-		LokiURL:                   getenv("OBS_LOKI_URL", defaultLokiURL),
-		JaegerURL:                 getenv("OBS_JAEGER_URL", defaultJaegerURL),
-		GrafanaURL:                getenv("OBS_GRAFANA_URL", ""),
-		GrafanaToken:              os.Getenv("OBS_GRAFANA_TOKEN"),
-		GrafanaAccessClientID:     os.Getenv("OBS_GRAFANA_ACCESS_CLIENT_ID"),
-		GrafanaAccessClientSecret: os.Getenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET"),
-		QueryTimeout:              queryTimeout,
-		DefaultWindow:             defaultWindow,
-		MaxWindow:                 maxWindow,
-		MaxLogLines:               maxLogLines,
-		MaxTraceSpans:             maxTraceSpans,
+		PrometheusURL:                  getenv("OBS_PROMETHEUS_URL", defaultPrometheusURL),
+		LokiURL:                        getenv("OBS_LOKI_URL", defaultLokiURL),
+		JaegerURL:                      getenv("OBS_JAEGER_URL", defaultJaegerURL),
+		GrafanaURL:                     getenv("OBS_GRAFANA_URL", ""),
+		GrafanaToken:                   os.Getenv("OBS_GRAFANA_TOKEN"),
+		GrafanaAccessClientID:          os.Getenv("OBS_GRAFANA_ACCESS_CLIENT_ID"),
+		GrafanaAccessClientSecret:      os.Getenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET"),
+		GrafanaPrometheusDatasourceUID: getenv("OBS_GRAFANA_PROMETHEUS_DS_UID", defaultGrafanaPrometheusDatasourceUID),
+		GrafanaLokiDatasourceUID:       getenv("OBS_GRAFANA_LOKI_DS_UID", defaultGrafanaLokiDatasourceUID),
+		QueryTimeout:                   queryTimeout,
+		DefaultWindow:                  defaultWindow,
+		MaxWindow:                      maxWindow,
+		MaxLogLines:                    maxLogLines,
+		MaxTraceSpans:                  maxTraceSpans,
 	}
 	if cfg.QueryTimeout <= 0 {
 		return Config{}, fmt.Errorf("OBS_QUERY_TIMEOUT must be positive")
@@ -90,6 +96,10 @@ func FromEnv() (Config, error) {
 
 func (c Config) UseGrafanaGateway() bool {
 	return c.GrafanaURL != ""
+}
+
+func (c Config) UsesDefaultJaegerURL() bool {
+	return c.JaegerURL == defaultJaegerURL
 }
 
 func (c Config) WindowOrDefault(raw string) (time.Duration, error) {

--- a/go/observability-mcp-service/internal/config/config_test.go
+++ b/go/observability-mcp-service/internal/config/config_test.go
@@ -67,6 +67,40 @@ func TestFromEnvOverrides(t *testing.T) {
 	}
 }
 
+func TestFromEnvGrafanaMode(t *testing.T) {
+	t.Setenv("OBS_GRAFANA_URL", "https://observability-api.kylebradshaw.dev")
+	t.Setenv("OBS_GRAFANA_TOKEN", "grafana-token")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "cf-id")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "cf-secret")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if !cfg.UseGrafanaGateway() {
+		t.Fatal("expected Grafana gateway mode")
+	}
+	if cfg.GrafanaURL != "https://observability-api.kylebradshaw.dev" {
+		t.Fatalf("GrafanaURL = %q", cfg.GrafanaURL)
+	}
+	if cfg.GrafanaToken != "grafana-token" {
+		t.Fatal("GrafanaToken not loaded")
+	}
+	if cfg.GrafanaAccessClientID != "cf-id" || cfg.GrafanaAccessClientSecret != "cf-secret" {
+		t.Fatalf("Cloudflare token config not loaded: %+v", cfg)
+	}
+}
+
+func TestFromEnvRejectsPartialGrafanaAccessToken(t *testing.T) {
+	t.Setenv("OBS_GRAFANA_URL", "https://observability-api.kylebradshaw.dev")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "cf-id")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
+
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("expected partial Cloudflare access token error")
+	}
+}
+
 func TestFromEnvRejectsInvalidValues(t *testing.T) {
 	t.Setenv("OBS_QUERY_TIMEOUT", "nope")
 	if _, err := FromEnv(); err == nil {

--- a/go/observability-mcp-service/internal/config/config_test.go
+++ b/go/observability-mcp-service/internal/config/config_test.go
@@ -14,6 +14,10 @@ func TestFromEnvDefaults(t *testing.T) {
 	t.Setenv("OBS_MAX_WINDOW", "")
 	t.Setenv("OBS_MAX_LOG_LINES", "")
 	t.Setenv("OBS_MAX_TRACE_SPANS", "")
+	t.Setenv("OBS_GRAFANA_URL", "")
+	t.Setenv("OBS_GRAFANA_TOKEN", "")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
 
 	cfg, err := FromEnv()
 	if err != nil {
@@ -42,6 +46,12 @@ func TestFromEnvDefaults(t *testing.T) {
 	}
 	if cfg.MaxTraceSpans != 100 {
 		t.Fatalf("MaxTraceSpans = %d", cfg.MaxTraceSpans)
+	}
+	if cfg.UseGrafanaGateway() {
+		t.Fatal("expected direct backend mode by default")
+	}
+	if cfg.GrafanaURL != "" || cfg.GrafanaToken != "" || cfg.GrafanaAccessClientID != "" || cfg.GrafanaAccessClientSecret != "" {
+		t.Fatalf("expected empty Grafana config by default: %+v", cfg)
 	}
 }
 

--- a/go/observability-mcp-service/internal/config/config_test.go
+++ b/go/observability-mcp-service/internal/config/config_test.go
@@ -42,6 +42,15 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.GrafanaURL != "" || cfg.GrafanaToken != "" || cfg.GrafanaAccessClientID != "" || cfg.GrafanaAccessClientSecret != "" {
 		t.Fatalf("expected empty Grafana config by default: %+v", cfg)
 	}
+	if cfg.GrafanaPrometheusDatasourceUID != "PBFA97CFB590B2093" {
+		t.Fatalf("GrafanaPrometheusDatasourceUID = %q", cfg.GrafanaPrometheusDatasourceUID)
+	}
+	if cfg.GrafanaLokiDatasourceUID != "loki" {
+		t.Fatalf("GrafanaLokiDatasourceUID = %q", cfg.GrafanaLokiDatasourceUID)
+	}
+	if !cfg.UsesDefaultJaegerURL() {
+		t.Fatal("expected default Jaeger URL")
+	}
 }
 
 func TestFromEnvOverrides(t *testing.T) {
@@ -64,6 +73,9 @@ func TestFromEnvOverrides(t *testing.T) {
 	}
 	if cfg.MaxLogLines != 25 || cfg.MaxTraceSpans != 50 {
 		t.Fatalf("limit overrides not applied: %+v", cfg)
+	}
+	if cfg.UsesDefaultJaegerURL() {
+		t.Fatal("expected Jaeger override to be detected")
 	}
 }
 
@@ -89,6 +101,23 @@ func TestFromEnvGrafanaMode(t *testing.T) {
 	}
 	if cfg.GrafanaAccessClientID != "cf-id" || cfg.GrafanaAccessClientSecret != "cf-secret" {
 		t.Fatalf("Cloudflare token config not loaded: %+v", cfg)
+	}
+}
+
+func TestFromEnvGrafanaDatasourceUIDOverrides(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_GRAFANA_PROMETHEUS_DS_UID", "custom-prometheus")
+	t.Setenv("OBS_GRAFANA_LOKI_DS_UID", "custom-loki")
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if cfg.GrafanaPrometheusDatasourceUID != "custom-prometheus" {
+		t.Fatalf("GrafanaPrometheusDatasourceUID = %q", cfg.GrafanaPrometheusDatasourceUID)
+	}
+	if cfg.GrafanaLokiDatasourceUID != "custom-loki" {
+		t.Fatalf("GrafanaLokiDatasourceUID = %q", cfg.GrafanaLokiDatasourceUID)
 	}
 }
 
@@ -125,6 +154,8 @@ func clearEnv(t *testing.T) {
 	t.Setenv("OBS_GRAFANA_TOKEN", "")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
+	t.Setenv("OBS_GRAFANA_PROMETHEUS_DS_UID", "")
+	t.Setenv("OBS_GRAFANA_LOKI_DS_UID", "")
 }
 
 func TestValidateWindow(t *testing.T) {

--- a/go/observability-mcp-service/internal/config/config_test.go
+++ b/go/observability-mcp-service/internal/config/config_test.go
@@ -6,18 +6,7 @@ import (
 )
 
 func TestFromEnvDefaults(t *testing.T) {
-	t.Setenv("OBS_PROMETHEUS_URL", "")
-	t.Setenv("OBS_LOKI_URL", "")
-	t.Setenv("OBS_JAEGER_URL", "")
-	t.Setenv("OBS_QUERY_TIMEOUT", "")
-	t.Setenv("OBS_DEFAULT_WINDOW", "")
-	t.Setenv("OBS_MAX_WINDOW", "")
-	t.Setenv("OBS_MAX_LOG_LINES", "")
-	t.Setenv("OBS_MAX_TRACE_SPANS", "")
-	t.Setenv("OBS_GRAFANA_URL", "")
-	t.Setenv("OBS_GRAFANA_TOKEN", "")
-	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "")
-	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
+	clearEnv(t)
 
 	cfg, err := FromEnv()
 	if err != nil {
@@ -56,6 +45,7 @@ func TestFromEnvDefaults(t *testing.T) {
 }
 
 func TestFromEnvOverrides(t *testing.T) {
+	clearEnv(t)
 	t.Setenv("OBS_PROMETHEUS_URL", "http://prometheus.monitoring.svc:9090")
 	t.Setenv("OBS_LOKI_URL", "http://loki.monitoring.svc:3100")
 	t.Setenv("OBS_JAEGER_URL", "http://jaeger.monitoring.svc:16686")
@@ -78,6 +68,7 @@ func TestFromEnvOverrides(t *testing.T) {
 }
 
 func TestFromEnvGrafanaMode(t *testing.T) {
+	clearEnv(t)
 	t.Setenv("OBS_GRAFANA_URL", "https://observability-api.kylebradshaw.dev")
 	t.Setenv("OBS_GRAFANA_TOKEN", "grafana-token")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "cf-id")
@@ -102,6 +93,7 @@ func TestFromEnvGrafanaMode(t *testing.T) {
 }
 
 func TestFromEnvRejectsPartialGrafanaAccessToken(t *testing.T) {
+	clearEnv(t)
 	t.Setenv("OBS_GRAFANA_URL", "https://observability-api.kylebradshaw.dev")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "cf-id")
 	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
@@ -112,10 +104,27 @@ func TestFromEnvRejectsPartialGrafanaAccessToken(t *testing.T) {
 }
 
 func TestFromEnvRejectsInvalidValues(t *testing.T) {
+	clearEnv(t)
 	t.Setenv("OBS_QUERY_TIMEOUT", "nope")
 	if _, err := FromEnv(); err == nil {
 		t.Fatal("expected invalid duration error")
 	}
+}
+
+func clearEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("OBS_PROMETHEUS_URL", "")
+	t.Setenv("OBS_LOKI_URL", "")
+	t.Setenv("OBS_JAEGER_URL", "")
+	t.Setenv("OBS_QUERY_TIMEOUT", "")
+	t.Setenv("OBS_DEFAULT_WINDOW", "")
+	t.Setenv("OBS_MAX_WINDOW", "")
+	t.Setenv("OBS_MAX_LOG_LINES", "")
+	t.Setenv("OBS_MAX_TRACE_SPANS", "")
+	t.Setenv("OBS_GRAFANA_URL", "")
+	t.Setenv("OBS_GRAFANA_TOKEN", "")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_ID", "")
+	t.Setenv("OBS_GRAFANA_ACCESS_CLIENT_SECRET", "")
 }
 
 func TestValidateWindow(t *testing.T) {

--- a/go/observability-mcp-service/internal/observability/grafana.go
+++ b/go/observability-mcp-service/internal/observability/grafana.go
@@ -22,7 +22,6 @@ type GrafanaConfig struct {
 type GrafanaClient struct {
 	prometheus *PrometheusClient
 	loki       *LokiClient
-	headers    map[string]string
 }
 
 func NewGrafana(cfg GrafanaConfig, httpClient *http.Client) *GrafanaClient {
@@ -49,7 +48,6 @@ func NewGrafana(cfg GrafanaConfig, httpClient *http.Client) *GrafanaClient {
 	return &GrafanaClient{
 		prometheus: NewPrometheus(baseURL+"/api/datasources/proxy/uid/"+grafanaPrometheusUID, &client),
 		loki:       NewLoki(baseURL+"/api/datasources/proxy/uid/"+grafanaLokiUID, &client),
-		headers:    headers,
 	}
 }
 

--- a/go/observability-mcp-service/internal/observability/grafana.go
+++ b/go/observability-mcp-service/internal/observability/grafana.go
@@ -8,15 +8,17 @@ import (
 )
 
 const (
-	grafanaPrometheusUID = "PBFA97CFB590B2093"
-	grafanaLokiUID       = "loki"
+	defaultGrafanaPrometheusUID = "PBFA97CFB590B2093"
+	defaultGrafanaLokiUID       = "loki"
 )
 
 type GrafanaConfig struct {
-	BaseURL            string
-	Token              string
-	AccessClientID     string
-	AccessClientSecret string
+	BaseURL                 string
+	Token                   string
+	AccessClientID          string
+	AccessClientSecret      string
+	PrometheusDatasourceUID string
+	LokiDatasourceUID       string
 }
 
 type GrafanaClient struct {
@@ -33,7 +35,7 @@ func NewGrafana(cfg GrafanaConfig, httpClient *http.Client) *GrafanaClient {
 	if cfg.Token != "" {
 		headers["Authorization"] = "Bearer " + cfg.Token
 	}
-	if cfg.AccessClientID != "" {
+	if cfg.AccessClientID != "" && cfg.AccessClientSecret != "" {
 		headers["CF-Access-Client-Id"] = cfg.AccessClientID
 		headers["CF-Access-Client-Secret"] = cfg.AccessClientSecret
 	}
@@ -45,9 +47,17 @@ func NewGrafana(cfg GrafanaConfig, httpClient *http.Client) *GrafanaClient {
 	}
 
 	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	prometheusUID := cfg.PrometheusDatasourceUID
+	if prometheusUID == "" {
+		prometheusUID = defaultGrafanaPrometheusUID
+	}
+	lokiUID := cfg.LokiDatasourceUID
+	if lokiUID == "" {
+		lokiUID = defaultGrafanaLokiUID
+	}
 	return &GrafanaClient{
-		prometheus: NewPrometheus(baseURL+"/api/datasources/proxy/uid/"+grafanaPrometheusUID, &client),
-		loki:       NewLoki(baseURL+"/api/datasources/proxy/uid/"+grafanaLokiUID, &client),
+		prometheus: NewPrometheus(baseURL+"/api/datasources/proxy/uid/"+prometheusUID, &client),
+		loki:       NewLoki(baseURL+"/api/datasources/proxy/uid/"+lokiUID, &client),
 	}
 }
 

--- a/go/observability-mcp-service/internal/observability/grafana.go
+++ b/go/observability-mcp-service/internal/observability/grafana.go
@@ -1,0 +1,84 @@
+package observability
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	grafanaPrometheusUID = "PBFA97CFB590B2093"
+	grafanaLokiUID       = "loki"
+)
+
+type GrafanaConfig struct {
+	BaseURL            string
+	Token              string
+	AccessClientID     string
+	AccessClientSecret string
+}
+
+type GrafanaClient struct {
+	prometheus *PrometheusClient
+	loki       *LokiClient
+	headers    map[string]string
+}
+
+func NewGrafana(cfg GrafanaConfig, httpClient *http.Client) *GrafanaClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	headers := make(map[string]string)
+	if cfg.Token != "" {
+		headers["Authorization"] = "Bearer " + cfg.Token
+	}
+	if cfg.AccessClientID != "" {
+		headers["CF-Access-Client-Id"] = cfg.AccessClientID
+		headers["CF-Access-Client-Secret"] = cfg.AccessClientSecret
+	}
+
+	client := *httpClient
+	client.Transport = headerRoundTripper{
+		base:    httpClient.Transport,
+		headers: headers,
+	}
+
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	return &GrafanaClient{
+		prometheus: NewPrometheus(baseURL+"/api/datasources/proxy/uid/"+grafanaPrometheusUID, &client),
+		loki:       NewLoki(baseURL+"/api/datasources/proxy/uid/"+grafanaLokiUID, &client),
+		headers:    headers,
+	}
+}
+
+func (c *GrafanaClient) Query(ctx context.Context, query string) ([]MetricSample, error) {
+	return c.prometheus.Query(ctx, query)
+}
+
+func (c *GrafanaClient) QueryRange(ctx context.Context, query string, start, end time.Time, step time.Duration) ([]MetricSample, error) {
+	return c.prometheus.QueryRange(ctx, query, start, end, step)
+}
+
+func (c *GrafanaClient) QueryLogs(ctx context.Context, q LogQuery) ([]LogLine, bool, error) {
+	return c.loki.QueryLogs(ctx, q)
+}
+
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers map[string]string
+}
+
+func (t headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	for name, value := range t.headers {
+		cloned.Header.Set(name, value)
+	}
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(cloned)
+}

--- a/go/observability-mcp-service/internal/observability/grafana_test.go
+++ b/go/observability-mcp-service/internal/observability/grafana_test.go
@@ -1,0 +1,82 @@
+package observability
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGrafanaPrometheusQueryUsesDatasourceProxy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer grafana-token" {
+			t.Fatalf("Authorization = %s", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("CF-Access-Client-Id") != "cf-id" {
+			t.Fatalf("CF-Access-Client-Id = %s", r.Header.Get("CF-Access-Client-Id"))
+		}
+		if r.URL.Path != "/api/datasources/proxy/uid/PBFA97CFB590B2093/api/v1/query" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("query") != "up" {
+			t.Fatalf("query = %s", r.URL.Query().Get("query"))
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"prometheus"},"value":[1710000000,"1"]}]}}`))
+	}))
+	defer server.Close()
+
+	client := NewGrafana(GrafanaConfig{
+		BaseURL:        server.URL,
+		Token:          "grafana-token",
+		AccessClientID: "cf-id",
+	}, server.Client())
+	got, err := client.Query(context.Background(), "up")
+	if err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Value != 1 {
+		t.Fatalf("samples = %+v", got)
+	}
+}
+
+func TestGrafanaLokiQueryUsesDatasourceProxy(t *testing.T) {
+	start := time.Unix(1710000000, 0).UTC()
+	end := time.Unix(1710000060, 0).UTC()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/datasources/proxy/uid/loki/loki/api/v1/query_range" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("start") != "1710000000000000000" {
+			t.Fatalf("start = %s", r.URL.Query().Get("start"))
+		}
+		if r.URL.Query().Get("end") != "1710000060000000000" {
+			t.Fatalf("end = %s", r.URL.Query().Get("end"))
+		}
+		if r.URL.Query().Get("limit") != "3" {
+			t.Fatalf("limit = %s", r.URL.Query().Get("limit"))
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[{"stream":{"service":"go-ai-service"},"values":[["1710000000000000000","first error"]]}]}}`))
+	}))
+	defer server.Close()
+
+	client := NewGrafana(GrafanaConfig{BaseURL: server.URL}, server.Client())
+	lines, truncated, err := client.QueryLogs(context.Background(), LogQuery{
+		Service: "go-ai-service",
+		Start:   start,
+		End:     end,
+		Limit:   2,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+	if len(lines) != 1 {
+		t.Fatalf("lines = %+v", lines)
+	}
+	if lines[0].Labels["service"] != "go-ai-service" {
+		t.Fatalf("service label = %s", lines[0].Labels["service"])
+	}
+	if truncated {
+		t.Fatal("truncated = true")
+	}
+}

--- a/go/observability-mcp-service/internal/observability/grafana_test.go
+++ b/go/observability-mcp-service/internal/observability/grafana_test.go
@@ -84,3 +84,56 @@ func TestGrafanaLokiQueryUsesDatasourceProxy(t *testing.T) {
 		t.Fatal("truncated = true")
 	}
 }
+
+func TestGrafanaDatasourceUIDOverrides(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/datasources/proxy/uid/custom-prometheus/api/v1/query":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+		case "/api/datasources/proxy/uid/custom-loki/loki/api/v1/query_range":
+			_, _ = w.Write([]byte(`{"status":"success","data":{"result":[]}}`))
+		default:
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewGrafana(GrafanaConfig{
+		BaseURL:                 server.URL,
+		PrometheusDatasourceUID: "custom-prometheus",
+		LokiDatasourceUID:       "custom-loki",
+	}, server.Client())
+	if _, err := client.Query(context.Background(), "up"); err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+	_, _, err := client.QueryLogs(context.Background(), LogQuery{
+		Service: "go-order-service",
+		Start:   time.Unix(1710000000, 0).UTC(),
+		End:     time.Unix(1710000060, 0).UTC(),
+		Limit:   2,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs() error = %v", err)
+	}
+}
+
+func TestGrafanaCloudflareHeadersRequirePair(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("CF-Access-Client-Id"); got != "" {
+			t.Fatalf("CF-Access-Client-Id = %q", got)
+		}
+		if got := r.Header.Get("CF-Access-Client-Secret"); got != "" {
+			t.Fatalf("CF-Access-Client-Secret = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer server.Close()
+
+	client := NewGrafana(GrafanaConfig{
+		BaseURL:            server.URL,
+		AccessClientSecret: "cf-secret",
+	}, server.Client())
+	if _, err := client.Query(context.Background(), "up"); err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+}

--- a/go/observability-mcp-service/internal/observability/grafana_test.go
+++ b/go/observability-mcp-service/internal/observability/grafana_test.go
@@ -16,6 +16,9 @@ func TestGrafanaPrometheusQueryUsesDatasourceProxy(t *testing.T) {
 		if r.Header.Get("CF-Access-Client-Id") != "cf-id" {
 			t.Fatalf("CF-Access-Client-Id = %s", r.Header.Get("CF-Access-Client-Id"))
 		}
+		if r.Header.Get("CF-Access-Client-Secret") != "cf-secret" {
+			t.Fatalf("CF-Access-Client-Secret = %s", r.Header.Get("CF-Access-Client-Secret"))
+		}
 		if r.URL.Path != "/api/datasources/proxy/uid/PBFA97CFB590B2093/api/v1/query" {
 			t.Fatalf("path = %s", r.URL.Path)
 		}
@@ -27,9 +30,10 @@ func TestGrafanaPrometheusQueryUsesDatasourceProxy(t *testing.T) {
 	defer server.Close()
 
 	client := NewGrafana(GrafanaConfig{
-		BaseURL:        server.URL,
-		Token:          "grafana-token",
-		AccessClientID: "cf-id",
+		BaseURL:            server.URL,
+		Token:              "grafana-token",
+		AccessClientID:     "cf-id",
+		AccessClientSecret: "cf-secret",
 	}, server.Client())
 	got, err := client.Query(context.Background(), "up")
 	if err != nil {

--- a/k8s/monitoring/ingress.yml
+++ b/k8s/monitoring/ingress.yml
@@ -16,6 +16,16 @@ spec:
                 name: grafana
                 port:
                   number: 3000
+    - host: observability-api.kylebradshaw.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000
     - host: jaeger.kylebradshaw.dev
       http:
         paths:


### PR DESCRIPTION
## Summary
- add an `observability-api.kylebradshaw.dev` monitoring ingress host for Grafana-backed API access
- add Grafana gateway mode config/client/startup wiring for Prometheus and Loki in the observability MCP
- document Cloudflare Access service-token setup, local Codex env registration, and the Jaeger/direct fallback boundary

## Test Plan
- [x] `cd go/observability-mcp-service && go test ./...`
- [x] `make preflight-go`
- [x] `codex mcp get observability`
- [x] `curl -I https://grafana.kylebradshaw.dev` returned HTTP 200
- [ ] `kubectl kustomize k8s/monitoring` blocked locally: `kubectl`/`kustomize` are not installed on this Mac
- [ ] `observability-api.kylebradshaw.dev` live checks blocked until DNS/Cloudflare Access/service token setup is completed

## Rollout Notes
- Do not apply the ingress until Cloudflare Access is ready for `observability-api.kylebradshaw.dev`.
- `~/.codex/env/observability-mcp.env` was created locally with `0600` permissions and no committed secrets.
- Public `grafana.kylebradshaw.dev` anonymous access is preserved.
