### PR TITLE
Expand AI internal MCP hub

### DIFF
--- a/frontend/e2e/mocked/ai-mcp-section.spec.ts
+++ b/frontend/e2e/mocked/ai-mcp-section.spec.ts
@@ -72,7 +72,32 @@ test.describe("/ai MCP Server section", () => {
     ).toBeVisible();
   });
 
-  test("MCP section highlights the internal engineering MCP workflow", async ({
+  test("AI page exposes anchor navigation for the major systems", async ({
+    page,
+  }) => {
+    await page.goto("/ai");
+
+    const nav = page.getByRole("navigation", { name: "AI section navigation" });
+    await expect(nav).toBeVisible();
+
+    await expect(
+      nav.getByRole("link", { name: "MCP Server" }),
+    ).toHaveAttribute("href", "#mcp-server");
+    await expect(
+      nav.getByRole("link", { name: "Internal MCPs" }),
+    ).toHaveAttribute("href", "#internal-mcps");
+    await expect(
+      nav.getByRole("link", { name: "RAG Evaluation" }),
+    ).toHaveAttribute("href", "#rag-evaluation");
+    await expect(
+      nav.getByRole("link", { name: "Debugging Assistant" }),
+    ).toHaveAttribute("href", "#debugging-assistant");
+    await expect(
+      nav.getByRole("link", { name: "Connect a Client" }),
+    ).toHaveAttribute("href", "#connect-client");
+  });
+
+  test("MCP section highlights internal MCP ecosystems and deeper routes", async ({
     page,
   }) => {
     await page.goto("/ai");
@@ -80,19 +105,48 @@ test.describe("/ai MCP Server section", () => {
     const section = page.locator("#internal-mcps");
     await expect(section).toBeVisible();
     await expect(
-      page.getByRole("heading", {
+      section.getByRole("heading", {
         name: "Internal MCPs for Engineering Operations",
       }),
     ).toBeVisible();
-    await expect(page.getByText("Observability MCP", { exact: false })).toBeVisible();
-    await expect(page.getByText("QA MCP", { exact: false })).toBeVisible();
-    await expect(page.getByText("Eval MCP service", { exact: false })).toBeVisible();
-    await expect(page.getByText("Evidence-backed engineering action")).toBeVisible();
-    await expect(page.getByText("Example tool-call trace")).toBeVisible();
+
     await expect(
-      page.getByText("observability.investigate_checkout"),
+      section.getByRole("heading", { name: "Observability MCP" }),
     ).toBeVisible();
-    await expect(page.getByText("Why this matters")).toBeVisible();
+    await expect(section.getByText("Prometheus")).toBeVisible();
+    await expect(section.getByText("Loki")).toBeVisible();
+    await expect(section.getByText("Jaeger")).toBeVisible();
+    await expect(section.getByText("Grafana")).toBeVisible();
+    await expect(section.getByText("5 dashboards")).toBeVisible();
+    await expect(section.getByText("16 alert rules")).toBeVisible();
+    await expect(section.getByText("get_system_health")).toBeVisible();
+    await expect(section.getByText("investigate_checkout")).toBeVisible();
+    await expect(section.getByText("get_trace")).toBeVisible();
+    await expect(
+      section.getByRole("link", { name: "See the full observability platform" }),
+    ).toHaveAttribute("href", "/observability");
+
+    await expect(
+      section.getByRole("heading", { name: "Eval MCP service" }),
+    ).toBeVisible();
+    await expect(section.getByText("Eval API")).toBeVisible();
+    await expect(section.getByText("RAG collections")).toBeVisible();
+    await expect(section.getByText("dataset fixtures")).toBeVisible();
+    await expect(section.getByText("evaluation runs")).toBeVisible();
+    await expect(section.getByText("experiments")).toBeVisible();
+    await expect(section.getByText("rerank")).toBeVisible();
+    await expect(section.getByText("top_k")).toBeVisible();
+    await expect(section.getByText("start_eval_run")).toBeVisible();
+    await expect(section.getByText("compare_eval_runs")).toBeVisible();
+    await expect(section.getByText("get_worst_eval_cases")).toBeVisible();
+    await expect(
+      section.getByRole("link", { name: "Open the RAG evaluation workflow" }),
+    ).toHaveAttribute("href", "/ai/eval");
+
+    await expect(
+      section.getByRole("heading", { name: "QA MCP" }),
+    ).toBeVisible();
+    await expect(section.getByText("weak-topic tracking")).toBeVisible();
   });
 
   test("Tool catalog renders on /go AI Assistant tab", async ({ page }) => {

--- a/frontend/src/app/ai/page.tsx
+++ b/frontend/src/app/ai/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { MermaidDiagram } from "@/components/MermaidDiagram";
+import { AISectionNav } from "@/components/ai/AISectionNav";
 import { MCPSection } from "@/components/ai/MCPSection";
 
 const architectureDiagram = `flowchart LR
@@ -70,11 +71,13 @@ export default function AISection() {
           </p>
         </section>
 
+        <AISectionNav />
+
         {/* MCP Server (top section) */}
         <MCPSection />
 
         {/* RAG Evaluation */}
-        <section className="mt-16">
+        <section id="rag-evaluation" className="mt-16 scroll-mt-20">
           <h2 className="text-2xl font-semibold">RAG Evaluation</h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
             A measurement tool for systematically tracking RAG pipeline quality.
@@ -143,9 +146,9 @@ export default function AISection() {
           </Link>
         </section>
 
-        {/* Debug Assistant */}
-        <section className="mt-16">
-          <h2 className="text-2xl font-semibold">Debug Assistant</h2>
+        {/* Debugging Assistant */}
+        <section id="debugging-assistant" className="mt-16 scroll-mt-20">
+          <h2 className="text-2xl font-semibold">Debugging Assistant</h2>
           <p className="mt-4 text-muted-foreground leading-relaxed">
             An agentic debugging tool that indexes a Python codebase into a
             vector store and uses a ReAct-style agent loop to search the code,

--- a/frontend/src/components/ai/AISectionNav.tsx
+++ b/frontend/src/components/ai/AISectionNav.tsx
@@ -1,0 +1,28 @@
+const aiSectionLinks = [
+  { href: "#mcp-server", label: "MCP Server" },
+  { href: "#internal-mcps", label: "Internal MCPs" },
+  { href: "#rag-evaluation", label: "RAG Evaluation" },
+  { href: "#debugging-assistant", label: "Debugging Assistant" },
+  { href: "#connect-client", label: "Connect a Client" },
+];
+
+export function AISectionNav() {
+  return (
+    <nav
+      aria-label="AI section navigation"
+      className="mt-8 rounded-lg border border-foreground/10 bg-card p-3"
+    >
+      <div className="flex flex-wrap gap-2">
+        {aiSectionLinks.map((link) => (
+          <a
+            key={link.href}
+            href={link.href}
+            className="rounded-md border border-foreground/10 px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-primary/60 hover:text-foreground"
+          >
+            {link.label}
+          </a>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/components/ai/MCPSection.tsx
+++ b/frontend/src/components/ai/MCPSection.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { MermaidDiagram } from "@/components/MermaidDiagram";
 import { MCPArchitectureDiagram } from "./MCPArchitectureDiagram";
 import { MCPToolCatalog } from "./MCPToolCatalog";
 
@@ -21,20 +20,49 @@ const inspectorCommand = `npx @modelcontextprotocol/inspector https://api.kylebr
 const githubMcpUrl =
   "https://github.com/kabradshaw1/portfolio/tree/main/go/ai-service/internal/mcp";
 
-const internalMcpChart = `flowchart LR
-  CODEX[Codex]
-  subgraph InternalMCPs ["Internal MCPs"]
-    OBS[Observability MCP<br/>logs · traces · health]
-    QA[QA MCP<br/>answers · critique · weak topics]
-    EVAL[Eval MCP service<br/>datasets · runs · comparisons]
-  end
-  ACTION[Evidence-backed engineering action]
-  CODEX --> InternalMCPs
-  InternalMCPs --> ACTION`;
+const observabilityProofPoints = [
+  "Prometheus",
+  "Loki",
+  "Jaeger",
+  "Grafana",
+  "5 dashboards",
+  "16 alert rules",
+];
+
+const observabilityTools = [
+  "get_system_health",
+  "investigate_checkout",
+  "investigate_ai_pipeline",
+  "investigate_eval_run",
+  "investigate_streaming_analytics",
+  "get_service_evidence",
+  "search_logs",
+  "get_trace",
+];
+
+const evalProofPoints = [
+  "Eval API",
+  "RAG collections",
+  "dataset fixtures",
+  "evaluation runs",
+  "experiments",
+  "rerank",
+  "top_k",
+];
+
+const evalTools = [
+  "start_eval_run",
+  "wait_for_eval_run",
+  "compare_eval_runs",
+  "get_worst_eval_cases",
+  "get_rag_collection_config",
+  "record_eval_experiment_conclusion",
+  "summarize_eval_experiment",
+];
 
 export function MCPSection() {
   return (
-    <section className="mt-12">
+    <section id="mcp-server" className="mt-12 scroll-mt-20">
       <h2 className="text-2xl font-semibold">MCP Server</h2>
       <p className="mt-4 text-muted-foreground leading-relaxed">
         The Go ai-service exposes twelve tools to any{" "}
@@ -73,59 +101,123 @@ export function MCPSection() {
           Internal MCPs for Engineering Operations
         </h3>
         <p className="mt-4 text-muted-foreground leading-relaxed">
-          The public MCP server is the user-facing showcase. Behind it, three
-          internal MCPs give Codex bounded, purpose-built access to the systems
-          that keep this portfolio operable: production evidence, structured
-          practice feedback, and repeatable RAG quality measurement.
+          These MCPs are Codex-facing control surfaces over larger engineering
+          systems. The route stays focused on what the MCP layer adds: bounded
+          tool access, evidence gathering, repeatable workflows, and links into
+          the deeper platforms behind each service.
         </p>
 
-        <div className="mt-6 rounded-lg border border-foreground/10 bg-card p-4 sm:p-6">
-          <MermaidDiagram chart={internalMcpChart} />
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          <article className="rounded-lg border border-foreground/10 bg-card p-4 sm:p-5">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Read-only production evidence
+            </div>
+            <h4 className="mt-2 text-lg font-semibold">Observability MCP</h4>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              A local MCP endpoint over the metrics, logs, traces, dashboard,
+              and runbook layers. It turns operational questions into bounded
+              evidence bundles for system health, checkout incidents, AI
+              pipeline failures, eval runs, streaming analytics, service logs,
+              and trace lookup without mutating the cluster.
+            </p>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              {observabilityProofPoints.map((point) => (
+                <span
+                  key={point}
+                  className="rounded-md border border-foreground/10 bg-muted px-2 py-1 text-xs text-muted-foreground"
+                >
+                  {point}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-4">
+              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Representative tools
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {observabilityTools.map((tool) => (
+                  <code
+                    key={tool}
+                    className="rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
+                  >
+                    {tool}
+                  </code>
+                ))}
+              </div>
+            </div>
+
+            <Link
+              href="/observability"
+              className="mt-5 inline-flex text-sm font-medium underline hover:text-foreground"
+            >
+              See the full observability platform &rarr;
+            </Link>
+          </article>
+
+          <article className="rounded-lg border border-foreground/10 bg-card p-4 sm:p-5">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              RAG experiment control plane
+            </div>
+            <h4 className="mt-2 text-lg font-semibold">Eval MCP service</h4>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              An operator MCP for repeatable RAG evaluation work. It coordinates
+              evaluator datasets, run history, study records, conclusions,
+              collection metadata from ingestion, retrieval settings, ranking
+              comparisons, worst-case review, and the eval-run evidence handoff
+              into the observability control plane.
+            </p>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              {evalProofPoints.map((point) => (
+                <span
+                  key={point}
+                  className="rounded-md border border-foreground/10 bg-muted px-2 py-1 text-xs text-muted-foreground"
+                >
+                  {point}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-4">
+              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Representative tools
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {evalTools.map((tool) => (
+                  <code
+                    key={tool}
+                    className="rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
+                  >
+                    {tool}
+                  </code>
+                ))}
+              </div>
+            </div>
+
+            <Link
+              href="/ai/eval"
+              className="mt-5 inline-flex text-sm font-medium underline hover:text-foreground"
+            >
+              Open the RAG evaluation workflow &rarr;
+            </Link>
+          </article>
         </div>
 
-        <div className="mt-6 grid gap-4 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-          <div className="rounded-lg border border-foreground/10 bg-card p-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Example tool-call trace
-            </div>
-            <div className="mt-4 space-y-3">
-              <div className="ml-auto w-fit max-w-[85%] rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground">
-                Why did checkout stall in QA?
-              </div>
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <span className="inline-block size-2 animate-pulse rounded-full bg-yellow-500" />
-                observability.investigate_checkout
-              </div>
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <span className="inline-block size-2 rounded-full bg-green-500" />
-                observability.get_trace
-              </div>
-              <div className="mr-auto w-fit max-w-[92%] rounded-lg bg-muted px-3 py-2 text-sm">
-                Payment was created, but the order saga never observed
-                completion. The trace points to a RabbitMQ reply timeout.
-              </div>
-            </div>
+        <article className="mt-4 rounded-lg border border-foreground/10 bg-card p-4">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Structured practice feedback
           </div>
-
-          <div className="rounded-lg border border-foreground/10 bg-card p-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              Why this matters
-            </div>
-            <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
-              <li>
-                Turns production questions into bounded evidence requests.
-              </li>
-              <li>
-                Keeps practice feedback and weak-topic tracking in the same
-                workflow.
-              </li>
-              <li>
-                Makes RAG changes measurable before they are treated as
-                improvements.
-              </li>
-            </ul>
-          </div>
-        </div>
+          <h4 className="mt-2 text-lg font-semibold">QA MCP</h4>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            A compact internal MCP for structured practice sessions, expected
+            answer feedback, weak-topic tracking, review attempts, and scoring.
+            It keeps interview preparation in the same tool-call workflow
+            without competing with the production observability and RAG eval
+            control planes.
+          </p>
+        </article>
       </section>
 
       <h3 className="mt-10 text-xl font-semibold">Try it interactively</h3>
@@ -143,21 +235,23 @@ export function MCPSection() {
         </Link>
       </div>
 
-      <h3 className="mt-10 text-xl font-semibold">Connect your own client</h3>
-      <p className="mt-4 text-muted-foreground leading-relaxed">
-        The MCP server is publicly reachable at{" "}
-        <code className="rounded bg-muted px-1.5 py-0.5 text-sm">
-          https://api.kylebradshaw.dev/ai-api/mcp
-        </code>
-        . Public tools (catalog search, RAG search,{" "}
-        <code>list_collections</code>) work without auth. Auth-scoped tools
-        require a Bearer JWT &mdash; register at{" "}
-        <Link href="/go/register" className="underline hover:text-foreground">
-          /go/register
-        </Link>
-        , log in, and copy the access token from the{" "}
-        <code>Authorization</code> header in DevTools.
-      </p>
+      <section id="connect-client" className="mt-10 scroll-mt-20">
+        <h3 className="text-xl font-semibold">Connect your own client</h3>
+        <p className="mt-4 text-muted-foreground leading-relaxed">
+          The MCP server is publicly reachable at{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-sm">
+            https://api.kylebradshaw.dev/ai-api/mcp
+          </code>
+          . Public tools (catalog search, RAG search,{" "}
+          <code>list_collections</code>) work without auth. Auth-scoped tools
+          require a Bearer JWT &mdash; register at{" "}
+          <Link href="/go/register" className="underline hover:text-foreground">
+            /go/register
+          </Link>
+          , log in, and copy the access token from the{" "}
+          <code>Authorization</code> header in DevTools.
+        </p>
+      </section>
 
       <h4 className="mt-6 text-lg font-medium">Claude Desktop</h4>
       <p className="mt-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- add compact anchor navigation for the /ai page major sections
- replace the internal MCP block with Observability MCP, Eval MCP, and QA MCP panels
- extend mocked Playwright coverage for nav anchors, proof points, and deep links

## Verification
- npx playwright test e2e/mocked/ai-mcp-section.spec.ts
- make preflight-frontend
- make preflight-e2e