### PR TITLE
Fix RAG triage compose smoke image

### DIFF
--- a/services/rag-triage/Dockerfile
+++ b/services/rag-triage/Dockerfile
@@ -8,10 +8,9 @@ WORKDIR /app
 COPY rag-triage/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY shared/ ./shared/
 COPY rag-triage/app/ ./app/
 
-ENV PYTHONPATH=/app:/app/shared
+ENV PYTHONPATH=/app
 
 RUN useradd --create-home appuser
 USER appuser


### PR DESCRIPTION
## Summary
- Remove the unnecessary shared package copy/path from the rag-triage Docker image so stdlib imports do not resolve services/shared/logging.py.
- Leaves the npm audit failure unchanged because the failure was ECONNRESET and the next qa run passed that job.

## Verification
- PYTHONPATH=services/rag-triage /tmp/rag-triage-venv/bin/python -c 'import asyncio; import app.main; print("ok")'
- /tmp/rag-triage-venv/bin/python -m pytest tests -v
- docker compose -f docker-compose.yml -f docker-compose.ci.yml config --quiet

Docker image build was not run locally because Colima/Docker is unavailable on this machine.