### PR TITLE
Add per-run retrieval config to eval workflow

### DIFF
--- a/go/eval-mcp-service/internal/evalapi/client.go
+++ b/go/eval-mcp-service/internal/evalapi/client.go
@@ -74,14 +74,19 @@ type CreateDatasetResponse struct {
 	ID string `json:"id"`
 }
 
+type RetrievalConfig struct {
+	TopK *int `json:"top_k,omitempty"`
+}
+
 type StartEvaluationRequest struct {
-	DatasetID       string `json:"dataset_id"`
-	Collection      string `json:"collection,omitempty"`
-	Notes           string `json:"notes,omitempty"`
-	BaselineEvalID  string `json:"baseline_eval_id,omitempty"`
-	ExperimentID    string `json:"experiment_id,omitempty"`
-	ExperimentLabel string `json:"experiment_label,omitempty"`
-	Rerank          bool   `json:"rerank"`
+	DatasetID       string           `json:"dataset_id"`
+	Collection      string           `json:"collection,omitempty"`
+	Notes           string           `json:"notes,omitempty"`
+	BaselineEvalID  string           `json:"baseline_eval_id,omitempty"`
+	ExperimentID    string           `json:"experiment_id,omitempty"`
+	ExperimentLabel string           `json:"experiment_label,omitempty"`
+	Rerank          bool             `json:"rerank"`
+	RetrievalConfig *RetrievalConfig `json:"retrieval_config,omitempty"`
 }
 
 type StartEvaluationResponse struct {

--- a/go/eval-mcp-service/internal/evalapi/client_test.go
+++ b/go/eval-mcp-service/internal/evalapi/client_test.go
@@ -67,6 +67,7 @@ func TestClientCreateDataset(t *testing.T) {
 }
 
 func TestStartEvaluationSendsOptionalFields(t *testing.T) {
+	topK := 3
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body StartEvaluationRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -74,6 +75,9 @@ func TestStartEvaluationSendsOptionalFields(t *testing.T) {
 		}
 		if body.DatasetID != "ds-1" || body.Collection != "documents" || body.Notes != "candidate" || body.BaselineEvalID != "eval-base" || body.ExperimentID != "exp-1" || body.ExperimentLabel != "candidate" || !body.Rerank {
 			t.Fatalf("body = %#v", body)
+		}
+		if body.RetrievalConfig == nil || body.RetrievalConfig.TopK == nil || *body.RetrievalConfig.TopK != 3 {
+			t.Fatalf("retrieval_config = %#v", body.RetrievalConfig)
 		}
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(StartEvaluationResponse{ID: "eval-2", Status: "running"})
@@ -89,6 +93,7 @@ func TestStartEvaluationSendsOptionalFields(t *testing.T) {
 		ExperimentID:    "exp-1",
 		ExperimentLabel: "candidate",
 		Rerank:          true,
+		RetrievalConfig: &RetrievalConfig{TopK: &topK},
 	})
 	if err != nil {
 		t.Fatalf("StartEvaluation error: %v", err)
@@ -333,12 +338,14 @@ func TestListDatasetsRetriesOnceAfterUnauthorized(t *testing.T) {
 
 func TestStartEvaluationRetriesUnauthorizedWithOriginalBody(t *testing.T) {
 	provider := &sequenceTokenProvider{tokens: []string{"expired-token", "fresh-token"}}
+	topK := 3
 	wantBody := StartEvaluationRequest{
-		DatasetID:      "ds-1",
-		Collection:     "documents",
-		Notes:          "candidate",
-		BaselineEvalID: "eval-base",
-		Rerank:         true,
+		DatasetID:       "ds-1",
+		Collection:      "documents",
+		Notes:           "candidate",
+		BaselineEvalID:  "eval-base",
+		Rerank:          true,
+		RetrievalConfig: &RetrievalConfig{TopK: &topK},
 	}
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -350,8 +357,11 @@ func TestStartEvaluationRetriesUnauthorizedWithOriginalBody(t *testing.T) {
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Fatalf("decode body request %d: %v", requests, err)
 		}
-		if gotBody != wantBody {
+		if gotBody.DatasetID != wantBody.DatasetID || gotBody.Collection != wantBody.Collection || gotBody.Notes != wantBody.Notes || gotBody.BaselineEvalID != wantBody.BaselineEvalID || gotBody.Rerank != wantBody.Rerank {
 			t.Fatalf("body request %d = %#v", requests, gotBody)
+		}
+		if gotBody.RetrievalConfig == nil || gotBody.RetrievalConfig.TopK == nil || *gotBody.RetrievalConfig.TopK != topK {
+			t.Fatalf("retrieval_config request %d = %#v", requests, gotBody.RetrievalConfig)
 		}
 		switch requests {
 		case 1:

--- a/go/eval-mcp-service/internal/evalworkflow/service.go
+++ b/go/eval-mcp-service/internal/evalworkflow/service.go
@@ -67,13 +67,14 @@ type StartExperimentInput struct {
 }
 
 type StartRunInput struct {
-	DatasetID      string
-	Collection     string
-	Notes          string
-	BaselineEvalID string
-	Rerank         bool
-	ExperimentID   string
-	Label          string
+	DatasetID       string
+	Collection      string
+	Notes           string
+	BaselineEvalID  string
+	Rerank          bool
+	ExperimentID    string
+	Label           string
+	RetrievalConfig *evalapi.RetrievalConfig
 }
 
 type StartRunResult struct {
@@ -253,6 +254,7 @@ func (s *Service) StartRun(ctx context.Context, in StartRunInput) (StartRunResul
 		Rerank:          in.Rerank,
 		ExperimentID:    in.ExperimentID,
 		ExperimentLabel: in.Label,
+		RetrievalConfig: in.RetrievalConfig,
 	})
 	if err != nil {
 		return StartRunResult{}, err

--- a/go/eval-mcp-service/internal/evalworkflow/service_test.go
+++ b/go/eval-mcp-service/internal/evalworkflow/service_test.go
@@ -41,15 +41,17 @@ func TestStartRunSendsExperimentAttachmentToEvalAPI(t *testing.T) {
 	ctx := context.Background()
 	api := &fakeAPI{startResponse: evalapi.StartEvaluationResponse{ID: "eval-123", Status: "queued"}}
 	svc := newTestService(api)
+	topK := 3
 
 	got, err := svc.StartRun(ctx, StartRunInput{
-		DatasetID:      "dataset-1",
-		Collection:     "kb",
-		Notes:          "candidate notes",
-		ExperimentID:   "exp-7",
-		Label:          "candidate",
-		BaselineEvalID: "eval-base",
-		Rerank:         true,
+		DatasetID:       "dataset-1",
+		Collection:      "kb",
+		Notes:           "candidate notes",
+		ExperimentID:    "exp-7",
+		Label:           "candidate",
+		BaselineEvalID:  "eval-base",
+		Rerank:          true,
+		RetrievalConfig: &evalapi.RetrievalConfig{TopK: &topK},
 	})
 	if err != nil {
 		t.Fatalf("StartRun error: %v", err)
@@ -63,6 +65,9 @@ func TestStartRunSendsExperimentAttachmentToEvalAPI(t *testing.T) {
 	req := api.startRequests[0]
 	if req.ExperimentID != "exp-7" || req.ExperimentLabel != "candidate" {
 		t.Fatalf("StartEvaluation request = %#v", req)
+	}
+	if req.RetrievalConfig == nil || req.RetrievalConfig.TopK == nil || *req.RetrievalConfig.TopK != 3 {
+		t.Fatalf("retrieval config = %#v", req.RetrievalConfig)
 	}
 }
 

--- a/go/eval-mcp-service/internal/mcpserver/server.go
+++ b/go/eval-mcp-service/internal/mcpserver/server.go
@@ -20,6 +20,8 @@ const workflowResourceURI = "eval://workflow"
 const (
 	minCompareInputs = 2
 	maxCompareInputs = 5
+	minRetrievalTopK = 1
+	maxRetrievalTopK = 20
 )
 
 type EvalService interface {
@@ -191,13 +193,14 @@ func getRAGCollectionConfigHandler(service EvalService) sdkmcp.ToolHandler {
 func startEvalRunHandler(service EvalService) sdkmcp.ToolHandler {
 	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
 		var args struct {
-			DatasetID      string `json:"dataset_id"`
-			Collection     string `json:"collection"`
-			Notes          string `json:"notes,omitempty"`
-			BaselineEvalID string `json:"baseline_eval_id,omitempty"`
-			Rerank         bool   `json:"rerank,omitempty"`
-			ExperimentID   string `json:"experiment_id,omitempty"`
-			Label          string `json:"label,omitempty"`
+			DatasetID       string          `json:"dataset_id"`
+			Collection      string          `json:"collection"`
+			Notes           string          `json:"notes,omitempty"`
+			BaselineEvalID  string          `json:"baseline_eval_id,omitempty"`
+			Rerank          bool            `json:"rerank,omitempty"`
+			ExperimentID    string          `json:"experiment_id,omitempty"`
+			Label           string          `json:"label,omitempty"`
+			RetrievalConfig json.RawMessage `json:"retrieval_config,omitempty"`
 		}
 		if err := decodeArgs(req, &args); err != nil {
 			return toolError(err.Error()), nil
@@ -214,18 +217,51 @@ func startEvalRunHandler(service EvalService) sdkmcp.ToolHandler {
 		if strings.TrimSpace(args.ExperimentID) != "" && strings.TrimSpace(args.Label) == "" {
 			return toolError("label is required when experiment_id is set"), nil
 		}
+		retrievalConfig, err := parseRetrievalConfig(args.RetrievalConfig)
+		if err != nil {
+			return toolError(err.Error()), nil
+		}
 		in := evalworkflow.StartRunInput{
-			DatasetID:      args.DatasetID,
-			Collection:     args.Collection,
-			Notes:          args.Notes,
-			BaselineEvalID: args.BaselineEvalID,
-			Rerank:         args.Rerank,
-			ExperimentID:   args.ExperimentID,
-			Label:          args.Label,
+			DatasetID:       args.DatasetID,
+			Collection:      args.Collection,
+			Notes:           args.Notes,
+			BaselineEvalID:  args.BaselineEvalID,
+			Rerank:          args.Rerank,
+			ExperimentID:    args.ExperimentID,
+			Label:           args.Label,
+			RetrievalConfig: retrievalConfig,
 		}
 		result, err := service.StartRun(ctx, in)
 		return resultOrError(result, err), nil
 	}
+}
+
+func parseRetrievalConfig(raw json.RawMessage) (*evalapi.RetrievalConfig, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("retrieval_config must be an object")
+	}
+	for field := range fields {
+		if field != "top_k" {
+			return nil, fmt.Errorf("retrieval_config.%s is not supported", field)
+		}
+	}
+
+	var config evalapi.RetrievalConfig
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return nil, fmt.Errorf("invalid retrieval_config: %w", err)
+	}
+	if config.TopK != nil {
+		topK := *config.TopK
+		if topK < minRetrievalTopK || topK > maxRetrievalTopK {
+			return nil, fmt.Errorf("retrieval_config.top_k must be between 1 and 20")
+		}
+	}
+	return &config, nil
 }
 
 func waitForEvalRunHandler(service EvalService) sdkmcp.ToolHandler {
@@ -506,7 +542,7 @@ func experimentIDSchema() json.RawMessage {
 }
 
 func startEvalRunSchema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"dataset_id":{"type":"string"},"collection":{"type":"string"},"notes":{"type":"string"},"baseline_eval_id":{"type":"string"},"rerank":{"type":"boolean"},"experiment_id":{"type":"string","minLength":1},"label":{"type":"string"}},"required":["dataset_id","collection"],"additionalProperties":false}`)
+	return json.RawMessage(`{"type":"object","properties":{"dataset_id":{"type":"string"},"collection":{"type":"string"},"notes":{"type":"string"},"baseline_eval_id":{"type":"string"},"rerank":{"type":"boolean"},"experiment_id":{"type":"string","minLength":1},"label":{"type":"string"},"retrieval_config":{"type":"object","properties":{"top_k":{"type":"integer","minimum":1,"maximum":20}},"additionalProperties":false}},"required":["dataset_id","collection"],"additionalProperties":false}`)
 }
 
 func waitEvalRunSchema() json.RawMessage {

--- a/go/eval-mcp-service/internal/mcpserver/server_test.go
+++ b/go/eval-mcp-service/internal/mcpserver/server_test.go
@@ -196,6 +196,80 @@ func TestStartEvalRunValidationError(t *testing.T) {
 	}
 }
 
+func TestStartEvalRunForwardsRetrievalConfig(t *testing.T) {
+	fake := &fakeEvalService{}
+	result, err := startEvalRunHandler(fake)(context.Background(), callReq(map[string]any{
+		"dataset_id":       "ds-1",
+		"collection":       "documents",
+		"rerank":           true,
+		"retrieval_config": map[string]any{"top_k": float64(3)},
+	}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned MCP error: %#v", result)
+	}
+	if fake.startRunInput.RetrievalConfig == nil || fake.startRunInput.RetrievalConfig.TopK == nil || *fake.startRunInput.RetrievalConfig.TopK != 3 {
+		t.Fatalf("retrieval config = %#v", fake.startRunInput.RetrievalConfig)
+	}
+}
+
+func TestStartEvalRunRejectsInvalidRetrievalConfig(t *testing.T) {
+	for _, topK := range []float64{0, 21} {
+		t.Run("top_k_range", func(t *testing.T) {
+			fake := &fakeEvalService{}
+			result, err := startEvalRunHandler(fake)(context.Background(), callReq(map[string]any{
+				"dataset_id":       "ds-1",
+				"collection":       "documents",
+				"retrieval_config": map[string]any{"top_k": topK},
+			}))
+			if err != nil {
+				t.Fatalf("handler returned transport error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("expected MCP tool error")
+			}
+			if fake.startRunCalls != 0 {
+				t.Fatalf("service should not be called on validation error, got %d calls", fake.startRunCalls)
+			}
+			if got := textResult(t, result); !strings.Contains(got, "retrieval_config.top_k must be between 1 and 20") {
+				t.Fatalf("error = %q", got)
+			}
+		})
+	}
+}
+
+func TestStartEvalRunRejectsUnknownRetrievalConfigField(t *testing.T) {
+	fake := &fakeEvalService{}
+	result, err := startEvalRunHandler(fake)(context.Background(), callReq(map[string]any{
+		"dataset_id":       "ds-1",
+		"collection":       "documents",
+		"retrieval_config": map[string]any{"limit": float64(3)},
+	}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected MCP tool error")
+	}
+	if fake.startRunCalls != 0 {
+		t.Fatalf("service should not be called on validation error, got %d calls", fake.startRunCalls)
+	}
+	if got := textResult(t, result); !strings.Contains(got, "retrieval_config.limit is not supported") {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestStartEvalRunSchemaIncludesRetrievalConfig(t *testing.T) {
+	schema := string(startEvalRunSchema())
+	for _, want := range []string{"retrieval_config", "top_k"} {
+		if !strings.Contains(schema, want) {
+			t.Fatalf("schema missing %q: %s", want, schema)
+		}
+	}
+}
+
 func TestCreateEvalDatasetHandlerRequiresFixture(t *testing.T) {
 	result, err := createEvalDatasetHandler(&fakeEvalService{})(context.Background(), callReq(map[string]any{}))
 	if err != nil {

--- a/services/chat/app/chain.py
+++ b/services/chat/app/chain.py
@@ -93,6 +93,15 @@ async def embed_texts(
     return embeddings
 
 
+async def get_embedding(
+    text: str,
+    provider: EmbeddingProvider,
+    model: str,
+) -> list[float]:
+    embeddings = await embed_texts(texts=[text], provider=provider, model=model)
+    return embeddings[0]
+
+
 async def stream_response(
     prompt: str,
     model: str,
@@ -141,12 +150,11 @@ async def retrieve_chunks(
 ) -> RetrievalResult:
     """Embed question and retrieve ranked chunks from Qdrant."""
     retrieve_start = time.perf_counter()
-    vectors = await embed_texts(
-        texts=[question],
+    query_vector = await get_embedding(
+        text=question,
         provider=embedding_provider,
         model=embedding_model,
     )
-    query_vector = vectors[0]
 
     retriever = QdrantRetriever(
         host=qdrant_host, port=qdrant_port, collection_name=collection_name
@@ -199,6 +207,8 @@ async def retrieve_chunks(
                 collection_name=collection_name,
                 error=semantic_error,
             )
+
+    result = _with_rerank_metadata(result, {"top_k": top_k})
 
     if rerank and not settings.rerank_enabled:
         result = _with_rerank_metadata(

--- a/services/chat/app/main.py
+++ b/services/chat/app/main.py
@@ -6,7 +6,7 @@ from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from llm.factory import get_embedding_provider, get_llm_provider
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from qdrant_client import QdrantClient
 from shared.auth import AuthContext, create_auth_context_dependency
 from shared.llm.admission import AdmissionRejected
@@ -124,9 +124,16 @@ _embedding_provider = get_embedding_provider(
 )
 
 
+class RetrievalConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    top_k: int | None = Field(default=None, ge=1, le=20, strict=True)
+
+
 class ChatRequest(BaseModel):
     question: str = Field(max_length=2000)
     collection: str | None = Field(default=None, pattern=r"^[a-zA-Z0-9_-]{1,100}$")
+    retrieval_config: RetrievalConfig | None = None
     rerank: bool = False
 
 
@@ -135,6 +142,12 @@ class SearchRequest(BaseModel):
     collection: str | None = Field(default=None, pattern=r"^[a-zA-Z0-9_-]{1,100}$")
     limit: int = Field(default=5, ge=1, le=20)
     rerank: bool = False
+
+
+def _effective_top_k(config: RetrievalConfig | None) -> int:
+    if config is not None and config.top_k is not None:
+        return config.top_k
+    return settings.top_k
 
 
 @app.get("/config")
@@ -201,6 +214,7 @@ async def chat(
     auth_context: AuthContext = Depends(enforce_chat_ask),
 ):
     wants_json = request.headers.get("accept", "").startswith("application/json")
+    effective_top_k = _effective_top_k(body.retrieval_config)
 
     if wants_json:
         try:
@@ -216,7 +230,7 @@ async def chat(
                 qdrant_host=settings.qdrant_host,
                 qdrant_port=settings.qdrant_port,
                 collection_name=body.collection or settings.collection_name,
-                top_k=settings.top_k,
+                top_k=effective_top_k,
                 rerank=body.rerank,
             ):
                 if "token" in event:
@@ -253,7 +267,7 @@ async def chat(
                 qdrant_host=settings.qdrant_host,
                 qdrant_port=settings.qdrant_port,
                 collection_name=body.collection or settings.collection_name,
-                top_k=settings.top_k,
+                top_k=effective_top_k,
                 rerank=body.rerank,
             ):
                 yield {"data": json.dumps(event)}

--- a/services/chat/tests/test_chain.py
+++ b/services/chat/tests/test_chain.py
@@ -371,6 +371,39 @@ async def test_retrieve_chunks_returns_hybrid_metadata(
     assert result.chunks[0]["text"] == "RFC 7231"
 
 
+@pytest.mark.asyncio
+@patch("app.chain.QdrantRetriever")
+@patch("app.chain.get_sparse_encoder")
+@patch("app.chain.get_embedding")
+async def test_retrieve_chunks_metadata_includes_final_top_k(
+    mock_get_embedding, mock_get_sparse_encoder, mock_retriever_cls
+):
+    mock_get_embedding.return_value = [0.1] * 768
+    mock_get_sparse_encoder.return_value.embed.return_value = [[0.2] * 10]
+    retriever = mock_retriever_cls.return_value
+    retriever.search_hybrid.return_value = RetrievalResult(
+        chunks=[],
+        metadata={
+            "retrieval_mode": "hybrid",
+            "retrieval_fallback": False,
+            "fusion": "rrf",
+        },
+    )
+
+    result = await retrieve_chunks(
+        question="hi",
+        embedding_provider=AsyncMock(),
+        embedding_model="nomic-embed-text",
+        qdrant_host="qdrant",
+        qdrant_port=6333,
+        collection_name="documents",
+        top_k=3,
+        rerank=False,
+    )
+
+    assert result.metadata["top_k"] == 3
+
+
 @patch("app.chain.logger", create=True)
 @patch("app.chain.get_sparse_encoder", create=True)
 @patch("app.chain.QdrantRetriever")

--- a/services/chat/tests/test_main.py
+++ b/services/chat/tests/test_main.py
@@ -97,6 +97,81 @@ def test_chat_threads_settings_top_k_into_rag_query(mock_rag_query):
     assert captured["top_k"] == 9
 
 
+@patch("app.main.rag_query")
+def test_chat_threads_retrieval_config_top_k_into_rag_query(mock_rag_query):
+    captured = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        yield {"done": True, "sources": [], "retrieval": {}}
+
+    mock_rag_query.side_effect = fake
+
+    response = client.post(
+        "/chat",
+        json={"question": "hi", "retrieval_config": {"top_k": 3}},
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert captured["top_k"] == 3
+
+
+@patch("app.main.rag_query")
+def test_chat_stream_threads_retrieval_config_top_k_into_rag_query(mock_rag_query):
+    from sse_starlette.sse import AppStatus
+
+    captured = {}
+
+    async def fake(**kwargs):
+        captured.update(kwargs)
+        yield {"done": True, "sources": [], "retrieval": {}}
+
+    mock_rag_query.side_effect = fake
+
+    try:
+        response = client.post(
+            "/chat",
+            json={"question": "hi", "retrieval_config": {"top_k": 4}},
+        )
+    finally:
+        AppStatus.should_exit_event = None
+
+    assert response.status_code == 200
+    assert captured["top_k"] == 4
+
+
+def test_chat_rejects_invalid_retrieval_config_top_k():
+    response = client.post(
+        "/chat",
+        json={"question": "hi", "retrieval_config": {"top_k": 0}},
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("top_k", [True, 3.0, "3"])
+def test_chat_rejects_non_integer_retrieval_config_top_k(top_k):
+    response = client.post(
+        "/chat",
+        json={"question": "hi", "retrieval_config": {"top_k": top_k}},
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_chat_rejects_unknown_retrieval_config_fields():
+    response = client.post(
+        "/chat",
+        json={"question": "hi", "retrieval_config": {"top_k": 3, "score": 0.8}},
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 422
+
+
 def test_config_endpoint_omits_secrets():
     response = client.get("/config")
     body = response.json()

--- a/services/eval/app/config_capture.py
+++ b/services/eval/app/config_capture.py
@@ -28,6 +28,7 @@ async def capture_run_config(
     ingestion_url: str,
     collection: str,
     requested_rerank: bool,
+    requested_retrieval_config: dict | None = None,
 ) -> dict:
     """Return a merged RAG config snapshot. Always returns a dict.
 
@@ -47,6 +48,7 @@ async def capture_run_config(
         "captured_at": captured_at,
         "effective_collection": collection,
         "requested_rerank": requested_rerank,
+        "requested_retrieval_config": requested_retrieval_config or {},
     }
     errors: list[str] = []
 
@@ -60,6 +62,25 @@ async def capture_run_config(
     else:
         out["collection"] = coll_res
 
+    chat_config = out.get("chat") if isinstance(out.get("chat"), dict) else {}
+    out["effective_retrieval_config"] = _effective_retrieval_config(
+        requested_retrieval_config, chat_config
+    )
+
     if errors:
         out["_capture_error"] = "; ".join(errors)
     return out
+
+
+def _effective_retrieval_config(
+    requested_retrieval_config: dict | None, chat_config: dict
+) -> dict:
+    requested_top_k = (requested_retrieval_config or {}).get("top_k")
+    if type(requested_top_k) is int:
+        return {"top_k": requested_top_k}
+
+    chat_top_k = chat_config.get("top_k")
+    if type(chat_top_k) is int:
+        return {"top_k": chat_top_k}
+
+    return {"top_k": 5}

--- a/services/eval/app/evaluator.py
+++ b/services/eval/app/evaluator.py
@@ -109,6 +109,7 @@ async def build_evaluation_dataset(
     rag_client: RAGClient,
     collection: str | None,
     rerank: bool = False,
+    top_k: int = 5,
     run_context: EvalRunContext | None = None,
 ) -> list[dict]:
     """Run each golden item through the RAG pipeline and build evaluation rows."""
@@ -127,10 +128,13 @@ async def build_evaluation_dataset(
             )
         try:
             search_results = await rag_client.search(
-                query, collection=collection, limit=5, rerank=rerank
+                query, collection=collection, limit=top_k, rerank=rerank
             )
             chat_response = await rag_client.ask(
-                query, collection=collection, rerank=rerank
+                query,
+                collection=collection,
+                rerank=rerank,
+                retrieval_config={"top_k": top_k},
             )
         except Exception:
             eval_items_total.labels(
@@ -291,12 +295,18 @@ async def run_evaluation(
     llm_model: str,
     llm_api_key: str,
     rerank: bool = False,
+    top_k: int = 5,
     judge: JudgeFn | None = None,
     run_context: EvalRunContext | None = None,
 ) -> tuple[dict, list[dict]]:
     """Run a full first-party RAG evaluation."""
     raw_dataset = await build_evaluation_dataset(
-        items, rag_client, collection, rerank=rerank, run_context=run_context
+        items,
+        rag_client,
+        collection,
+        rerank=rerank,
+        top_k=top_k,
+        run_context=run_context,
     )
     if not raw_dataset:
         return {name: None for name in METRIC_NAMES}, []

--- a/services/eval/app/main.py
+++ b/services/eval/app/main.py
@@ -39,6 +39,7 @@ from app.models import (
     EvaluationDashboard,
     MetricTrendPoint,
     QueryScore,
+    RetrievalConfig,
     StartEvaluationRequest,
     UpdateExperimentRequest,
 )
@@ -223,8 +224,30 @@ def _failure_message(
     )
 
 
+def _requested_retrieval_config(config: RetrievalConfig | None) -> dict:
+    return config.model_dump(exclude_none=True) if config else {}
+
+
+def _effective_top_k(
+    config: RetrievalConfig | None, captured_config: dict | None
+) -> int:
+    if config and config.top_k is not None:
+        return config.top_k
+
+    effective_config = (captured_config or {}).get("effective_retrieval_config", {})
+    effective_top_k = effective_config.get("top_k")
+    if type(effective_top_k) is int:
+        return effective_top_k
+
+    return 5
+
+
 async def _run_evaluation_task(
-    eval_id: str, items: list[dict], collection: str | None, rerank: bool = False
+    eval_id: str,
+    items: list[dict],
+    collection: str | None,
+    rerank: bool = False,
+    retrieval_config: RetrievalConfig | None = None,
 ):
     """Background task that runs the RAG quality evaluation."""
     db = await get_db()
@@ -257,8 +280,10 @@ async def _run_evaluation_task(
             ingestion_url=settings.ingestion_service_url,
             collection=coll_name,
             requested_rerank=rerank,
+            requested_retrieval_config=_requested_retrieval_config(retrieval_config),
         )
         await db.set_evaluation_config(eval_id, config)
+        effective_top_k = _effective_top_k(retrieval_config, config)
 
         aggregate, results = await asyncio.wait_for(
             run_evaluation(
@@ -270,6 +295,7 @@ async def _run_evaluation_task(
                 llm_model=settings.llm_model,
                 llm_api_key=settings.llm_api_key,
                 rerank=rerank,
+                top_k=effective_top_k,
                 run_context=run_context,
             ),
             timeout=settings.eval_run_max_seconds,
@@ -447,7 +473,12 @@ async def start_evaluation(
     )
 
     background_tasks.add_task(
-        _run_evaluation_task, eval_id, dataset["items"], collection, body.rerank
+        _run_evaluation_task,
+        eval_id,
+        dataset["items"],
+        collection,
+        body.rerank,
+        body.retrieval_config,
     )
 
     return {"id": eval_id, "status": "running"}

--- a/services/eval/app/models.py
+++ b/services/eval/app/models.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class GoldenItem(BaseModel):
@@ -28,12 +28,19 @@ class DatasetDetail(BaseModel):
     created_at: str
 
 
+class RetrievalConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    top_k: int | None = Field(default=None, ge=1, le=20, strict=True)
+
+
 class StartEvaluationRequest(BaseModel):
     dataset_id: str
     collection: str | None = Field(default=None, pattern=r"^[a-zA-Z0-9_-]{1,100}$")
     notes: str | None = Field(default=None, max_length=500)
     baseline_eval_id: str | None = None
     rerank: bool = False
+    retrieval_config: RetrievalConfig | None = None
     experiment_id: str | None = None
     experiment_label: str | None = Field(
         default=None, min_length=1, max_length=100, pattern=r"^[a-zA-Z0-9_-]+$"

--- a/services/eval/app/rag_client.py
+++ b/services/eval/app/rag_client.py
@@ -94,12 +94,18 @@ class RAGClient:
         return resp.json()["results"]
 
     async def ask(
-        self, question: str, collection: str | None, rerank: bool = False
+        self,
+        question: str,
+        collection: str | None,
+        rerank: bool = False,
+        retrieval_config: dict | None = None,
     ) -> dict:
         """Call POST /chat with Accept: application/json for a full RAG response."""
         body: dict = {"question": question, "rerank": rerank}
         if collection:
             body["collection"] = collection
+        if retrieval_config:
+            body["retrieval_config"] = retrieval_config
 
         started_at = time.perf_counter()
         try:

--- a/services/eval/tests/test_config_capture.py
+++ b/services/eval/tests/test_config_capture.py
@@ -77,6 +77,50 @@ async def test_capture_records_baseline_rerank_intent():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_capture_records_requested_and_effective_retrieval_config():
+    respx.get("http://chat/config").mock(
+        return_value=httpx.Response(200, json={"top_k": 5})
+    )
+    respx.get("http://ingestion/collections/documents/config").mock(
+        return_value=httpx.Response(200, json={"chunk_size": 1000})
+    )
+
+    cfg = await capture_run_config(
+        chat_url="http://chat",
+        ingestion_url="http://ingestion",
+        collection="documents",
+        requested_rerank=False,
+        requested_retrieval_config={"top_k": 3},
+    )
+
+    assert cfg["requested_retrieval_config"] == {"top_k": 3}
+    assert cfg["effective_retrieval_config"] == {"top_k": 3}
+    assert cfg["chat"]["top_k"] == 5
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_capture_records_empty_requested_retrieval_config_for_default_run():
+    respx.get("http://chat/config").mock(
+        return_value=httpx.Response(200, json={"top_k": 5})
+    )
+    respx.get("http://ingestion/collections/documents/config").mock(
+        return_value=httpx.Response(200, json={"chunk_size": 1000})
+    )
+
+    cfg = await capture_run_config(
+        chat_url="http://chat",
+        ingestion_url="http://ingestion",
+        collection="documents",
+        requested_rerank=False,
+    )
+
+    assert cfg["requested_retrieval_config"] == {}
+    assert cfg["effective_retrieval_config"] == {"top_k": 5}
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_capture_records_error_when_chat_fails():
     respx.get("http://chat/config").mock(side_effect=httpx.ConnectError("boom"))
     respx.get("http://ingestion/collections/documents/config").mock(

--- a/services/eval/tests/test_evaluator.py
+++ b/services/eval/tests/test_evaluator.py
@@ -164,6 +164,26 @@ async def test_build_evaluation_dataset_passes_rerank(
 
 
 @pytest.mark.asyncio
+async def test_build_evaluation_dataset_uses_effective_top_k_for_search_and_chat(
+    golden_items, mock_search_results, mock_chat_answer
+):
+    rag_client = AsyncMock()
+    rag_client.search.return_value = mock_search_results
+    rag_client.ask.return_value = mock_chat_answer
+
+    await build_evaluation_dataset(
+        items=golden_items,
+        rag_client=rag_client,
+        collection="documents",
+        rerank=False,
+        top_k=3,
+    )
+
+    assert rag_client.search.call_args_list[0].kwargs["limit"] == 3
+    assert rag_client.ask.call_args_list[0].kwargs["retrieval_config"] == {"top_k": 3}
+
+
+@pytest.mark.asyncio
 async def test_build_evaluation_dataset_preserves_retrieval_metadata(
     golden_items, mock_search_results, mock_chat_answer_with_retrieval
 ):

--- a/services/eval/tests/test_main.py
+++ b/services/eval/tests/test_main.py
@@ -838,6 +838,39 @@ def test_start_evaluation_passes_rerank_to_background_run(
     assert mock_capture.await_args.kwargs["collection"] == "documents"
 
 
+@patch("app.main.run_evaluation", new_callable=AsyncMock)
+@patch("app.main.capture_run_config", new_callable=AsyncMock)
+@patch("app.main.validate_collection_exists", new_callable=AsyncMock)
+@patch("app.main.get_db")
+def test_start_evaluation_passes_retrieval_config_to_background_run(
+    mock_get_db, mock_validate_collection, mock_capture, mock_run_evaluation
+):
+    mock_db = AsyncMock()
+    mock_db.get_dataset.return_value = {
+        "id": "ds-top-k",
+        "name": "test",
+        "items": [{"query": "q", "expected_answer": "a", "expected_sources": []}],
+        "created_at": "2026-04-16T00:00:00Z",
+    }
+    mock_db.create_evaluation.return_value = "eval-top-k"
+    mock_get_db.return_value = mock_db
+    mock_capture.return_value = {
+        "captured_at": "x",
+        "chat": {"top_k": 5},
+        "effective_retrieval_config": {"top_k": 3},
+    }
+    mock_run_evaluation.return_value = ({"faithfulness": 0.8}, [])
+
+    response = client.post(
+        "/evaluations",
+        json={"dataset_id": "ds-top-k", "retrieval_config": {"top_k": 3}},
+    )
+
+    assert response.status_code == 202
+    assert mock_capture.await_args.kwargs["requested_retrieval_config"] == {"top_k": 3}
+    assert mock_run_evaluation.await_args.kwargs["top_k"] == 3
+
+
 @patch("app.main.validate_collection_exists", new_callable=AsyncMock)
 @patch("app.main.run_evaluation", new_callable=AsyncMock)
 @patch("app.main.capture_run_config", new_callable=AsyncMock)

--- a/services/eval/tests/test_models.py
+++ b/services/eval/tests/test_models.py
@@ -47,6 +47,28 @@ def test_start_request_accepts_rerank_flag():
     assert req.rerank is True
 
 
+def test_start_request_accepts_retrieval_config_top_k():
+    req = StartEvaluationRequest(dataset_id="ds-1", retrieval_config={"top_k": 3})
+
+    assert req.retrieval_config.top_k == 3
+
+
+def test_start_request_rejects_invalid_retrieval_config_top_k():
+    with pytest.raises(ValidationError):
+        StartEvaluationRequest(dataset_id="ds-1", retrieval_config={"top_k": 0})
+
+
+@pytest.mark.parametrize("top_k", [True, 3.0, "3"])
+def test_start_request_rejects_non_integer_retrieval_config_top_k(top_k):
+    with pytest.raises(ValidationError):
+        StartEvaluationRequest(dataset_id="ds-1", retrieval_config={"top_k": top_k})
+
+
+def test_start_request_rejects_unknown_retrieval_config_fields():
+    with pytest.raises(ValidationError):
+        StartEvaluationRequest(dataset_id="ds-1", retrieval_config={"limit": 3})
+
+
 def test_evaluation_detail_includes_new_fields():
     detail = EvaluationDetail(
         id="e1",

--- a/services/eval/tests/test_rag_client.py
+++ b/services/eval/tests/test_rag_client.py
@@ -141,6 +141,26 @@ async def test_ask_sends_rerank_false_for_baseline(mock_chat_response):
 
 
 @pytest.mark.asyncio
+async def test_ask_forwards_retrieval_config(mock_chat_response):
+    async def mock_handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/chat"
+        body = json.loads(request.content)
+        assert body["retrieval_config"] == {"top_k": 3}
+        return httpx.Response(200, json=mock_chat_response)
+
+    transport = httpx.MockTransport(mock_handler)
+    client = RAGClient(base_url="http://chat:8000", transport=transport)
+
+    response = await client.ask(
+        "what is kubernetes",
+        collection=None,
+        rerank=False,
+        retrieval_config={"top_k": 3},
+    )
+    assert response["answer"] == mock_chat_response["answer"]
+
+
+@pytest.mark.asyncio
 async def test_search_server_error():
     async def mock_handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(500, json={"detail": "internal error"})


### PR DESCRIPTION
## Summary
- add typed `retrieval_config.top_k` support to eval runs
- align eval `/search.limit` and chat `/chat` final context budget
- capture requested and effective retrieval config in eval run metadata
- expose the option through the eval MCP `start_eval_run` tool

## Verification
- `PATH=/tmp/codex-python-shim:$PATH PYTHONPATH=services make preflight-python`
- `PYTHONPATH=services/eval:services /tmp/eval-task2-venv/bin/python -m pytest services/eval/tests/test_models.py services/eval/tests/test_rag_client.py services/eval/tests/test_evaluator.py services/eval/tests/test_config_capture.py services/eval/tests/test_main.py -q`
- `make preflight-go`
- `make preflight-security`