### PR TITLE
Tighten AI tool schema guidance

### DIFF
--- a/go/ai-service/internal/tools/cart.go
+++ b/go/ai-service/internal/tools/cart.go
@@ -24,8 +24,10 @@ type viewCartTool struct{ api cartAPI }
 
 func NewViewCartTool(api cartAPI) Tool { return &viewCartTool{api: api} }
 
-func (t *viewCartTool) Name() string        { return "view_cart" }
-func (t *viewCartTool) Description() string { return "Return the current user's shopping cart with items and total in cents." }
+func (t *viewCartTool) Name() string { return "view_cart" }
+func (t *viewCartTool) Description() string {
+	return "Return the authenticated user's shopping cart with items and total in cents. Use when they ask what is in their cart. Do not use when they need public catalog search or another user id would be needed."
+}
 func (t *viewCartTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{}}`)
 }
@@ -56,14 +58,14 @@ func NewAddToCartTool(api cartAPI) Tool { return &addToCartTool{api: api} }
 
 func (t *addToCartTool) Name() string { return "add_to_cart" }
 func (t *addToCartTool) Description() string {
-	return "Add a product to the current user's cart. Quantity must be a positive integer."
+	return "Add a product to the authenticated user's cart. Use when they explicitly want a catalog item added with a quantity. Do not use when acting for another user or inventing a user id would be needed."
 }
 func (t *addToCartTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"product_id":{"type":"string"},
-			"qty":{"type":"integer","minimum":1}
+			"product_id":{"type":"string","description":"Public catalog product id to add to the authenticated user's cart."},
+			"qty":{"type":"integer","description":"Quantity to add; must be at least 1.","minimum":1}
 		},
 		"required":["product_id","qty"]
 	}`)

--- a/go/ai-service/internal/tools/catalog.go
+++ b/go/ai-service/internal/tools/catalog.go
@@ -22,8 +22,8 @@ type ecommerceAPI interface {
 // -------- get_product --------
 
 type getProductTool struct {
-	api       ecommerceAPI
-	kafkaPub  kafka.Producer
+	api      ecommerceAPI
+	kafkaPub kafka.Producer
 }
 
 func NewGetProductTool(api ecommerceAPI, opts ...kafka.Producer) Tool {
@@ -34,8 +34,10 @@ func NewGetProductTool(api ecommerceAPI, opts ...kafka.Producer) Tool {
 	return t
 }
 
-func (t *getProductTool) Name() string        { return "get_product" }
-func (t *getProductTool) Description() string { return "Fetch the full details of one product by id." }
+func (t *getProductTool) Name() string { return "get_product" }
+func (t *getProductTool) Description() string {
+	return "Fetch public catalog details for one product by id. Use when the user asks about a specific product. Do not use when they need account-specific orders, cart, or returns."
+}
 func (t *getProductTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
@@ -94,15 +96,15 @@ func NewSearchProductsTool(api ecommerceAPI, opts ...kafka.Producer) Tool {
 
 func (t *searchProductsTool) Name() string { return "search_products" }
 func (t *searchProductsTool) Description() string {
-	return "Search the product catalog by free-text query. Optional max_price in dollars (e.g. 150 for $150). Returns at most 10 results."
+	return "Search public product catalog knowledge by free-text query. Use when finding products by name, category, or attributes. Do not use when they need account-specific orders, cart, or returns."
 }
 func (t *searchProductsTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"query":{"type":"string","description":"Free-text product query."},
-			"max_price":{"type":"number","description":"Optional upper bound on price."},
-			"limit":{"type":"integer","description":"Max results to return (cap 10)."}
+			"query":{"type":"string","description":"Free-text public catalog search query."},
+			"max_price":{"type":"number","description":"Optional upper bound in dollars, for example 150 for $150."},
+			"limit":{"type":"integer","description":"Maximum products to return; capped at 10."}
 		},
 		"required":["query"]
 	}`)
@@ -173,13 +175,13 @@ func NewCheckInventoryTool(api ecommerceAPI) Tool { return &checkInventoryTool{a
 
 func (t *checkInventoryTool) Name() string { return "check_inventory" }
 func (t *checkInventoryTool) Description() string {
-	return "Check whether a product is in stock. Returns stock count and a boolean."
+	return "Check public catalog inventory for one product. Use when the user asks whether a product is in stock. Do not use when they need cart reservations, orders, or account-specific state."
 }
 func (t *checkInventoryTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"product_id":{"type":"string"}
+			"product_id":{"type":"string","description":"Opaque public catalog product id to check."}
 		},
 		"required":["product_id"]
 	}`)

--- a/go/ai-service/internal/tools/composite/auth_boundary_test.go
+++ b/go/ai-service/internal/tools/composite/auth_boundary_test.go
@@ -1,0 +1,173 @@
+package composite
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+type recordingUserHistory struct {
+	seen []string
+}
+
+func (f *recordingUserHistory) Orders(ctx context.Context, userID string) ([]HistoricalItem, error) {
+	f.seen = append(f.seen, userID)
+	return nil, nil
+}
+
+func (f *recordingUserHistory) CartItems(ctx context.Context, userID string) ([]HistoricalItem, error) {
+	f.seen = append(f.seen, userID)
+	return nil, nil
+}
+
+func (f *recordingUserHistory) RecentlyViewed(ctx context.Context, userID string) ([]HistoricalItem, error) {
+	f.seen = append(f.seen, userID)
+	return nil, nil
+}
+
+func TestRecommendWithRationaleRejectsMissingAuthenticatedUser(t *testing.T) {
+	tool := NewRecommendWithRationaleTool(&recordingUserHistory{}, fakeNeighborSearch{})
+
+	_, err := tool.Call(context.Background(), []byte(`{"user_id":"customer-1"}`), "")
+	if err == nil {
+		t.Fatalf("expected missing authenticated user to be rejected")
+	}
+}
+
+func TestRecommendWithRationaleRejectsCrossUserIDArgument(t *testing.T) {
+	history := &recordingUserHistory{}
+	tool := NewRecommendWithRationaleTool(history, fakeNeighborSearch{})
+
+	_, err := tool.Call(context.Background(), []byte(`{"user_id":"other-customer"}`), "customer-1")
+	if err == nil {
+		t.Fatalf("expected mismatched user_id argument to be rejected")
+	}
+	if len(history.seen) > 0 {
+		t.Fatalf("history lookup should not run with user_id argument, saw %v", history.seen)
+	}
+}
+
+func TestRecommendWithRationaleUsesAuthenticatedUserForHistory(t *testing.T) {
+	history := &recordingUserHistory{}
+	tool := NewRecommendWithRationaleTool(history, fakeNeighborSearch{})
+
+	_, err := tool.Call(context.Background(), []byte(`{"user_id":"customer-1"}`), "customer-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"customer-1", "customer-1", "customer-1"}
+	if len(history.seen) != len(want) {
+		t.Fatalf("history lookups = %v, want %v", history.seen, want)
+	}
+	for i := range want {
+		if history.seen[i] != want[i] {
+			t.Fatalf("history lookups = %v, want %v", history.seen, want)
+		}
+	}
+}
+
+func TestInvestigateMyOrderRejectsMissingAuthenticatedUser(t *testing.T) {
+	tool := NewInvestigateMyOrderTool(authBoundaryFetcher(OrderRecord{
+		ID:     "ord-1",
+		Status: "completed",
+		UserID: "customer-1",
+	}))
+
+	_, err := tool.Call(context.Background(), []byte(`{"order_id":"ord-1"}`), "")
+	if err == nil {
+		t.Fatalf("expected missing authenticated user to be rejected")
+	}
+}
+
+func TestInvestigateMyOrderRejectsOwnerMismatch(t *testing.T) {
+	tool := NewInvestigateMyOrderTool(authBoundaryFetcher(OrderRecord{
+		ID:     "ord-1",
+		Status: "completed",
+		UserID: "other-customer",
+	}))
+
+	_, err := tool.Call(context.Background(), []byte(`{"order_id":"ord-1"}`), "customer-1")
+	if err == nil {
+		t.Fatalf("expected order owned by another user to be rejected")
+	}
+}
+
+func TestInvestigateMyOrderRejectsMissingOwnershipEvidence(t *testing.T) {
+	tool := NewInvestigateMyOrderTool(authBoundaryFetcher(OrderRecord{
+		ID:     "ord-1",
+		Status: "completed",
+		UserID: "",
+	}))
+
+	_, err := tool.Call(context.Background(), []byte(`{"order_id":"ord-1"}`), "customer-1")
+	if err == nil {
+		t.Fatalf("expected order without ownership evidence to be rejected")
+	}
+}
+
+func TestInvestigateMyOrderRejectsOwnerMismatchBeforeSecondaryEvidence(t *testing.T) {
+	secondary := &recordingSecondaryEvidence{}
+	tool := NewInvestigateMyOrderTool(EvidenceFetcher{
+		Order:   fakeOrderSource{data: OrderRecord{ID: "ord-1", Status: "completed", UserID: "other-customer", TraceID: "trace-1", CorrelationID: "corr-1"}},
+		Saga:    secondary,
+		Payment: secondary,
+		Cart:    secondary,
+		Rabbit:  secondary,
+		Trace:   secondary,
+		Logs:    secondary,
+	})
+
+	_, err := tool.Call(context.Background(), []byte(`{"order_id":"ord-1"}`), "customer-1")
+	if err == nil {
+		t.Fatalf("expected order owned by another user to be rejected")
+	}
+	if got := secondary.calls.Load(); got != 0 {
+		t.Fatalf("secondary evidence should not be fetched before owner check, got %d calls", got)
+	}
+}
+
+func authBoundaryFetcher(order OrderRecord) EvidenceFetcher {
+	return EvidenceFetcher{
+		Order:   fakeOrderSource{data: order},
+		Saga:    fakeSagaSource{data: SagaHistory{Step: "completed"}},
+		Payment: fakePaymentSource{data: PaymentRecord{StripeChargeID: "ch_1", WebhookReceived: true}},
+		Cart:    fakeCartSource{},
+		Rabbit:  fakeRabbitSource{},
+		Trace:   fakeTraceSource{},
+		Logs:    fakeLogSource{},
+	}
+}
+
+type recordingSecondaryEvidence struct {
+	calls atomic.Int32
+}
+
+func (r *recordingSecondaryEvidence) FetchSaga(ctx context.Context, id string) (SagaHistory, error) {
+	r.calls.Add(1)
+	return SagaHistory{}, nil
+}
+
+func (r *recordingSecondaryEvidence) FetchPayment(ctx context.Context, id string) (PaymentRecord, error) {
+	r.calls.Add(1)
+	return PaymentRecord{}, nil
+}
+
+func (r *recordingSecondaryEvidence) FetchCartReservation(ctx context.Context, id string) (CartReservation, error) {
+	r.calls.Add(1)
+	return CartReservation{}, nil
+}
+
+func (r *recordingSecondaryEvidence) FetchEvents(ctx context.Context, correlationID string) ([]RabbitEvent, error) {
+	r.calls.Add(1)
+	return nil, nil
+}
+
+func (r *recordingSecondaryEvidence) FetchTrace(ctx context.Context, traceID string) (TraceSummary, error) {
+	r.calls.Add(1)
+	return TraceSummary{}, nil
+}
+
+func (r *recordingSecondaryEvidence) FetchLogs(ctx context.Context, services []string, from, to int64) ([]string, error) {
+	r.calls.Add(1)
+	return nil, nil
+}

--- a/go/ai-service/internal/tools/composite/compare_products.go
+++ b/go/ai-service/internal/tools/composite/compare_products.go
@@ -80,14 +80,14 @@ func NewCompareProductsTool(c ProductCatalog, e EmbeddingSource) *compareProduct
 func (t *compareProductsTool) Name() string { return "compare_products" }
 
 func (t *compareProductsTool) Description() string {
-	return "Compares two or more products structurally and semantically. Returns shared and differing attributes, pairwise embedding similarity, and a short recommendation."
+	return "Compare two to five public catalog products structurally and semantically. Use when the user asks which product fits better. Do not use when they need account-specific orders, cart, or returns."
 }
 
 func (t *compareProductsTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"product_ids":{"type":"array","items":{"type":"string"},"minItems":2,"maxItems":5}
+			"product_ids":{"type":"array","description":"Two to five public catalog product ids to compare.","items":{"type":"string"},"minItems":2,"maxItems":5}
 		},
 		"required":["product_ids"]
 	}`)

--- a/go/ai-service/internal/tools/composite/investigate_order.go
+++ b/go/ai-service/internal/tools/composite/investigate_order.go
@@ -106,14 +106,14 @@ func (t *investigateMyOrderTool) Name() string {
 }
 
 func (t *investigateMyOrderTool) Description() string {
-	return "Investigates the full checkout saga for a given order, correlating order, payment, cart reservation, RabbitMQ events, trace, and logs into a structured verdict with a customer-facing message."
+	return "Investigate checkout evidence for the authenticated user's own order. Use when they ask what happened to their order. Do not use when acting for another user or inventing a user id would be needed."
 }
 
 func (t *investigateMyOrderTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
-			"order_id": { "type": "string", "description": "The order id to investigate." }
+			"order_id": { "type": "string", "description": "Order id from the authenticated user's own order history to investigate." }
 		},
 		"required": ["order_id"]
 	}`)
@@ -142,15 +142,32 @@ func (t *investigateMyOrderTool) Call(ctx context.Context, args json.RawMessage,
 		span.SetStatus(codes.Error, err.Error())
 		return tools.Result{}, err
 	}
-	// TODO(auth): verify order.UserID == userID once source adapters are wired (A5).
-	_ = userID
-	bundle, err := t.fetcher.Fetch(ctx, req.OrderID)
+	if userID == "" {
+		err := errors.New("investigate_my_order: authenticated user required")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return tools.Result{}, err
+	}
+	order, err := t.fetcher.Order.FetchOrder(ctx, req.OrderID)
 	if err != nil {
 		slog.WarnContext(ctx, "tool error", "tool", "investigate_my_order", "order_id", req.OrderID, "error", err.Error())
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return tools.Result{}, fmt.Errorf("investigate_my_order: %w", err)
 	}
+	if order.UserID == "" {
+		err := errors.New("investigate_my_order: order ownership unavailable")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return tools.Result{}, err
+	}
+	if order.UserID != userID {
+		err := errors.New("investigate_my_order: order does not belong to authenticated user")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return tools.Result{}, err
+	}
+	bundle := t.fetcher.fetchWithOrder(ctx, req.OrderID, order)
 	verdict := ComputeVerdict(bundle)
 	slog.InfoContext(ctx, "tool result", "tool", "investigate_my_order",
 		"order_id", req.OrderID,

--- a/go/ai-service/internal/tools/composite/investigate_order_evidence.go
+++ b/go/ai-service/internal/tools/composite/investigate_order_evidence.go
@@ -106,14 +106,15 @@ type EvidenceFetcher struct {
 // failure there returns a hard error. All other sources are best-effort
 // and contribute Partial=true on failure rather than aborting.
 func (f EvidenceFetcher) Fetch(ctx context.Context, orderID string) (EvidenceBundle, error) {
-	var bundle EvidenceBundle
-
 	order, err := f.Order.FetchOrder(ctx, orderID)
 	if err != nil {
-		return bundle, err
+		return EvidenceBundle{}, err
 	}
-	bundle.Order = order
+	return f.fetchWithOrder(ctx, orderID, order), nil
+}
 
+func (f EvidenceFetcher) fetchWithOrder(ctx context.Context, orderID string, order OrderRecord) EvidenceBundle {
+	bundle := EvidenceBundle{Order: order}
 	g, gctx := errgroup.WithContext(ctx)
 
 	var (
@@ -211,5 +212,5 @@ func (f EvidenceFetcher) Fetch(ctx context.Context, orderID string) (EvidenceBun
 	bundle.Logs = logs
 	bundle.Partial = partial
 	bundle.PartialReason = partialReasons
-	return bundle, nil
+	return bundle
 }

--- a/go/ai-service/internal/tools/composite/investigate_order_test.go
+++ b/go/ai-service/internal/tools/composite/investigate_order_test.go
@@ -82,7 +82,7 @@ func TestVerdictPartialEvidenceFlagged(t *testing.T) {
 
 func TestInvestigateMyOrderToolEndToEnd(t *testing.T) {
 	tool := NewInvestigateMyOrderTool(EvidenceFetcher{
-		Order:   fakeOrderSource{data: OrderRecord{ID: "ord1", Status: "completed", TraceID: "t1"}},
+		Order:   fakeOrderSource{data: OrderRecord{ID: "ord1", Status: "completed", UserID: "user-1", TraceID: "t1"}},
 		Saga:    fakeSagaSource{data: SagaHistory{Step: "completed"}},
 		Payment: fakePaymentSource{data: PaymentRecord{StripeChargeID: "ch", WebhookReceived: true}},
 		Cart:    fakeCartSource{},
@@ -93,7 +93,7 @@ func TestInvestigateMyOrderToolEndToEnd(t *testing.T) {
 	if tool.Name() != "investigate_my_order" {
 		t.Fatalf("name: %s", tool.Name())
 	}
-	result, err := tool.Call(context.Background(), []byte(`{"order_id":"ord1"}`), "")
+	result, err := tool.Call(context.Background(), []byte(`{"order_id":"ord1"}`), "user-1")
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}

--- a/go/ai-service/internal/tools/composite/recommend_rationale.go
+++ b/go/ai-service/internal/tools/composite/recommend_rationale.go
@@ -78,17 +78,15 @@ func NewRecommendWithRationaleTool(h UserHistory, n NeighborSearch) *recommendTo
 func (t *recommendTool) Name() string { return "recommend_with_rationale" }
 
 func (t *recommendTool) Description() string {
-	return "Recommends products for a user by averaging embeddings of past purchases, cart items, and recently viewed products. Returns each recommendation with a plain-English rationale and the surfaced signals."
+	return "Recommend products for the authenticated user with rationale from their purchases, cart, and views. Use when they ask for personalized product suggestions. Do not use when acting for another user or inventing a user id would be needed."
 }
 
 func (t *recommendTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"user_id":{"type":"string"},
-			"category":{"type":"string"}
-		},
-		"required":["user_id"]
+			"category":{"type":"string","description":"Optional public catalog category to filter personalized recommendations."}
+		}
 	}`)
 }
 
@@ -110,30 +108,35 @@ func (t *recommendTool) Call(ctx context.Context, args json.RawMessage, userID s
 		span.SetStatus(codes.Error, err.Error())
 		return tools.Result{}, fmt.Errorf("recommend_with_rationale: invalid args: %w", err)
 	}
-	if req.UserID == "" {
-		err := errors.New("recommend_with_rationale: user_id is required")
+	if userID == "" {
+		err := errors.New("recommend_with_rationale: authenticated user required")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return tools.Result{}, err
 	}
-	_ = userID // no per-user authorization beyond the explicit user_id arg in v1
+	if req.UserID != "" && req.UserID != userID {
+		err := errors.New("recommend_with_rationale: user_id must match authenticated user")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return tools.Result{}, err
+	}
 
-	orders, err := t.hist.Orders(ctx, req.UserID)
+	orders, err := t.hist.Orders(ctx, userID)
 	if err != nil {
 		slog.WarnContext(ctx, "recommend_with_rationale: orders fetch failed",
-			"tool", "recommend_with_rationale", "user_id", req.UserID, "error", err)
+			"tool", "recommend_with_rationale", "user_id", userID, "error", err)
 		orders = nil
 	}
-	cart, err := t.hist.CartItems(ctx, req.UserID)
+	cart, err := t.hist.CartItems(ctx, userID)
 	if err != nil {
 		slog.WarnContext(ctx, "recommend_with_rationale: cart fetch failed",
-			"tool", "recommend_with_rationale", "user_id", req.UserID, "error", err)
+			"tool", "recommend_with_rationale", "user_id", userID, "error", err)
 		cart = nil
 	}
-	views, err := t.hist.RecentlyViewed(ctx, req.UserID)
+	views, err := t.hist.RecentlyViewed(ctx, userID)
 	if err != nil {
 		slog.WarnContext(ctx, "recommend_with_rationale: views fetch failed",
-			"tool", "recommend_with_rationale", "user_id", req.UserID, "error", err)
+			"tool", "recommend_with_rationale", "user_id", userID, "error", err)
 		views = nil
 	}
 
@@ -144,14 +147,14 @@ func (t *recommendTool) Call(ctx context.Context, args json.RawMessage, userID s
 
 	if len(signals) == 0 {
 		result := RecommendResult{Products: nil, QueryEmbeddingSource: "no_history"}
-		t.logResult(ctx, req.UserID, result, start)
+		t.logResult(ctx, userID, result, start)
 		return tools.Result{Content: result}, nil
 	}
 
 	avg := averageEmbedding(signals)
 	if avg == nil {
 		result := RecommendResult{Products: nil, QueryEmbeddingSource: "no_embeddings"}
-		t.logResult(ctx, req.UserID, result, start)
+		t.logResult(ctx, userID, result, start)
 		return tools.Result{Content: result}, nil
 	}
 
@@ -191,7 +194,7 @@ func (t *recommendTool) Call(ctx context.Context, args json.RawMessage, userID s
 		Products:             recs,
 		QueryEmbeddingSource: "average_of_" + strconv.Itoa(len(embeddedSignals)) + "_signals",
 	}
-	t.logResult(ctx, req.UserID, result, start)
+	t.logResult(ctx, userID, result, start)
 	return tools.Result{Content: result}, nil
 }
 

--- a/go/ai-service/internal/tools/composite/recommend_rationale_test.go
+++ b/go/ai-service/internal/tools/composite/recommend_rationale_test.go
@@ -49,7 +49,7 @@ func TestRecommendRationaleProducesRationaleAndSignals(t *testing.T) {
 		{ProductID: "shoe-trail-2", Score: 0.92, Name: "Trail Shoe v2", Category: "footwear"},
 	}}
 	tool := NewRecommendWithRationaleTool(hist, neigh)
-	res, err := tool.Call(context.Background(), []byte(`{"user_id":"u1"}`), "u1")
+	res, err := tool.Call(context.Background(), []byte(`{"category":"footwear"}`), "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,17 +75,25 @@ func TestRecommendRationaleProducesRationaleAndSignals(t *testing.T) {
 	}
 }
 
-func TestRecommendRationaleRejectsMissingUser(t *testing.T) {
+func TestRecommendRationaleAcceptsOmittedUserID(t *testing.T) {
 	tool := NewRecommendWithRationaleTool(fakeUserHistory{}, fakeNeighborSearch{})
-	_, err := tool.Call(context.Background(), []byte(`{}`), "u1")
-	if err == nil {
-		t.Fatalf("expected error on missing user_id")
+	res, err := tool.Call(context.Background(), []byte(`{}`), "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _ := json.Marshal(res.Content)
+	var r RecommendResult
+	if err := json.Unmarshal(out, &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.QueryEmbeddingSource != "no_history" {
+		t.Fatalf("query_embedding_source: %s", r.QueryEmbeddingSource)
 	}
 }
 
 func TestRecommendRationaleNoHistoryReturnsEmptyResult(t *testing.T) {
 	tool := NewRecommendWithRationaleTool(fakeUserHistory{}, fakeNeighborSearch{})
-	res, err := tool.Call(context.Background(), []byte(`{"user_id":"u1"}`), "u1")
+	res, err := tool.Call(context.Background(), []byte(`{}`), "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +117,7 @@ func TestRecommendRationaleHistoryWithoutEmbeddingsFallsBack(t *testing.T) {
 		},
 	}
 	tool := NewRecommendWithRationaleTool(hist, fakeNeighborSearch{})
-	res, err := tool.Call(context.Background(), []byte(`{"user_id":"u1"}`), "u1")
+	res, err := tool.Call(context.Background(), []byte(`{}`), "u1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +142,7 @@ func TestRecommendRationalePropagatesNearestError(t *testing.T) {
 	}
 	neigh := fakeNeighborSearch{err: errors.New("qdrant down")}
 	tool := NewRecommendWithRationaleTool(hist, neigh)
-	_, err := tool.Call(context.Background(), []byte(`{"user_id":"u1"}`), "u1")
+	_, err := tool.Call(context.Background(), []byte(`{}`), "u1")
 	if err == nil {
 		t.Fatalf("expected error from Nearest to propagate")
 	}

--- a/go/ai-service/internal/tools/composite/schema_guidance_contract_test.go
+++ b/go/ai-service/internal/tools/composite/schema_guidance_contract_test.go
@@ -1,0 +1,147 @@
+package composite
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCompositeToolSchemasExposeDescribedObjectContracts(t *testing.T) {
+	tests := []struct {
+		name string
+		tool interface {
+			Description() string
+			Schema() json.RawMessage
+		}
+		required         []string
+		described        []string
+		arrayStringItems []string
+		authScoped       bool
+		requiresNoUser   bool
+	}{
+		{
+			name:             "compare_products",
+			tool:             NewCompareProductsTool(fakeProductCatalog{}, fakeEmbeddings{}),
+			required:         []string{"product_ids"},
+			described:        []string{"product_ids"},
+			arrayStringItems: []string{"product_ids"},
+		},
+		{
+			name:           "recommend_with_rationale",
+			tool:           NewRecommendWithRationaleTool(fakeUserHistory{}, fakeNeighborSearch{}),
+			described:      []string{"category"},
+			authScoped:     true,
+			requiresNoUser: true,
+		},
+		{
+			name:       "investigate_my_order",
+			tool:       NewInvestigateMyOrderTool(EvidenceFetcher{}),
+			required:   []string{"order_id"},
+			described:  []string{"order_id"},
+			authScoped: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := decodeCompositeSchema(t, tt.tool.Schema())
+			if got := schema["type"]; got != "object" {
+				t.Fatalf("schema type = %v, want object", got)
+			}
+			props := compositeSchemaProperties(t, schema)
+			if tt.authScoped {
+				if _, ok := props["user_id"]; ok {
+					t.Fatalf("authenticated-user tool must not advertise user_id")
+				}
+			}
+			if tt.requiresNoUser && compositeSchemaRequires(schema, "user_id") {
+				t.Fatalf("authenticated-user tool must not require user_id")
+			}
+			for _, field := range tt.required {
+				if !compositeSchemaRequires(schema, field) {
+					t.Fatalf("schema required fields missing %q", field)
+				}
+			}
+			for _, field := range tt.described {
+				prop, ok := props[field].(map[string]any)
+				if !ok {
+					t.Fatalf("schema properties missing %q", field)
+				}
+				desc, _ := prop["description"].(string)
+				if strings.TrimSpace(desc) == "" {
+					t.Fatalf("property %q must include a description", field)
+				}
+			}
+			for _, field := range tt.arrayStringItems {
+				prop, ok := props[field].(map[string]any)
+				if !ok {
+					t.Fatalf("schema properties missing %q", field)
+				}
+				items, ok := prop["items"].(map[string]any)
+				if !ok {
+					t.Fatalf("array property %q must include items schema", field)
+				}
+				if got := items["type"]; got != "string" {
+					t.Fatalf("array property %q items type = %v, want string", field, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCompositeToolDescriptionsIncludeUseAndDoNotUseGuidance(t *testing.T) {
+	tests := []struct {
+		name string
+		tool interface{ Description() string }
+	}{
+		{name: "compare_products", tool: NewCompareProductsTool(fakeProductCatalog{}, fakeEmbeddings{})},
+		{name: "recommend_with_rationale", tool: NewRecommendWithRationaleTool(fakeUserHistory{}, fakeNeighborSearch{})},
+		{name: "investigate_my_order", tool: NewInvestigateMyOrderTool(EvidenceFetcher{})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := strings.ToLower(tt.tool.Description())
+			if !strings.Contains(desc, "use when") {
+				t.Fatalf("description must include Use when guidance: %q", tt.tool.Description())
+			}
+			if !strings.Contains(desc, "do not use") {
+				t.Fatalf("description must include Do not use guidance: %q", tt.tool.Description())
+			}
+		})
+	}
+}
+
+func decodeCompositeSchema(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("schema is invalid JSON: %v", err)
+	}
+	if schema == nil {
+		t.Fatalf("schema must be a JSON object")
+	}
+	return schema
+}
+
+func compositeSchemaProperties(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	raw, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties must be an object")
+	}
+	return raw
+}
+
+func compositeSchemaRequires(schema map[string]any, field string) bool {
+	raw, ok := schema["required"].([]any)
+	if !ok {
+		return false
+	}
+	for _, v := range raw {
+		if v == field {
+			return true
+		}
+	}
+	return false
+}

--- a/go/ai-service/internal/tools/orders.go
+++ b/go/ai-service/internal/tools/orders.go
@@ -29,13 +29,13 @@ func NewListOrdersTool(api ordersAPI) Tool { return &listOrdersTool{api: api} }
 
 func (t *listOrdersTool) Name() string { return "list_orders" }
 func (t *listOrdersTool) Description() string {
-	return "List the current user's orders. Returns at most 20 most recent orders with id, status, total in cents, and creation date."
+	return "List recent orders for the authenticated user only. Use when they ask about their order history. Do not use when they need public catalog answers or another user id would be needed."
 }
 func (t *listOrdersTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"limit":{"type":"integer","description":"Max orders to return (cap 20)."}
+			"limit":{"type":"integer","description":"Maximum recent orders to return; capped at 20."}
 		}
 	}`)
 }
@@ -89,13 +89,13 @@ func NewGetOrderTool(api ordersAPI) Tool { return &getOrderTool{api: api} }
 
 func (t *getOrderTool) Name() string { return "get_order" }
 func (t *getOrderTool) Description() string {
-	return "Fetch one order by id for the current user. Returns id, status, total, and creation date."
+	return "Fetch one order for the authenticated user only. Use when they provide an order id for their own order. Do not use when they need public catalog answers or another user id would be needed."
 }
 func (t *getOrderTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"order_id":{"type":"string"}
+			"order_id":{"type":"string","description":"Order id from the authenticated user's own order history."}
 		},
 		"required":["order_id"]
 	}`)
@@ -161,13 +161,13 @@ func NewSummarizeOrdersToolWithRecorder(api ordersAPI, llmc llm.Client, rec tool
 
 func (t *summarizeOrdersTool) Name() string { return "summarize_orders" }
 func (t *summarizeOrdersTool) Description() string {
-	return "Summarize the current user's recent orders in plain English."
+	return "Summarize recent orders for the authenticated user only. Use when they ask for a plain-English overview of their orders. Do not use when they need public catalog answers or another user id would be needed."
 }
 func (t *summarizeOrdersTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"period":{"type":"string","enum":["week","month","all"]}
+			"period":{"type":"string","description":"Order summary window: week, month, or all recent orders.","enum":["week","month","all"]}
 		}
 	}`)
 }

--- a/go/ai-service/internal/tools/rag.go
+++ b/go/ai-service/internal/tools/rag.go
@@ -29,15 +29,15 @@ func NewSearchDocumentsTool(api ragAPI) Tool { return &searchDocumentsTool{api: 
 
 func (t *searchDocumentsTool) Name() string { return "search_documents" }
 func (t *searchDocumentsTool) Description() string {
-	return "Semantic search over ingested documents. Returns ranked chunks with source file and page. Optional collection name and limit (default 5, max 20)."
+	return "Search public ingested document knowledge and return ranked chunks with sources. Use when the user needs source snippets from documents. Do not use when they need account-specific orders, cart, or returns."
 }
 func (t *searchDocumentsTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"query":{"type":"string","description":"Free-text search query."},
-			"collection":{"type":"string","description":"Optional collection name to search within."},
-			"limit":{"type":"integer","description":"Max results to return (default 5, cap 20)."}
+			"query":{"type":"string","description":"Free-text question or keywords to search in public document knowledge."},
+			"collection":{"type":"string","description":"Optional document collection name to search within."},
+			"limit":{"type":"integer","description":"Maximum document chunks to return; defaults to 5 and caps at 20."}
 		},
 		"required":["query"]
 	}`)
@@ -100,14 +100,14 @@ func NewAskDocumentTool(api ragAPI) Tool { return &askDocumentTool{api: api} }
 
 func (t *askDocumentTool) Name() string { return "ask_document" }
 func (t *askDocumentTool) Description() string {
-	return "Ask a natural-language question against ingested documents. Returns a generated answer with source citations."
+	return "Answer a question from public ingested document knowledge with source citations. Use when the user wants a synthesized document answer. Do not use when they need account-specific orders, cart, or returns."
 }
 func (t *askDocumentTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"question":{"type":"string","description":"The question to answer using document context."},
-			"collection":{"type":"string","description":"Optional collection name to query within."}
+			"question":{"type":"string","description":"Natural-language question to answer using public document context."},
+			"collection":{"type":"string","description":"Optional document collection name to query within."}
 		},
 		"required":["question"]
 	}`)
@@ -162,7 +162,7 @@ func NewListCollectionsTool(api ragAPI) Tool { return &listCollectionsTool{api: 
 
 func (t *listCollectionsTool) Name() string { return "list_collections" }
 func (t *listCollectionsTool) Description() string {
-	return "List all document collections available in the vector store, with their document counts."
+	return "List public document collections available for RAG queries. Use when choosing a collection for document search or question answering. Do not use when they need account-specific orders, cart, or returns."
 }
 func (t *listCollectionsTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{}}`)

--- a/go/ai-service/internal/tools/returns.go
+++ b/go/ai-service/internal/tools/returns.go
@@ -22,15 +22,15 @@ func NewInitiateReturnTool(api returnsAPI) Tool { return &initiateReturnTool{api
 
 func (t *initiateReturnTool) Name() string { return "initiate_return" }
 func (t *initiateReturnTool) Description() string {
-	return "Initiate a return for specific items on one of the current user's orders. Requires the order id, a non-empty list of item ids, and a short reason."
+	return "Initiate a return for items on the authenticated user's own order. Use when they request a return with order id, item ids, and reason. Do not use when acting for another user or inventing a user id would be needed."
 }
 func (t *initiateReturnTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type":"object",
 		"properties":{
-			"order_id":{"type":"string"},
-			"item_ids":{"type":"array","items":{"type":"string"},"minItems":1},
-			"reason":{"type":"string"}
+			"order_id":{"type":"string","description":"Order id from the authenticated user's own order history."},
+			"item_ids":{"type":"array","description":"One or more item ids from that order to return.","items":{"type":"string"},"minItems":1},
+			"reason":{"type":"string","description":"Brief reason the authenticated user wants to return the items."}
 		},
 		"required":["order_id","item_ids","reason"]
 	}`)

--- a/go/ai-service/internal/tools/schema_guidance_contract_test.go
+++ b/go/ai-service/internal/tools/schema_guidance_contract_test.go
@@ -1,0 +1,201 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestToolSchemasExposeDescribedObjectContracts(t *testing.T) {
+	tests := []struct {
+		name             string
+		tool             Tool
+		required         []string
+		described        []string
+		arrayStringItems []string
+		authScoped       bool
+	}{
+		{
+			name:      "search_products",
+			tool:      NewSearchProductsTool(&fakeEcommerce{}),
+			required:  []string{"query"},
+			described: []string{"query", "limit"},
+		},
+		{
+			name:      "get_product",
+			tool:      NewGetProductTool(&fakeEcommerce{}),
+			required:  []string{"product_id"},
+			described: []string{"product_id"},
+		},
+		{
+			name:      "check_inventory",
+			tool:      NewCheckInventoryTool(&fakeEcommerce{}),
+			required:  []string{"product_id"},
+			described: []string{"product_id"},
+		},
+		{
+			name:       "list_orders",
+			tool:       NewListOrdersTool(&fakeOrdersAPI{}),
+			described:  []string{"limit"},
+			authScoped: true,
+		},
+		{
+			name:       "get_order",
+			tool:       NewGetOrderTool(&fakeOrdersAPI{}),
+			required:   []string{"order_id"},
+			described:  []string{"order_id"},
+			authScoped: true,
+		},
+		{
+			name:       "summarize_orders",
+			tool:       NewSummarizeOrdersTool(&fakeOrdersAPI{}, &summarizerLLM{}),
+			described:  []string{"period"},
+			authScoped: true,
+		},
+		{
+			name:       "view_cart",
+			tool:       NewViewCartTool(&fakeCartAPI{}),
+			authScoped: true,
+		},
+		{
+			name:       "add_to_cart",
+			tool:       NewAddToCartTool(&fakeCartAPI{}),
+			required:   []string{"product_id", "qty"},
+			described:  []string{"product_id", "qty"},
+			authScoped: true,
+		},
+		{
+			name:             "initiate_return",
+			tool:             NewInitiateReturnTool(&fakeReturnsAPI{}),
+			required:         []string{"order_id", "item_ids", "reason"},
+			described:        []string{"order_id", "item_ids", "reason"},
+			arrayStringItems: []string{"item_ids"},
+			authScoped:       true,
+		},
+		{
+			name:      "search_documents",
+			tool:      NewSearchDocumentsTool(&fakeRAG{}),
+			required:  []string{"query"},
+			described: []string{"query", "collection", "limit"},
+		},
+		{
+			name:      "ask_document",
+			tool:      NewAskDocumentTool(&fakeRAG{}),
+			required:  []string{"question"},
+			described: []string{"question", "collection"},
+		},
+		{
+			name: "list_collections",
+			tool: NewListCollectionsTool(&fakeRAG{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := decodeToolSchema(t, tt.tool.Schema())
+			if got := schema["type"]; got != "object" {
+				t.Fatalf("schema type = %v, want object", got)
+			}
+			props := schemaProperties(t, schema)
+			if tt.authScoped {
+				if _, ok := props["user_id"]; ok {
+					t.Fatalf("authenticated-user tool must not advertise user_id")
+				}
+			}
+			for _, field := range tt.required {
+				if !schemaRequires(schema, field) {
+					t.Fatalf("schema required fields missing %q", field)
+				}
+			}
+			for _, field := range tt.described {
+				prop, ok := props[field].(map[string]any)
+				if !ok {
+					t.Fatalf("schema properties missing %q", field)
+				}
+				desc, _ := prop["description"].(string)
+				if strings.TrimSpace(desc) == "" {
+					t.Fatalf("property %q must include a description", field)
+				}
+			}
+			for _, field := range tt.arrayStringItems {
+				prop, ok := props[field].(map[string]any)
+				if !ok {
+					t.Fatalf("schema properties missing %q", field)
+				}
+				items, ok := prop["items"].(map[string]any)
+				if !ok {
+					t.Fatalf("array property %q must include items schema", field)
+				}
+				if got := items["type"]; got != "string" {
+					t.Fatalf("array property %q items type = %v, want string", field, got)
+				}
+			}
+		})
+	}
+}
+
+func TestToolDescriptionsIncludeUseAndDoNotUseGuidance(t *testing.T) {
+	tests := []struct {
+		name string
+		tool Tool
+	}{
+		{name: "search_products", tool: NewSearchProductsTool(&fakeEcommerce{})},
+		{name: "get_product", tool: NewGetProductTool(&fakeEcommerce{})},
+		{name: "check_inventory", tool: NewCheckInventoryTool(&fakeEcommerce{})},
+		{name: "list_orders", tool: NewListOrdersTool(&fakeOrdersAPI{})},
+		{name: "get_order", tool: NewGetOrderTool(&fakeOrdersAPI{})},
+		{name: "summarize_orders", tool: NewSummarizeOrdersTool(&fakeOrdersAPI{}, &summarizerLLM{})},
+		{name: "view_cart", tool: NewViewCartTool(&fakeCartAPI{})},
+		{name: "add_to_cart", tool: NewAddToCartTool(&fakeCartAPI{})},
+		{name: "initiate_return", tool: NewInitiateReturnTool(&fakeReturnsAPI{})},
+		{name: "search_documents", tool: NewSearchDocumentsTool(&fakeRAG{})},
+		{name: "ask_document", tool: NewAskDocumentTool(&fakeRAG{})},
+		{name: "list_collections", tool: NewListCollectionsTool(&fakeRAG{})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := strings.ToLower(tt.tool.Description())
+			if !strings.Contains(desc, "use when") {
+				t.Fatalf("description must include Use when guidance: %q", tt.tool.Description())
+			}
+			if !strings.Contains(desc, "do not use") {
+				t.Fatalf("description must include Do not use guidance: %q", tt.tool.Description())
+			}
+		})
+	}
+}
+
+func decodeToolSchema(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("schema is invalid JSON: %v", err)
+	}
+	if schema == nil {
+		t.Fatalf("schema must be a JSON object")
+	}
+	return schema
+}
+
+func schemaProperties(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	raw, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema properties must be an object")
+	}
+	return raw
+}
+
+func schemaRequires(schema map[string]any, field string) bool {
+	raw, ok := schema["required"].([]any)
+	if !ok {
+		return false
+	}
+	for _, v := range raw {
+		if v == field {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Clarifies AI tool descriptions with use/do-not-use guidance and public vs authenticated-user scope.
- Adds focused schema contract tests for required fields, property descriptions, array item schemas, and hidden user boundaries.
- Enforces authenticated-user boundaries for personalized recommendations and order investigation, including ownership-before-evidence fan-out.

## Test Plan
- make preflight-go
- go test ./internal/tools/...
- go test -count=1 ./internal/tools ./internal/tools/composite