### PR TITLE
Persist eval retrieval provenance

### DIFF
--- a/services/eval/app/evaluator.py
+++ b/services/eval/app/evaluator.py
@@ -110,15 +110,16 @@ async def build_evaluation_dataset(
             query, collection=collection, rerank=rerank
         )
 
-        dataset.append(
-            {
-                "user_input": query,
-                "retrieved_contexts": [r["text"] for r in search_results],
-                "response": chat_response["answer"],
-                "reference": item["expected_answer"],
-                "expected_sources": item.get("expected_sources", []),
-            }
-        )
+        row = {
+            "user_input": query,
+            "retrieved_contexts": [r["text"] for r in search_results],
+            "response": chat_response["answer"],
+            "reference": item["expected_answer"],
+            "expected_sources": item.get("expected_sources", []),
+        }
+        if "retrieval" in chat_response:
+            row["retrieval"] = chat_response["retrieval"]
+        dataset.append(row)
     return dataset
 
 
@@ -275,14 +276,15 @@ async def run_evaluation(
             ),
         }
         all_scores.append(scores)
-        per_query.append(
-            {
-                "query": row["user_input"],
-                "answer": row["response"],
-                "contexts": row["retrieved_contexts"],
-                "scores": scores,
-                "score_reasons": judge_scores.reasons,
-            }
-        )
+        result = {
+            "query": row["user_input"],
+            "answer": row["response"],
+            "contexts": row["retrieved_contexts"],
+            "scores": scores,
+            "score_reasons": judge_scores.reasons,
+        }
+        if "retrieval" in row:
+            result["retrieval"] = row["retrieval"]
+        per_query.append(result)
 
     return _aggregate(all_scores), per_query

--- a/services/eval/app/rag_client.py
+++ b/services/eval/app/rag_client.py
@@ -24,11 +24,9 @@ class RAGClient:
         rerank: bool = False,
     ) -> list[dict]:
         """Call POST /search for retrieval-only results."""
-        body: dict = {"query": query, "limit": limit}
+        body: dict = {"query": query, "limit": limit, "rerank": rerank}
         if collection:
             body["collection"] = collection
-        if rerank:
-            body["rerank"] = True
 
         resp = await self._client.post("/search", json=body)
         resp.raise_for_status()
@@ -38,11 +36,9 @@ class RAGClient:
         self, question: str, collection: str | None, rerank: bool = False
     ) -> dict:
         """Call POST /chat with Accept: application/json for a full RAG response."""
-        body: dict = {"question": question}
+        body: dict = {"question": question, "rerank": rerank}
         if collection:
             body["collection"] = collection
-        if rerank:
-            body["rerank"] = True
 
         resp = await self._client.post(
             "/chat", json=body, headers={"Accept": "application/json"}

--- a/services/eval/tests/test_evaluator.py
+++ b/services/eval/tests/test_evaluator.py
@@ -57,6 +57,24 @@ def mock_chat_answer():
     }
 
 
+@pytest.fixture
+def mock_chat_answer_with_retrieval(mock_chat_answer):
+    return {
+        **mock_chat_answer,
+        "retrieval": {
+            "retrieval_mode": "hybrid",
+            "retrieval_fallback": False,
+            "rerank_requested": True,
+            "rerank_enabled": True,
+            "rerank_applied": True,
+            "rerank_fallback": False,
+            "rerank_model": "cross-encoder/ms-marco-MiniLM-L6-v2",
+            "rerank_candidate_count": 20,
+            "rerank_returned_count": 5,
+        },
+    }
+
+
 @pytest.mark.asyncio
 async def test_build_evaluation_dataset(
     golden_items, mock_search_results, mock_chat_answer
@@ -123,6 +141,24 @@ async def test_build_evaluation_dataset_passes_rerank(
 
     assert rag_client.search.call_args_list[0].kwargs["rerank"] is True
     assert rag_client.ask.call_args_list[0].kwargs["rerank"] is True
+
+
+@pytest.mark.asyncio
+async def test_build_evaluation_dataset_preserves_retrieval_metadata(
+    golden_items, mock_search_results, mock_chat_answer_with_retrieval
+):
+    rag_client = AsyncMock()
+    rag_client.search.return_value = mock_search_results
+    rag_client.ask.return_value = mock_chat_answer_with_retrieval
+
+    dataset = await build_evaluation_dataset(
+        items=golden_items,
+        rag_client=rag_client,
+        collection="documents",
+        rerank=True,
+    )
+
+    assert dataset[0]["retrieval"] == mock_chat_answer_with_retrieval["retrieval"]
 
 
 def test_score_context_recall_counts_reference_terms_in_contexts():
@@ -235,6 +271,44 @@ async def test_run_evaluation_preserves_result_shape(
     assert results[0]["query"] == "What is chunking?"
     assert results[0]["scores"]["faithfulness"] == 0.9
     assert results[0]["score_reasons"]["faithfulness"] == "answer is supported"
+    assert "retrieval" not in results[0]
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_persists_retrieval_metadata_in_results(
+    golden_items,
+    mock_search_results,
+    mock_chat_answer_with_retrieval,
+):
+    rag_client = MagicMock(spec=RAGClient)
+    rag_client.search = AsyncMock(return_value=mock_search_results)
+    rag_client.ask = AsyncMock(return_value=mock_chat_answer_with_retrieval)
+    judge = AsyncMock(
+        return_value=JudgeScores(
+            faithfulness=1.0,
+            answer_relevancy=1.0,
+            reasons={
+                "faithfulness": "supported",
+                "answer_relevancy": "direct",
+            },
+        )
+    )
+
+    aggregate, results = await run_evaluation(
+        items=golden_items,
+        rag_client=rag_client,
+        collection="documents",
+        llm_provider="ollama",
+        llm_base_url="http://localhost:11434",
+        llm_model="qwen2.5:14b",
+        llm_api_key="",
+        rerank=True,
+        judge=judge,
+    )
+
+    assert aggregate["faithfulness"] == 1.0
+    assert aggregate["answer_relevancy"] == 1.0
+    assert results[0]["retrieval"] == mock_chat_answer_with_retrieval["retrieval"]
 
 
 @pytest.mark.asyncio

--- a/services/eval/tests/test_rag_client.py
+++ b/services/eval/tests/test_rag_client.py
@@ -82,6 +82,19 @@ async def test_search_passes_rerank_when_true(mock_search_response):
 
 
 @pytest.mark.asyncio
+async def test_search_sends_rerank_false_for_baseline(mock_search_response):
+    async def mock_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["rerank"] is False
+        return httpx.Response(200, json=mock_search_response)
+
+    transport = httpx.MockTransport(mock_handler)
+    client = RAGClient(base_url="http://chat:8000", transport=transport)
+
+    await client.search("test", collection=None, limit=5, rerank=False)
+
+
+@pytest.mark.asyncio
 async def test_ask(mock_chat_response):
     async def mock_handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/chat"
@@ -112,6 +125,19 @@ async def test_ask_passes_rerank_when_true(mock_chat_response):
     client = RAGClient(base_url="http://chat:8000", transport=transport)
 
     await client.ask("test", collection=None, rerank=True)
+
+
+@pytest.mark.asyncio
+async def test_ask_sends_rerank_false_for_baseline(mock_chat_response):
+    async def mock_handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["rerank"] is False
+        return httpx.Response(200, json=mock_chat_response)
+
+    transport = httpx.MockTransport(mock_handler)
+    client = RAGClient(base_url="http://chat:8000", transport=transport)
+
+    await client.ask("test", collection=None, rerank=False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Send explicit rerank booleans from eval RAG client requests to chat search and chat endpoints.
- Preserve chat retrieval metadata on eval dataset rows and final per-query result payloads when present.
- Add focused eval tests for baseline rerank payloads, rerank payloads, metadata persistence, and missing metadata shape.

## Test Plan
- PYTHONPATH=services/eval pytest services/eval/tests/test_rag_client.py -v
- PYTHONPATH=services/eval pytest services/eval/tests/test_evaluator.py::test_build_evaluation_dataset services/eval/tests/test_evaluator.py::test_build_evaluation_dataset_preserves_retrieval_metadata -v
- PYTHONPATH=services/eval pytest services/eval/tests/test_evaluator.py::test_run_evaluation_preserves_result_shape services/eval/tests/test_evaluator.py::test_run_evaluation_persists_retrieval_metadata_in_results -v
- PYTHONPATH=services:services/eval pytest services/eval/tests/test_evaluator.py services/eval/tests/test_rag_client.py -v
- PATH=/opt/homebrew/opt/python@3.13/libexec/bin:\$PATH PYTHONPATH=services make preflight-python
- make preflight-security

## Notes
- The requested command `PYTHONPATH=services/shared:services/eval pytest services/eval/tests -v` fails before collection because `services/shared/logging.py` shadows the stdlib `logging` module when `services/shared` is first on `PYTHONPATH`.
- Full eval suite with `PYTHONPATH=services:services/eval` currently has 7 unrelated RESPX route-matching failures in collection/config capture tests; the touched eval client/evaluator tests pass.