### PR TITLE
Add Observability MCP management actions

### DIFF
--- a/docs/superpowers/plans/2026-05-20-observability-mcp-management-actions.md
+++ b/docs/superpowers/plans/2026-05-20-observability-mcp-management-actions.md
@@ -1,0 +1,1296 @@
+# Observability MCP Management Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in, cataloged management actions to the Observability MCP so agents can run low-risk committed ops procedures autonomously without free-form mutation.
+
+**Architecture:** Add a new `internal/management` package for catalog, policy, runner, service, and result types. Extend existing config and SQLite history so management action previews/executions are policy-gated, bounded, redacted, and optionally attached to incident timelines. Register four MCP tools that delegate to the management service instead of exposing shell or Kubernetes primitives.
+
+**Tech Stack:** Go, `github.com/modelcontextprotocol/go-sdk/mcp`, `modernc.org/sqlite`, stdlib `os/exec`, existing `config`, `history`, and `mcpserver` packages.
+
+---
+
+## File Structure
+
+- Create `go/observability-mcp-service/internal/management/types.go`: risk tiers, decisions, statuses, action metadata, request/result types.
+- Create `go/observability-mcp-service/internal/management/catalog.go`: built-in catalog and validation.
+- Create `go/observability-mcp-service/internal/management/policy.go`: config-driven allow/block/preview policy.
+- Create `go/observability-mcp-service/internal/management/redact.go`: bounded output and redaction helpers.
+- Create `go/observability-mcp-service/internal/management/runner.go`: fixed-path script runner.
+- Create `go/observability-mcp-service/internal/management/service.go`: list, preview, execute, and history orchestration.
+- Create tests beside each new file in `internal/management`.
+- Modify `go/observability-mcp-service/internal/config/config.go` and `config_test.go`: management env config.
+- Modify `go/observability-mcp-service/internal/history/types.go`, `sqlite.go`, and `sqlite_test.go`: management action event persistence and query.
+- Modify `go/observability-mcp-service/internal/mcpserver/server.go` and `server_test.go`: register and handle management tools.
+- Modify `go/observability-mcp-service/cmd/observability-mcp/main.go` and `main_test.go`: wire management service from repo root and config.
+- Modify `go/observability-mcp-service/README.md`: document opt-in management model.
+
+## Task 1: Management Config
+
+**Files:**
+- Modify: `go/observability-mcp-service/internal/config/config.go`
+- Modify: `go/observability-mcp-service/internal/config/config_test.go`
+
+- [ ] **Step 1: Write failing config tests**
+
+Add these tests to `config_test.go`:
+
+```go
+func TestFromEnvManagementDefaults(t *testing.T) {
+	clearEnv(t)
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if cfg.ManagementActionsEnabled {
+		t.Fatal("expected management actions disabled by default")
+	}
+	if cfg.ManagementAllowHighRisk {
+		t.Fatal("expected high-risk management actions disabled by default")
+	}
+	if cfg.ManagementActionTimeout != 45*time.Minute {
+		t.Fatalf("ManagementActionTimeout = %s, want 45m", cfg.ManagementActionTimeout)
+	}
+	if cfg.ManagementMaxOutputBytes != 32768 {
+		t.Fatalf("ManagementMaxOutputBytes = %d, want 32768", cfg.ManagementMaxOutputBytes)
+	}
+}
+
+func TestFromEnvManagementOverrides(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "true")
+	t.Setenv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", "true")
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "45s")
+	t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "4096")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if !cfg.ManagementActionsEnabled || !cfg.ManagementAllowHighRisk {
+		t.Fatalf("management bool overrides not applied: %+v", cfg)
+	}
+	if cfg.ManagementActionTimeout != 45*time.Second {
+		t.Fatalf("ManagementActionTimeout = %s", cfg.ManagementActionTimeout)
+	}
+	if cfg.ManagementMaxOutputBytes != 4096 {
+		t.Fatalf("ManagementMaxOutputBytes = %d", cfg.ManagementMaxOutputBytes)
+	}
+}
+
+func TestFromEnvRejectsInvalidManagementConfig(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "0s")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("expected non-positive management timeout error")
+	}
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "0")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("expected non-positive management output cap error")
+	}
+}
+```
+
+Also add these lines to `clearEnv(t)`:
+
+```go
+t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "")
+t.Setenv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", "")
+t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "")
+t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "")
+```
+
+- [ ] **Step 2: Run config tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/config -run 'Management|Defaults|Overrides|Invalid' -v
+```
+
+Expected: FAIL with missing `Config` fields such as `ManagementActionsEnabled`.
+
+- [ ] **Step 3: Implement config fields and env parsing**
+
+In `config.go`, add fields to `Config`:
+
+```go
+ManagementActionsEnabled bool
+ManagementAllowHighRisk  bool
+ManagementActionTimeout  time.Duration
+ManagementMaxOutputBytes int
+```
+
+In `FromEnv()`, parse values:
+
+```go
+managementActionsEnabled, err := boolEnv("OBS_MANAGEMENT_ACTIONS_ENABLED", false)
+if err != nil {
+	return Config{}, err
+}
+managementAllowHighRisk, err := boolEnv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", false)
+if err != nil {
+	return Config{}, err
+}
+managementActionTimeout, err := durationEnv("OBS_MANAGEMENT_ACTION_TIMEOUT", 45*time.Minute)
+if err != nil {
+	return Config{}, err
+}
+managementMaxOutputBytes, err := intEnv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", 32768)
+if err != nil {
+	return Config{}, err
+}
+```
+
+Set them in the `Config` literal and validate:
+
+```go
+if cfg.ManagementActionTimeout <= 0 {
+	return Config{}, fmt.Errorf("OBS_MANAGEMENT_ACTION_TIMEOUT must be positive")
+}
+if cfg.ManagementMaxOutputBytes <= 0 {
+	return Config{}, fmt.Errorf("OBS_MANAGEMENT_MAX_OUTPUT_BYTES must be positive")
+}
+```
+
+- [ ] **Step 4: Run config tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/config -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/config/config.go go/observability-mcp-service/internal/config/config_test.go
+git commit -m "feat(observability): add management action config"
+```
+
+## Task 2: Catalog And Policy
+
+**Files:**
+- Create: `go/observability-mcp-service/internal/management/types.go`
+- Create: `go/observability-mcp-service/internal/management/catalog.go`
+- Create: `go/observability-mcp-service/internal/management/policy.go`
+- Test: `go/observability-mcp-service/internal/management/catalog_test.go`
+- Test: `go/observability-mcp-service/internal/management/policy_test.go`
+
+- [ ] **Step 1: Write failing catalog tests**
+
+Create `catalog_test.go`:
+
+```go
+package management
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDefaultCatalogContainsInitialActions(t *testing.T) {
+	catalog := DefaultCatalog()
+	for _, id := range []string{"reload_grafana_alerting", "run_postgres_backup_verify"} {
+		action, ok := catalog.Get(id)
+		if !ok {
+			t.Fatalf("missing action %q", id)
+		}
+		if action.RiskTier != RiskLowRiskMutation {
+			t.Fatalf("%s risk = %q", id, action.RiskTier)
+		}
+		if action.ScriptPath == "" || filepath.IsAbs(action.ScriptPath) {
+			t.Fatalf("%s script path = %q", id, action.ScriptPath)
+		}
+		if action.Timeout <= 0 || action.Timeout > 45*time.Minute {
+			t.Fatalf("%s timeout = %s", id, action.Timeout)
+		}
+	}
+}
+
+func TestDefaultCatalogScriptsExist(t *testing.T) {
+	catalog := DefaultCatalog()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	if err := catalog.ValidateScripts(repoRoot); err != nil {
+		t.Fatalf("ValidateScripts() error = %v", err)
+	}
+}
+
+func TestCatalogValidationRejectsBadEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []Action
+	}{
+		{name: "duplicate id", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second}, {ID: "a", Title: "B", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/b.sh", Timeout: time.Second}}},
+		{name: "absolute path", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "/tmp/a.sh", Timeout: time.Second}}},
+		{name: "path traversal", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "../a.sh", Timeout: time.Second}}},
+		{name: "invalid risk", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskTier("surprise"), ScriptPath: "scripts/ops/a.sh", Timeout: time.Second}}},
+		{name: "no timeout", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/a.sh"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewCatalog(tc.actions); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateScriptsRejectsMissingScript(t *testing.T) {
+	catalog, err := NewCatalog([]Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/missing.sh", Timeout: time.Second}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.ValidateScripts(t.TempDir()); err == nil {
+		t.Fatal("expected missing script error")
+	}
+}
+```
+
+- [ ] **Step 2: Write failing policy tests**
+
+Create `policy_test.go`:
+
+```go
+package management
+
+import "testing"
+
+func TestPolicyDecisions(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy Policy
+		risk   RiskTier
+		want   Decision
+	}{
+		{name: "disabled diagnostic blocked", policy: Policy{}, risk: RiskDiagnostic, want: DecisionBlock},
+		{name: "disabled low risk blocked", policy: Policy{}, risk: RiskLowRiskMutation, want: DecisionBlock},
+		{name: "enabled diagnostic allowed", policy: Policy{ActionsEnabled: true}, risk: RiskDiagnostic, want: DecisionAllow},
+		{name: "enabled low risk allowed", policy: Policy{ActionsEnabled: true}, risk: RiskLowRiskMutation, want: DecisionAllow},
+		{name: "high risk preview", policy: Policy{ActionsEnabled: true}, risk: RiskHighRiskMutation, want: DecisionPreviewOnly},
+		{name: "high risk enabled", policy: Policy{ActionsEnabled: true, AllowHighRisk: true}, risk: RiskHighRiskMutation, want: DecisionAllow},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.policy.Evaluate(Action{ID: "a", RiskTier: tc.risk})
+			if got.Decision != tc.want {
+				t.Fatalf("Decision = %q, want %q; reason=%s", got.Decision, tc.want, got.Reason)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/management -v
+```
+
+Expected: FAIL because the package and symbols do not exist.
+
+- [ ] **Step 4: Implement types, catalog, and policy**
+
+Create `types.go` with:
+
+```go
+package management
+
+import "time"
+
+type RiskTier string
+type Decision string
+type Status string
+
+const (
+	RiskDiagnostic       RiskTier = "diagnostic"
+	RiskLowRiskMutation RiskTier = "low_risk_mutation"
+	RiskHighRiskMutation RiskTier = "high_risk_mutation"
+
+	DecisionAllow       Decision = "allow"
+	DecisionBlock       Decision = "block"
+	DecisionPreviewOnly Decision = "preview_only"
+
+	StatusPreviewed Status = "previewed"
+	StatusBlocked   Status = "blocked"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusTimedOut  Status = "timed_out"
+)
+
+type Action struct {
+	ID               string        `json:"id"`
+	Title            string        `json:"title"`
+	Description      string        `json:"description"`
+	RiskTier         RiskTier      `json:"risk_tier"`
+	ScriptPath       string        `json:"script_path"`
+	AllowedArgs      []Argument    `json:"allowed_args,omitempty"`
+	Timeout          time.Duration `json:"-"`
+	TimeoutText      string        `json:"timeout"`
+	RequiresIncident bool          `json:"requires_incident"`
+	Idempotent        bool          `json:"idempotent"`
+	Preflight        string        `json:"preflight"`
+	Postflight       string        `json:"postflight"`
+	RedactPatterns   []string      `json:"-"`
+	NextSteps        string        `json:"next_steps"`
+}
+
+type Argument struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+type PolicyDecision struct {
+	Decision Decision `json:"decision"`
+	Reason   string   `json:"reason"`
+}
+```
+
+Create `catalog.go` with `NewCatalog`, `Get`, `List`, `ValidateScripts(repoRoot string) error`, `DefaultCatalog`, and validation matching the tests. `ValidateScripts` must reject missing scripts and paths that escape `repoRoot`. `DefaultCatalog()` must include only:
+
+```go
+Action{
+	ID: "reload_grafana_alerting",
+	Title: "Reload Grafana alerting",
+	Description: "Restart Grafana so committed alerting provisioning is loaded and verified.",
+	RiskTier: RiskLowRiskMutation,
+	ScriptPath: "scripts/ops/2026-05-09-reload-grafana-alerting.sh",
+	Timeout: 2 * time.Minute,
+	TimeoutText: "2m0s",
+	Idempotent: true,
+	Preflight: "Script verifies the expected Grafana alerting ConfigMap content before restart.",
+	Postflight: "Script waits for rollout and verifies live Grafana alert expression and active alert count.",
+	NextSteps: "Inspect script output and rerun system health evidence if the action fails.",
+}
+```
+
+and:
+
+```go
+Action{
+	ID: "run_postgres_backup_verify",
+	Title: "Run Postgres backup verification",
+	Description: "Create a manual Job from the committed Postgres backup verification CronJob and wait for completion.",
+	RiskTier: RiskLowRiskMutation,
+	ScriptPath: "scripts/ops/2026-05-15-run-postgres-backup-verify.sh",
+	Timeout: 40 * time.Minute,
+	TimeoutText: "40m0s",
+	Idempotent: true,
+	Preflight: "Script creates a timestamped Job from the existing CronJob.",
+	Postflight: "Script waits for completion and prints bounded pod logs.",
+	NextSteps: "Review Job logs and investigate backup-verification alerts if the action fails.",
+}
+```
+
+Create `policy.go`:
+
+```go
+package management
+
+type Policy struct {
+	ActionsEnabled bool
+	AllowHighRisk  bool
+}
+
+func (p Policy) Evaluate(action Action) PolicyDecision {
+	if !p.ActionsEnabled {
+		return PolicyDecision{Decision: DecisionBlock, Reason: "management actions are disabled; set OBS_MANAGEMENT_ACTIONS_ENABLED=true"}
+	}
+	if action.RiskTier == RiskHighRiskMutation && !p.AllowHighRisk {
+		return PolicyDecision{Decision: DecisionPreviewOnly, Reason: "high-risk management actions require OBS_MANAGEMENT_ALLOW_HIGH_RISK=true"}
+	}
+	return PolicyDecision{Decision: DecisionAllow, Reason: "action is allowed by management policy"}
+}
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/management -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/management
+git commit -m "feat(observability): add management action catalog"
+```
+
+## Task 3: Runner And Redaction
+
+**Files:**
+- Create: `go/observability-mcp-service/internal/management/redact.go`
+- Create: `go/observability-mcp-service/internal/management/runner.go`
+- Test: `go/observability-mcp-service/internal/management/runner_test.go`
+
+- [ ] **Step 1: Write failing runner tests**
+
+Create `runner_test.go`:
+
+```go
+package management
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunnerExecutesCatalogScriptAndBoundsOutput(t *testing.T) {
+	repo := t.TempDir()
+	script := filepath.Join(repo, "scripts/ops/test.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env bash\nprintf 'abcdef'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := Runner{RepoRoot: repo, MaxOutputBytes: 4, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "test", ScriptPath: "scripts/ops/test.sh", Timeout: time.Second})
+	if result.Status != StatusSucceeded {
+		t.Fatalf("status = %q stderr=%q", result.Status, result.Stderr)
+	}
+	if result.Stdout != "abcd" || !result.OutputTruncated {
+		t.Fatalf("stdout=%q truncated=%t", result.Stdout, result.OutputTruncated)
+	}
+}
+
+func TestRunnerRejectsUnsafeScriptPath(t *testing.T) {
+	runner := Runner{RepoRoot: t.TempDir(), MaxOutputBytes: 1024, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "bad", ScriptPath: "../bad.sh", Timeout: time.Second})
+	if result.Status != StatusFailed || !strings.Contains(result.Stderr, "unsafe script path") {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestRunnerRedactsSecretLookingOutput(t *testing.T) {
+	repo := t.TempDir()
+	script := filepath.Join(repo, "scripts/ops/secret.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env bash\necho 'token=super-secret-value'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := Runner{RepoRoot: repo, MaxOutputBytes: 1024, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "secret", ScriptPath: "scripts/ops/secret.sh", Timeout: time.Second})
+	if strings.Contains(result.Stdout, "super-secret-value") {
+		t.Fatalf("secret was not redacted: %q", result.Stdout)
+	}
+	if result.RedactionsApplied == 0 {
+		t.Fatalf("expected redaction count, got %+v", result)
+	}
+}
+
+func TestRunnerTimesOut(t *testing.T) {
+	repo := t.TempDir()
+	script := filepath.Join(repo, "scripts/ops/slow.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env bash\nsleep 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := Runner{RepoRoot: repo, MaxOutputBytes: 1024, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "slow", ScriptPath: "scripts/ops/slow.sh", Timeout: 10 * time.Millisecond})
+	if result.Status != StatusTimedOut {
+		t.Fatalf("status = %q, want timed_out", result.Status)
+	}
+}
+```
+
+- [ ] **Step 2: Run runner tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/management -run Runner -v
+```
+
+Expected: FAIL because `Runner` and result fields do not exist.
+
+- [ ] **Step 3: Implement runner result and redaction**
+
+Add to `types.go`:
+
+```go
+type ActionResult struct {
+	ActionID          string         `json:"action_id"`
+	RiskTier          RiskTier       `json:"risk_tier"`
+	Decision          Decision       `json:"decision"`
+	Status            Status         `json:"status"`
+	ScriptPath        string         `json:"script_path"`
+	IncidentKey       string         `json:"incident_key,omitempty"`
+	StartedAt         time.Time      `json:"started_at,omitempty"`
+	CompletedAt       time.Time      `json:"completed_at,omitempty"`
+	DurationMillis    int64          `json:"duration_ms,omitempty"`
+	ExitCode          int            `json:"exit_code,omitempty"`
+	Stdout            string         `json:"stdout,omitempty"`
+	Stderr            string         `json:"stderr,omitempty"`
+	OutputTruncated   bool           `json:"output_truncated,omitempty"`
+	RedactionsApplied int            `json:"redactions_applied,omitempty"`
+	PolicyReason      string         `json:"policy_reason,omitempty"`
+	HistoryEventIDs   []int64        `json:"history_event_ids,omitempty"`
+	Warning           string         `json:"warning,omitempty"`
+}
+```
+
+Create `redact.go` with `boundOutput` and `redactOutput`. Use regexes for `(?i)(token|secret|password|authorization)=...` and `(?i)bearer\\s+...`; replace values with `[REDACTED]` and return a count.
+
+Create `runner.go` with:
+
+```go
+type Runner struct {
+	RepoRoot       string
+	MaxOutputBytes int
+	MaxTimeout     time.Duration
+}
+
+func (r Runner) Run(ctx context.Context, action Action) ActionResult
+```
+
+Implementation details:
+- Clean and join `RepoRoot` plus `action.ScriptPath`.
+- Reject absolute paths, `..`, and paths that escape `RepoRoot`.
+- Use `exec.CommandContext(ctxWithTimeout, "bash", fullPath)`.
+- Use `action.Timeout` unless `MaxTimeout` is set and lower; the lower timeout is the effective context deadline.
+- Set `cmd.Dir = r.RepoRoot`.
+- Capture stdout/stderr with `bytes.Buffer`.
+- Map success to `StatusSucceeded`, context deadline to `StatusTimedOut`, and nonzero exit to `StatusFailed`.
+- Always bound and redact output.
+
+- [ ] **Step 4: Run runner tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/management -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/management
+git commit -m "feat(observability): add management action runner"
+```
+
+## Task 4: History Persistence
+
+**Files:**
+- Modify: `go/observability-mcp-service/internal/history/types.go`
+- Modify: `go/observability-mcp-service/internal/history/sqlite.go`
+- Modify: `go/observability-mcp-service/internal/history/sqlite_test.go`
+
+- [ ] **Step 1: Write failing history tests**
+
+Add to `sqlite_test.go`:
+
+```go
+func TestRecordManagementActionCreatesIncidentTimeline(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	event, err := db.RecordManagementAction(ctx, ManagementActionInput{
+		IncidentKey:   "grafana-alerting",
+		IncidentTitle: "Grafana alerting reload",
+		ActionID:      "reload_grafana_alerting",
+		RiskTier:      "low_risk_mutation",
+		Decision:      "allow",
+		Status:        "succeeded",
+		Summary:       "reload_grafana_alerting succeeded",
+		DetailsJSON:   []byte(`{"status":"succeeded"}`),
+	})
+	if err != nil {
+		t.Fatalf("RecordManagementAction() error = %v", err)
+	}
+	if event.ID == 0 || event.Type != EventManagementActionCompleted {
+		t.Fatalf("event = %+v", event)
+	}
+	history, err := db.GetIncidentHistory(ctx, "grafana-alerting")
+	if err != nil {
+		t.Fatalf("GetIncidentHistory() error = %v", err)
+	}
+	if len(history.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(history.Events))
+	}
+	if history.Events[0].Details != `{"status":"succeeded"}` {
+		t.Fatalf("details = %q", history.Events[0].Details)
+	}
+}
+
+func TestRecordManagementActionRequiresTitleForNewIncident(t *testing.T) {
+	db := openTestDB(t)
+	_, err := db.RecordManagementAction(context.Background(), ManagementActionInput{
+		IncidentKey: "missing-title",
+		ActionID:    "reload_grafana_alerting",
+		RiskTier:    "low_risk_mutation",
+		Decision:    "allow",
+		Status:      "succeeded",
+		Summary:     "reload_grafana_alerting succeeded",
+	})
+	if err == nil {
+		t.Fatal("expected missing title error")
+	}
+}
+
+func TestListManagementActionsFilters(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	_, _ = db.RecordManagementAction(ctx, ManagementActionInput{IncidentKey: "one", IncidentTitle: "One", ActionID: "reload_grafana_alerting", RiskTier: "low_risk_mutation", Decision: "allow", Status: "succeeded", Summary: "one"})
+	_, _ = db.RecordManagementAction(ctx, ManagementActionInput{IncidentKey: "two", IncidentTitle: "Two", ActionID: "run_postgres_backup_verify", RiskTier: "low_risk_mutation", Decision: "block", Status: "blocked", Summary: "two"})
+	events, err := db.ListManagementActions(ctx, ManagementActionFilter{ActionID: "reload_grafana_alerting", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListManagementActions() error = %v", err)
+	}
+	if len(events) != 1 || events[0].Summary != "one" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+```
+
+- [ ] **Step 2: Run history tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/history -run Management -v
+```
+
+Expected: FAIL because management history types and methods do not exist.
+
+- [ ] **Step 3: Implement history types and methods**
+
+In `types.go`, add event constants:
+
+```go
+EventManagementActionPreviewed = "management_action_previewed"
+EventManagementActionStarted   = "management_action_started"
+EventManagementActionCompleted = "management_action_completed"
+EventManagementActionFailed    = "management_action_failed"
+EventManagementActionBlocked   = "management_action_blocked"
+```
+
+Add:
+
+```go
+type ManagementActionInput struct {
+	IncidentKey   string
+	IncidentTitle string
+	Severity      string
+	Service       string
+	ActionID      string
+	RiskTier      string
+	Decision      string
+	Status        string
+	Summary       string
+	DetailsJSON   []byte
+}
+
+type ManagementActionFilter struct {
+	IncidentKey string
+	ActionID    string
+	Status      string
+	Decision    string
+	Limit       int
+}
+```
+
+Extend `Store` with:
+
+```go
+RecordManagementAction(context.Context, ManagementActionInput) (Event, error)
+ListManagementActions(context.Context, ManagementActionFilter) ([]Event, error)
+```
+
+In `sqlite.go`, implement `RecordManagementAction` by reusing `upsertIncident` and `insertTimelineEvent`. Choose event type from status:
+- `previewed` -> `EventManagementActionPreviewed`
+- `blocked` -> `EventManagementActionBlocked`
+- `succeeded` -> `EventManagementActionCompleted`
+- `failed` or `timed_out` -> `EventManagementActionFailed`
+- default -> `EventManagementActionStarted`
+
+Implement `ListManagementActions` by joining `timeline_events` to `incidents`, filtering event types to the five management action constants, and filtering JSON details with `LIKE` for `"action_id":"<id>"`, `"status":"<status>"`, and `"decision":"<decision>"`.
+
+- [ ] **Step 4: Update fake history stores**
+
+Update fake stores in `internal/workflows/service_test.go` and any compiler errors with no-op methods:
+
+```go
+func (f *fakeHistoryStore) RecordManagementAction(context.Context, history.ManagementActionInput) (history.Event, error) {
+	return history.Event{ID: 1}, f.err
+}
+
+func (f *fakeHistoryStore) ListManagementActions(context.Context, history.ManagementActionFilter) ([]history.Event, error) {
+	return []history.Event{}, f.err
+}
+```
+
+- [ ] **Step 5: Run history tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/history ./internal/workflows -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/history go/observability-mcp-service/internal/workflows/service_test.go
+git commit -m "feat(observability): persist management action history"
+```
+
+## Task 5: Management Service
+
+**Files:**
+- Create: `go/observability-mcp-service/internal/management/service.go`
+- Test: `go/observability-mcp-service/internal/management/service_test.go`
+
+- [ ] **Step 1: Write failing service tests**
+
+Create `service_test.go`:
+
+```go
+package management
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+)
+
+type fakeRunner struct{ result ActionResult }
+
+func (f fakeRunner) Run(context.Context, Action) ActionResult { return f.result }
+
+type fakeStore struct {
+	inputs []history.ManagementActionInput
+	events []history.Event
+}
+
+func (f *fakeStore) RecordManagementAction(_ context.Context, in history.ManagementActionInput) (history.Event, error) {
+	f.inputs = append(f.inputs, in)
+	return history.Event{ID: int64(len(f.inputs)), Type: history.EventManagementActionCompleted, Summary: in.Summary}, nil
+}
+
+func (f *fakeStore) ListManagementActions(context.Context, history.ManagementActionFilter) ([]history.Event, error) {
+	return f.events, nil
+}
+
+func TestServicePreviewBlocksDisabledPolicy(t *testing.T) {
+	catalog := mustCatalog(t, []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskLowRiskMutation, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second, TimeoutText: "1s"}})
+	service := NewService(catalog, Policy{}, fakeRunner{}, nil)
+	result := service.Preview(context.Background(), ActionRequest{ActionID: "a"})
+	if result.Status != StatusBlocked || result.Decision != DecisionBlock {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestServiceExecuteRunsAllowedActionAndRecordsHistory(t *testing.T) {
+	catalog := mustCatalog(t, []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskLowRiskMutation, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second, TimeoutText: "1s"}})
+	store := &fakeStore{}
+	service := NewService(catalog, Policy{ActionsEnabled: true}, fakeRunner{result: ActionResult{Status: StatusSucceeded, Stdout: "ok"}}, store)
+	result := service.Execute(context.Background(), ActionRequest{ActionID: "a", IncidentKey: "inc", IncidentTitle: "Incident"})
+	if result.Status != StatusSucceeded || result.Decision != DecisionAllow {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(store.inputs) != 1 || store.inputs[0].ActionID != "a" {
+		t.Fatalf("history inputs = %+v", store.inputs)
+	}
+	if len(result.HistoryEventIDs) != 1 {
+		t.Fatalf("history ids = %+v", result.HistoryEventIDs)
+	}
+}
+
+func TestServiceExecuteRequiresTitleForNewIncident(t *testing.T) {
+	catalog := mustCatalog(t, []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskLowRiskMutation, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second, TimeoutText: "1s"}})
+	service := NewService(catalog, Policy{ActionsEnabled: true}, fakeRunner{result: ActionResult{Status: StatusSucceeded}}, &fakeStore{})
+	result := service.Execute(context.Background(), ActionRequest{ActionID: "a", IncidentKey: "inc"})
+	if result.Status != StatusBlocked || result.PolicyReason != "incident_title is required when incident_key creates action history" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func mustCatalog(t *testing.T, actions []Action) Catalog {
+	t.Helper()
+	catalog, err := NewCatalog(actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return catalog
+}
+```
+
+- [ ] **Step 2: Run service tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/management -run Service -v
+```
+
+Expected: FAIL because `Service`, `ActionRequest`, and `NewService` do not exist.
+
+- [ ] **Step 3: Implement service**
+
+Add to `types.go`:
+
+```go
+type ActionRequest struct {
+	ActionID       string         `json:"action_id"`
+	Args           map[string]any `json:"args,omitempty"`
+	IncidentKey    string         `json:"incident_key,omitempty"`
+	IncidentTitle  string         `json:"incident_title,omitempty"`
+	Severity       string         `json:"severity,omitempty"`
+	Service        string         `json:"service,omitempty"`
+}
+```
+
+In `service.go`, define:
+
+```go
+type RunnerInterface interface {
+	Run(context.Context, Action) ActionResult
+}
+
+type HistoryStore interface {
+	RecordManagementAction(context.Context, history.ManagementActionInput) (history.Event, error)
+	ListManagementActions(context.Context, history.ManagementActionFilter) ([]history.Event, error)
+}
+
+type Service struct {
+	catalog Catalog
+	policy  Policy
+	runner  RunnerInterface
+	history HistoryStore
+}
+```
+
+Implement:
+- `List() []Action`
+- `Preview(ctx context.Context, req ActionRequest) ActionResult`
+- `Execute(ctx context.Context, req ActionRequest) ActionResult`
+- `History(ctx context.Context, filter history.ManagementActionFilter) ([]history.Event, error)`
+
+Rules:
+- Unknown `ActionID` returns `StatusBlocked`, `DecisionBlock`, `PolicyReason: "unknown management action"`.
+- If `IncidentKey` is set and `IncidentTitle` is empty, block before execution.
+- Preview never runs the runner.
+- Execute runs only when policy decision is `allow`.
+- Record one final event per preview/block/execution result. If history is nil, set `Warning: "management action history is disabled"`.
+
+- [ ] **Step 4: Run service tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/management -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/management
+git commit -m "feat(observability): add management action service"
+```
+
+## Task 6: MCP Tool Handlers
+
+**Files:**
+- Modify: `go/observability-mcp-service/internal/mcpserver/server.go`
+- Modify: `go/observability-mcp-service/internal/mcpserver/server_test.go`
+
+- [ ] **Step 1: Write failing MCP tests**
+
+In `server_test.go`, import management:
+
+```go
+"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/management"
+```
+
+Add assertions to the tool registration test for:
+
+```go
+"list_management_actions", "preview_management_action", "execute_management_action", "get_management_action_history"
+```
+
+Add handler tests:
+
+```go
+func TestManagementActionHandlers(t *testing.T) {
+	fake := &fakeWorkflow{}
+	result, err := previewManagementActionHandler(fake)(context.Background(), callReq(map[string]any{"action_id": "reload_grafana_alerting"}))
+	if err != nil || result.IsError {
+		t.Fatalf("preview failed: result=%#v err=%v", result, err)
+	}
+	if fake.managementRequest.ActionID != "reload_grafana_alerting" {
+		t.Fatalf("request = %+v", fake.managementRequest)
+	}
+
+	result, err = executeManagementActionHandler(fake)(context.Background(), callReq(map[string]any{
+		"action_id": "reload_grafana_alerting",
+		"incident_key": "inc",
+		"incident_title": "Incident",
+	}))
+	if err != nil || result.IsError {
+		t.Fatalf("execute failed: result=%#v err=%v", result, err)
+	}
+	if fake.managementRequest.IncidentKey != "inc" {
+		t.Fatalf("request = %+v", fake.managementRequest)
+	}
+}
+
+func TestManagementActionHistoryHandlerValidatesLimit(t *testing.T) {
+	result, err := managementActionHistoryHandler(&fakeWorkflow{})(context.Background(), callReq(map[string]any{"limit": 101}))
+	if err != nil {
+		t.Fatalf("handler transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected tool error")
+	}
+}
+```
+
+Extend `fakeWorkflow` with:
+
+```go
+managementRequest management.ActionRequest
+```
+
+and methods:
+
+```go
+func (f *fakeWorkflow) ListManagementActions(context.Context) ([]management.Action, error) {
+	return []management.Action{{ID: "reload_grafana_alerting"}}, nil
+}
+
+func (f *fakeWorkflow) PreviewManagementAction(_ context.Context, req management.ActionRequest) (management.ActionResult, error) {
+	f.managementRequest = req
+	return management.ActionResult{ActionID: req.ActionID, Status: management.StatusPreviewed}, nil
+}
+
+func (f *fakeWorkflow) ExecuteManagementAction(_ context.Context, req management.ActionRequest) (management.ActionResult, error) {
+	f.managementRequest = req
+	return management.ActionResult{ActionID: req.ActionID, Status: management.StatusSucceeded}, nil
+}
+
+func (f *fakeWorkflow) ListManagementActionHistory(context.Context, history.ManagementActionFilter) ([]history.Event, error) {
+	return []history.Event{}, nil
+}
+```
+
+- [ ] **Step 2: Run MCP tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/mcpserver -run Management -v
+```
+
+Expected: FAIL because handlers and interface methods do not exist.
+
+- [ ] **Step 3: Implement MCP interface and handlers**
+
+In `server.go`, extend `WorkflowService` with:
+
+```go
+ListManagementActions(context.Context) ([]management.Action, error)
+PreviewManagementAction(context.Context, management.ActionRequest) (management.ActionResult, error)
+ExecuteManagementAction(context.Context, management.ActionRequest) (management.ActionResult, error)
+ListManagementActionHistory(context.Context, history.ManagementActionFilter) ([]history.Event, error)
+```
+
+Register tools in `New()` after incident tools:
+
+```go
+addTool(srv, "list_management_actions", "List cataloged observability management actions.", listManagementActionsSchema(), listManagementActionsHandler(service))
+addTool(srv, "preview_management_action", "Validate and preview a cataloged management action without executing it.", managementActionSchema(), previewManagementActionHandler(service))
+addTool(srv, "execute_management_action", "Execute an allowed cataloged management action.", managementActionSchema(), executeManagementActionHandler(service))
+addTool(srv, "get_management_action_history", "List persisted management action events.", managementActionHistorySchema(), managementActionHistoryHandler(service))
+```
+
+Add schemas with `additionalProperties:false`. `managementActionSchema` requires `action_id` and allows `args`, `incident_key`, `incident_title`, `severity`, and `service`. History schema allows `incident_key`, `action_id`, `status`, `decision`, and `limit` with max 100.
+
+Implement handlers using existing `decodeArgs`, `decodeOptionalArgs`, `jsonResult`, and `toolError`.
+
+- [ ] **Step 4: Run MCP tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/mcpserver -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/mcpserver
+git commit -m "feat(observability): expose management action tools"
+```
+
+## Task 7: Workflow And Main Wiring
+
+**Files:**
+- Modify: `go/observability-mcp-service/internal/workflows/service.go`
+- Modify: `go/observability-mcp-service/internal/workflows/service_test.go`
+- Modify: `go/observability-mcp-service/cmd/observability-mcp/main.go`
+- Modify: `go/observability-mcp-service/cmd/observability-mcp/main_test.go`
+
+- [ ] **Step 1: Write failing workflow wiring tests**
+
+In `workflows/service_test.go`, import management and add:
+
+```go
+func TestManagementActionsUnavailableUntilConfigured(t *testing.T) {
+	service := NewService(nil, nil, nil, 10)
+	if _, err := service.ListManagementActions(context.Background()); err == nil {
+		t.Fatal("expected management service disabled error")
+	}
+}
+```
+
+In `main_test.go`, add:
+
+```go
+func TestRunWiresManagementWhenEnabled(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "true")
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "30s")
+	err := run(context.Background(), log.New(&bytes.Buffer{}, "", 0), func(ctx context.Context, application *app) error {
+		actions, err := application.service.ListManagementActions(ctx)
+		if err != nil {
+			t.Fatalf("ListManagementActions() error = %v", err)
+		}
+		if len(actions) == 0 {
+			t.Fatal("expected management actions")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+}
+```
+
+Add management env resets to `clearEnv(t)`.
+
+- [ ] **Step 2: Run wiring tests and verify failure**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/workflows ./cmd/observability-mcp -run Management -v
+```
+
+Expected: FAIL because workflow service has no management methods.
+
+- [ ] **Step 3: Add workflow delegation**
+
+In `workflows.Service`, add:
+
+```go
+management *management.Service
+```
+
+Add:
+
+```go
+func (s *Service) WithManagement(m *management.Service) *Service {
+	s.management = m
+	return s
+}
+```
+
+Implement the four management methods by returning `errors.New("management actions are disabled")` when `s.management == nil`, otherwise delegating to the management service.
+
+- [ ] **Step 4: Wire main**
+
+In `main.go`, import `path/filepath`, `runtime`, and `internal/management`.
+
+Add helper:
+
+```go
+func repoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+```
+
+After history setup, build:
+
+```go
+catalog := management.DefaultCatalog()
+if err := catalog.ValidateScripts(repoRoot()); err != nil {
+	return fmt.Errorf("management catalog: %w", err)
+}
+runner := management.Runner{RepoRoot: repoRoot(), MaxOutputBytes: cfg.ManagementMaxOutputBytes, MaxTimeout: cfg.ManagementActionTimeout}
+managementService := management.NewService(
+	catalog,
+	management.Policy{ActionsEnabled: cfg.ManagementActionsEnabled, AllowHighRisk: cfg.ManagementAllowHighRisk},
+	runner,
+	historyDB,
+)
+service.WithManagement(managementService)
+```
+
+Keep `historyDB` as a variable outside the history `if` so it can be nil when history is disabled.
+
+- [ ] **Step 5: Run wiring tests and commit**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/workflows ./cmd/observability-mcp -v
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/internal/workflows go/observability-mcp-service/cmd/observability-mcp
+git commit -m "feat(observability): wire management actions"
+```
+
+## Task 8: README And End-To-End Checks
+
+**Files:**
+- Modify: `go/observability-mcp-service/README.md`
+
+- [ ] **Step 1: Update README**
+
+In the configuration table, add:
+
+```markdown
+| `OBS_MANAGEMENT_ACTIONS_ENABLED` | `false` | Enables cataloged management action execution. Read-only evidence tools work without this. |
+| `OBS_MANAGEMENT_ALLOW_HIGH_RISK` | `false` | Allows high-risk cataloged actions to execute instead of preview-only. Keep false for normal use. |
+| `OBS_MANAGEMENT_ACTION_TIMEOUT` | `45m` | Default maximum action execution timeout unless a catalog entry is lower. |
+| `OBS_MANAGEMENT_MAX_OUTPUT_BYTES` | `32768` | Maximum stdout/stderr bytes returned and stored for each action. |
+```
+
+In the tools list, add:
+
+```markdown
+- `list_management_actions`
+- `preview_management_action`
+- `execute_management_action`
+- `get_management_action_history`
+```
+
+Replace the Safety paragraph with wording that says:
+
+```markdown
+By default, external observability and runtime systems remain read-only. When
+`OBS_MANAGEMENT_ACTIONS_ENABLED=true`, the MCP can execute cataloged management
+actions only. Those actions must map to committed repo scripts, use fixed
+command shapes, bounded inputs, timeouts, output redaction, and incident-history
+logging. The MCP still does not accept free-form shell, kubectl, SSH commands,
+Grafana mutation payloads, arbitrary URLs, or arbitrary script paths.
+```
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cd go/observability-mcp-service && go test ./internal/config ./internal/history ./internal/management ./internal/mcpserver ./internal/workflows ./cmd/observability-mcp -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full Go preflight**
+
+Run from repo root:
+
+```bash
+make preflight-go
+```
+
+Expected: PASS. If blocked by local toolchain, capture the exact missing tool or failing command in the final handoff.
+
+- [ ] **Step 4: Commit docs and any final fixes**
+
+Commit:
+
+```bash
+git add go/observability-mcp-service/README.md
+git commit -m "docs(observability): document management actions"
+```
+
+## Task 9: Final Review
+
+**Files:**
+- Review all changed files from Tasks 1-8.
+
+- [ ] **Step 1: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -8
+git diff qa...HEAD -- go/observability-mcp-service
+```
+
+Expected: the diff contains only management-action implementation, tests, and README updates.
+
+- [ ] **Step 2: Verify safety properties in code**
+
+Use `rg` to confirm there is no free-form command API:
+
+```bash
+rg -n "kubectl|ssh|CommandContext|ScriptPath|Args|shell|/bin/sh" go/observability-mcp-service/internal
+```
+
+Expected: `CommandContext` appears only in `internal/management/runner.go`; `kubectl` and `ssh` appear only in static script metadata or README text, not as accepted user input.
+
+- [ ] **Step 3: Confirm final preflight evidence**
+
+Run:
+
+```bash
+make preflight-go
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Prepare PR**
+
+Because this changes Go application behavior, implementation should be done in a feature worktree/branch and opened as a PR to `qa`.
+
+Use a PR summary with:
+
+```markdown
+## Summary
+- added opt-in cataloged management actions for the Observability MCP
+- added policy-gated runner, output redaction, and action history persistence
+- documented the agent-autonomous ops-as-code safety model
+
+## Tests
+- make preflight-go
+```

--- a/docs/superpowers/plans/2026-05-20-rag-eval-cancellation-stale-recovery.md
+++ b/docs/superpowers/plans/2026-05-20-rag-eval-cancellation-stale-recovery.md
@@ -1,0 +1,1262 @@
+# RAG Eval Cancellation And Stale Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add explicit cancellation and repair-oriented stale recovery for RabbitMQ-backed RAG eval item work.
+
+**Architecture:** `services/eval` remains the source of truth. The API records cancellation and exposes richer evidence, the worker treats cancellation as a normal terminal item outcome, recovery republish/reset logic preserves retryable item work, and `go/eval-mcp-service` converts the richer API response into operator guidance.
+
+**Tech Stack:** Python 3.11, FastAPI, aiosqlite, aio-pika/RabbitMQ, pytest/pytest-asyncio, Go eval MCP service tests.
+
+---
+
+## File Map
+
+- Modify `services/eval/app/db.py`: add item cancellation helpers, run cancellation helper, richer item evidence counts, recovery query helpers, and terminal repair safeguards.
+- Modify `services/eval/app/main.py`: add cancel endpoint, richer `item_counts`, and recovery republish/finalization flow.
+- Modify `services/eval/app/evaluator.py`: add optional cancellation check hook before search, chat, and judge stages.
+- Modify `services/eval/app/worker.py`: check parent run cancellation before claim, after claim, and handle cancellation from `evaluate_item`.
+- Modify `services/eval/tests/test_db.py`: cover cancellation state transitions, expired lease recovery, queued republish candidates, evidence counts, and cancelled finalization guard.
+- Modify `services/eval/tests/test_main.py`: cover cancel API, richer evidence response, and startup recovery publisher calls.
+- Modify `services/eval/tests/test_evaluator.py`: cover cancellation hook before expensive stages.
+- Modify `services/eval/tests/test_worker.py`: cover cancelled run ack behavior and no retry/DLQ path.
+- Modify `go/eval-mcp-service/internal/evalworkflow/service.go`: update evidence next steps for cancelled, stale retryable, and stale exhausted cases.
+- Modify `go/eval-mcp-service/internal/evalworkflow/service_test.go`: cover the new evidence guidance.
+
+## Task 1: Eval DB Cancellation State
+
+**Files:**
+- Modify: `services/eval/app/db.py`
+- Test: `services/eval/tests/test_db.py`
+
+- [ ] **Step 1: Write failing DB tests for cancellation helpers**
+
+Add these tests after `test_claim_evaluation_item_returns_none_for_completed_item` in `services/eval/tests/test_db.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_cancel_evaluation_marks_run_and_non_terminal_items_cancelled(db):
+    items = [
+        {"query": "q1", "expected_answer": "a1", "expected_sources": []},
+        {"query": "q2", "expected_answer": "a2", "expected_sources": []},
+    ]
+    ds_id = await db.create_dataset(name="ds-cancel", items=items)
+    eval_id = await db.create_evaluation(ds_id, "documents", status="running")
+    first, second = await db.create_evaluation_items(eval_id, items, max_attempts=3)
+    await db.mark_evaluation_item_completed(
+        first["id"],
+        result={"query": "q1", "answer": "a1", "contexts": []},
+        scores={"faithfulness": 1.0},
+        score_reasons={"faithfulness": "ok"},
+    )
+    await db.claim_evaluation_item(second["id"], worker_id="worker-1", lease_seconds=60)
+
+    cancelled = await db.cancel_evaluation(eval_id)
+
+    assert cancelled is not None
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["error"] == "evaluation cancelled by operator"
+    stored = await db.list_evaluation_items(eval_id)
+    assert stored[0]["status"] == "completed"
+    assert stored[1]["status"] == "cancelled"
+    assert stored[1]["lease_owner"] is None
+    assert stored[1]["lease_expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_evaluation_returns_none_for_terminal_run(db):
+    ds_id = await db.create_dataset(name="ds-cancel-terminal", items=SIMPLE_ITEM)
+    eval_id = await db.create_evaluation(ds_id, "documents", status="running")
+    await db.complete_evaluation(eval_id, aggregate_scores={}, results=[])
+
+    cancelled = await db.cancel_evaluation(eval_id)
+
+    assert cancelled is None
+    evaluation = await db.get_evaluation(eval_id)
+    assert evaluation["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_mark_evaluation_item_cancelled_clears_lease(db):
+    ds_id = await db.create_dataset(name="ds-cancel-item", items=SIMPLE_ITEM)
+    eval_id = await db.create_evaluation(ds_id, "documents", status="running")
+    [item] = await db.create_evaluation_items(eval_id, SIMPLE_ITEM, max_attempts=3)
+    await db.claim_evaluation_item(item["id"], worker_id="worker-1", lease_seconds=60)
+
+    await db.mark_evaluation_item_cancelled(item["id"])
+
+    stored = await db.get_evaluation_item(item["id"])
+    assert stored["status"] == "cancelled"
+    assert stored["lease_owner"] is None
+    assert stored["lease_expires_at"] is None
+    assert stored["completed_at"] is not None
+```
+
+- [ ] **Step 2: Run the new DB tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest \
+  services/eval/tests/test_db.py::test_cancel_evaluation_marks_run_and_non_terminal_items_cancelled \
+  services/eval/tests/test_db.py::test_cancel_evaluation_returns_none_for_terminal_run \
+  services/eval/tests/test_db.py::test_mark_evaluation_item_cancelled_clears_lease \
+  -v
+```
+
+Expected: fail with missing `cancel_evaluation` and `mark_evaluation_item_cancelled`.
+
+- [ ] **Step 3: Add cancellation helpers**
+
+In `services/eval/app/db.py`, add these methods after `mark_evaluation_item_failed`:
+
+```python
+    async def mark_evaluation_item_cancelled(self, item_id: str) -> None:
+        now = datetime.now(_UTC).isoformat()
+        await self._db.execute(
+            "UPDATE evaluation_items "
+            "SET status = 'cancelled', lease_owner = NULL, lease_expires_at = NULL, "
+            "completed_at = ?, updated_at = ? "
+            "WHERE id = ? AND status NOT IN ('completed', 'failed', 'cancelled')",
+            (now, now, item_id),
+        )
+        await self._db.commit()
+
+    async def cancel_evaluation(self, eval_id: str) -> dict | None:
+        now = datetime.now(_UTC).isoformat()
+        cursor = await self._db.execute(
+            "UPDATE evaluations "
+            "SET status = 'cancelled', error = ?, completed_at = ? "
+            "WHERE id = ? AND status IN ('queued', 'running')",
+            ("evaluation cancelled by operator", now, eval_id),
+        )
+        if cursor.rowcount == 0:
+            await self._db.commit()
+            return None
+        await self._db.execute(
+            "UPDATE evaluation_items "
+            "SET status = 'cancelled', lease_owner = NULL, lease_expires_at = NULL, "
+            "completed_at = COALESCE(completed_at, ?), updated_at = ? "
+            "WHERE evaluation_id = ? "
+            "AND status NOT IN ('completed', 'failed', 'cancelled')",
+            (now, now, eval_id),
+        )
+        await self._db.commit()
+        return await self.get_evaluation(eval_id)
+```
+
+- [ ] **Step 4: Protect aggregation from overwriting cancelled runs**
+
+In `finalize_evaluation_if_terminal`, change both update guards so `cancelled` is terminal:
+
+```python
+                "completed_at = ? WHERE id = ? AND status NOT IN "
+                "('completed', 'completed_with_failures', 'failed', 'cancelled')",
+```
+
+and:
+
+```python
+                "WHERE id = ? AND status NOT IN ('failed', 'cancelled')",
+```
+
+- [ ] **Step 5: Run DB tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_db.py -v
+```
+
+Expected: all DB tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/eval/app/db.py services/eval/tests/test_db.py
+git commit -m "feat(eval): persist cancellation state"
+```
+
+## Task 2: Cancellation API And Item Counts
+
+**Files:**
+- Modify: `services/eval/app/main.py`
+- Test: `services/eval/tests/test_main.py`
+
+- [ ] **Step 1: Write failing API tests**
+
+Add these tests after `test_get_evaluation_includes_item_summary` in `services/eval/tests/test_main.py`:
+
+```python
+@patch("app.main.get_db")
+def test_get_evaluation_includes_cancelled_retryable_and_stale_counts(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_evaluation.return_value = {
+        "id": "eval-456",
+        "dataset_id": "ds-123",
+        "status": "running",
+        "collection": "documents",
+        "aggregate_scores": None,
+        "results": None,
+        "error": None,
+        "created_at": "2026-04-16T00:00:00Z",
+        "completed_at": None,
+        "notes": None,
+        "config": None,
+        "baseline_eval_id": None,
+    }
+    mock_db.count_evaluation_items_by_status.return_value = {
+        "queued": 1,
+        "running": 1,
+        "completed": 2,
+        "failed": 1,
+        "cancelled": 1,
+        "retryable": 2,
+        "stale": 1,
+    }
+    mock_get_db.return_value = mock_db
+
+    response = client.get("/evaluations/eval-456")
+
+    assert response.status_code == 200
+    assert response.json()["item_counts"] == {
+        "queued": 1,
+        "running": 1,
+        "completed": 2,
+        "failed": 1,
+        "cancelled": 1,
+        "retryable": 2,
+        "stale": 1,
+        "total": 6,
+    }
+
+
+@patch("app.main.get_db")
+def test_cancel_evaluation_marks_run_cancelled(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_evaluation.return_value = _baseline_run(status="running")
+    mock_db.cancel_evaluation.return_value = _baseline_run(status="cancelled") | {
+        "error": "evaluation cancelled by operator",
+        "completed_at": "2026-04-16T00:05:00Z",
+    }
+    mock_db.count_evaluation_items_by_status.return_value = {
+        "queued": 0,
+        "running": 0,
+        "completed": 1,
+        "failed": 0,
+        "cancelled": 1,
+        "retryable": 0,
+        "stale": 0,
+    }
+    mock_get_db.return_value = mock_db
+
+    response = client.post("/evaluations/eval-prev/cancel")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+    assert response.json()["item_counts"]["cancelled"] == 1
+    mock_db.cancel_evaluation.assert_awaited_once_with("eval-prev")
+
+
+@patch("app.main.get_db")
+def test_cancel_evaluation_rejects_terminal_run(mock_get_db):
+    mock_db = AsyncMock()
+    mock_db.get_evaluation.return_value = _baseline_run(status="completed")
+    mock_get_db.return_value = mock_db
+
+    response = client.post("/evaluations/eval-prev/cancel")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "evaluation is already terminal"
+    mock_db.cancel_evaluation.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run the new API tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest \
+  services/eval/tests/test_main.py::test_get_evaluation_includes_cancelled_retryable_and_stale_counts \
+  services/eval/tests/test_main.py::test_cancel_evaluation_marks_run_cancelled \
+  services/eval/tests/test_main.py::test_cancel_evaluation_rejects_terminal_run \
+  -v
+```
+
+Expected: fail because the route and richer counts do not exist.
+
+- [ ] **Step 3: Add shared item count builder**
+
+In `services/eval/app/main.py`, add this helper above `get_evaluation`:
+
+```python
+TERMINAL_EVALUATION_STATUSES = {
+    "completed",
+    "completed_with_failures",
+    "failed",
+    "cancelled",
+}
+
+
+def _item_counts_response(counts: dict) -> dict:
+    queued = counts.get("queued", 0)
+    running = counts.get("running", 0)
+    completed = counts.get("completed", 0)
+    failed = counts.get("failed", 0)
+    cancelled = counts.get("cancelled", 0)
+    return {
+        "queued": queued,
+        "running": running,
+        "completed": completed,
+        "failed": failed,
+        "cancelled": cancelled,
+        "retryable": counts.get("retryable", 0),
+        "stale": counts.get("stale", 0),
+        "total": queued + running + completed + failed + cancelled,
+    }
+
+
+async def _attach_item_counts(db: EvalDB, evaluation: dict) -> dict:
+    counts = await db.count_evaluation_items_by_status(
+        evaluation["id"], stale_seconds=settings.eval_stale_item_seconds
+    )
+    if isinstance(counts, dict) and counts:
+        item_counts = _item_counts_response(counts)
+        evaluation["item_counts"] = item_counts
+        evaluation["item_summary"] = item_counts
+    return evaluation
+```
+
+- [ ] **Step 4: Update `get_evaluation` to use the helper**
+
+Replace the count-building body in `get_evaluation` with:
+
+```python
+    evaluation = await _attach_item_counts(db, evaluation)
+    return evaluation
+```
+
+- [ ] **Step 5: Add cancellation endpoint**
+
+Add this route immediately before `get_evaluation`:
+
+```python
+@app.post("/evaluations/{eval_id}/cancel", dependencies=[Depends(enforce_eval_write)])
+async def cancel_evaluation(request: Request, eval_id: str):
+    db = await get_db()
+    evaluation = await db.get_evaluation(eval_id)
+    if not evaluation:
+        raise HTTPException(status_code=404, detail="Evaluation not found")
+    if evaluation["status"] in TERMINAL_EVALUATION_STATUSES:
+        raise HTTPException(status_code=409, detail="evaluation is already terminal")
+    cancelled = await db.cancel_evaluation(eval_id)
+    if cancelled is None:
+        raise HTTPException(status_code=409, detail="evaluation is already terminal")
+    return await _attach_item_counts(db, cancelled)
+```
+
+- [ ] **Step 6: Run API tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_main.py -v
+```
+
+Expected: all eval API tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/eval/app/main.py services/eval/tests/test_main.py
+git commit -m "feat(eval): add cancellation endpoint"
+```
+
+## Task 3: DB Recovery Evidence And Republish Queries
+
+**Files:**
+- Modify: `services/eval/app/db.py`
+- Test: `services/eval/tests/test_db.py`
+
+- [ ] **Step 1: Write failing DB recovery tests**
+
+Add these tests near the existing expired item test in `services/eval/tests/test_db.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_reset_expired_running_items_returns_republishable_items(db):
+    ds_id = await db.create_dataset(name="ds-expired-return", items=SIMPLE_ITEM)
+    eval_id = await db.create_evaluation(ds_id, "documents", status="running")
+    [item] = await db.create_evaluation_items(eval_id, SIMPLE_ITEM, max_attempts=3)
+    await db.claim_evaluation_item(item["id"], worker_id="worker-1", lease_seconds=1)
+    expired = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    await db._db.execute(  # noqa: SLF001
+        "UPDATE evaluation_items SET lease_expires_at = ? WHERE id = ?",
+        (expired, item["id"]),
+    )
+    await db._db.commit()  # noqa: SLF001
+
+    reset_items = await db.reset_expired_running_items(max_age_seconds=60)
+
+    assert [item["id"] for item in reset_items] == [item["id"]]
+    assert reset_items[0]["item_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_fail_expired_running_items_without_attempts_remaining(db):
+    ds_id = await db.create_dataset(name="ds-expired-fail", items=SIMPLE_ITEM)
+    eval_id = await db.create_evaluation(ds_id, "documents", status="running")
+    [item] = await db.create_evaluation_items(eval_id, SIMPLE_ITEM, max_attempts=1)
+    await db.claim_evaluation_item(item["id"], worker_id="worker-1", lease_seconds=1)
+    expired = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+    await db._db.execute(  # noqa: SLF001
+        "UPDATE evaluation_items SET lease_expires_at = ? WHERE id = ?",
+        (expired, item["id"]),
+    )
+    await db._db.commit()  # noqa: SLF001
+
+    failed_items = await db.fail_expired_running_items(max_age_seconds=60)
+
+    assert [failed["id"] for failed in failed_items] == [item["id"]]
+    stored = await db.get_evaluation_item(item["id"])
+    assert stored["status"] == "failed"
+    assert stored["last_error"]["error_type"] == "stale_item_lease"
+    assert stored["last_error"]["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_queued_items_for_republish_excludes_cancelled_runs(db):
+    ds_id = await db.create_dataset(name="ds-republish", items=SIMPLE_ITEM)
+    running_eval = await db.create_evaluation(ds_id, "documents", status="running")
+    cancelled_eval = await db.create_evaluation(ds_id, "documents", status="cancelled")
+    [running_item] = await db.create_evaluation_items(
+        running_eval, SIMPLE_ITEM, max_attempts=3
+    )
+    await db.create_evaluation_items(cancelled_eval, SIMPLE_ITEM, max_attempts=3)
+
+    queued = await db.list_queued_items_for_republish(max_age_seconds=0)
+
+    assert [item["id"] for item in queued] == [running_item["id"]]
+
+
+@pytest.mark.asyncio
+async def test_count_evaluation_items_by_status_includes_retryable_and_stale(db):
+    ds_id = await db.create_dataset(name="ds-count-rich", items=SIMPLE_ITEM)
+    eval_id = await db.create_evaluation(ds_id, "documents", status="running")
+    [item] = await db.create_evaluation_items(eval_id, SIMPLE_ITEM, max_attempts=3)
+    old = (datetime.now(UTC) - timedelta(minutes=30)).isoformat()
+    await db._db.execute(  # noqa: SLF001
+        "UPDATE evaluation_items SET updated_at = ? WHERE id = ?",
+        (old, item["id"]),
+    )
+    await db._db.commit()  # noqa: SLF001
+
+    counts = await db.count_evaluation_items_by_status(eval_id)
+
+    assert counts["queued"] == 1
+    assert counts["retryable"] == 1
+    assert counts["stale"] == 1
+```
+
+- [ ] **Step 2: Run the new recovery tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest \
+  services/eval/tests/test_db.py::test_reset_expired_running_items_returns_republishable_items \
+  services/eval/tests/test_db.py::test_fail_expired_running_items_without_attempts_remaining \
+  services/eval/tests/test_db.py::test_list_queued_items_for_republish_excludes_cancelled_runs \
+  services/eval/tests/test_db.py::test_count_evaluation_items_by_status_includes_retryable_and_stale \
+  -v
+```
+
+Expected: fail because recovery helpers and richer counts are not implemented.
+
+- [ ] **Step 3: Change `reset_expired_running_items` to return reset rows**
+
+Replace `reset_expired_running_items` in `services/eval/app/db.py` with:
+
+```python
+    async def reset_expired_running_items(self, max_age_seconds: float) -> list[dict]:
+        now = datetime.now(_UTC)
+        cutoff = (now - timedelta(seconds=max_age_seconds)).isoformat()
+        cursor = await self._db.execute(
+            "SELECT * FROM evaluation_items "
+            "WHERE status = 'running' AND lease_expires_at < ? "
+            "AND attempt_count < max_attempts "
+            "ORDER BY updated_at ASC",
+            (cutoff,),
+        )
+        rows = await cursor.fetchall()
+        items = [self._item_row_to_dict(row) for row in rows]
+        await self._db.execute(
+            "UPDATE evaluation_items "
+            "SET status = 'queued', lease_owner = NULL, lease_expires_at = NULL, "
+            "updated_at = ? "
+            "WHERE status = 'running' AND lease_expires_at < ? "
+            "AND attempt_count < max_attempts",
+            (now.isoformat(), cutoff),
+        )
+        await self._db.commit()
+        return items
+```
+
+- [ ] **Step 4: Add exhausted lease and queued republish helpers**
+
+Add these methods after `reset_expired_running_items`:
+
+```python
+    async def fail_expired_running_items(self, max_age_seconds: float) -> list[dict]:
+        now = datetime.now(_UTC)
+        cutoff = (now - timedelta(seconds=max_age_seconds)).isoformat()
+        cursor = await self._db.execute(
+            "SELECT * FROM evaluation_items "
+            "WHERE status = 'running' AND lease_expires_at < ? "
+            "AND attempt_count >= max_attempts "
+            "ORDER BY updated_at ASC",
+            (cutoff,),
+        )
+        rows = await cursor.fetchall()
+        items = [self._item_row_to_dict(row) for row in rows]
+        error = json.dumps({"error_type": "stale_item_lease", "retryable": False})
+        await self._db.execute(
+            "UPDATE evaluation_items "
+            "SET status = 'failed', last_error = ?, lease_owner = NULL, "
+            "lease_expires_at = NULL, completed_at = ?, updated_at = ? "
+            "WHERE status = 'running' AND lease_expires_at < ? "
+            "AND attempt_count >= max_attempts",
+            (error, now.isoformat(), now.isoformat(), cutoff),
+        )
+        await self._db.commit()
+        return items
+
+    async def list_queued_items_for_republish(
+        self, max_age_seconds: float
+    ) -> list[dict]:
+        cutoff = (datetime.now(_UTC) - timedelta(seconds=max_age_seconds)).isoformat()
+        cursor = await self._db.execute(
+            "SELECT i.* FROM evaluation_items i "
+            "JOIN evaluations e ON e.id = i.evaluation_id "
+            "WHERE i.status = 'queued' AND i.updated_at < ? "
+            "AND e.status NOT IN "
+            "('completed', 'completed_with_failures', 'failed', 'cancelled') "
+            "ORDER BY i.updated_at ASC",
+            (cutoff,),
+        )
+        rows = await cursor.fetchall()
+        return [self._item_row_to_dict(row) for row in rows]
+```
+
+- [ ] **Step 5: Enrich `count_evaluation_items_by_status`**
+
+Replace `count_evaluation_items_by_status` with:
+
+```python
+    async def count_evaluation_items_by_status(
+        self, eval_id: str, stale_seconds: float = 900.0
+    ) -> dict[str, int]:
+        cursor = await self._db.execute(
+            "SELECT status, COUNT(*) AS count FROM evaluation_items "
+            "WHERE evaluation_id = ? GROUP BY status",
+            (eval_id,),
+        )
+        rows = await cursor.fetchall()
+        counts = {row["status"]: row["count"] for row in rows}
+        stale_cutoff = (
+            datetime.now(_UTC) - timedelta(seconds=stale_seconds)
+        ).isoformat()
+        retryable_cursor = await self._db.execute(
+            "SELECT COUNT(*) AS count FROM evaluation_items "
+            "WHERE evaluation_id = ? "
+            "AND status IN ('queued', 'running', 'failed') "
+            "AND attempt_count < max_attempts",
+            (eval_id,),
+        )
+        stale_cursor = await self._db.execute(
+            "SELECT COUNT(*) AS count FROM evaluation_items "
+            "WHERE evaluation_id = ? "
+            "AND status IN ('queued', 'running') "
+            "AND (updated_at < ? OR lease_expires_at < ?)",
+            (eval_id, stale_cutoff, datetime.now(_UTC).isoformat()),
+        )
+        retryable_row = await retryable_cursor.fetchone()
+        stale_row = await stale_cursor.fetchone()
+        counts["retryable"] = int(retryable_row["count"])
+        counts["stale"] = int(stale_row["count"])
+        return counts
+```
+
+- [ ] **Step 6: Run DB tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_db.py -v
+```
+
+Expected: all DB tests pass. If an older test expects `reset_expired_running_items` to equal `1`, update it to assert `len(reset) == 1` and the stored item state.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add services/eval/app/db.py services/eval/tests/test_db.py
+git commit -m "feat(eval): repair stale item state"
+```
+
+## Task 4: Startup Recovery Republish Flow
+
+**Files:**
+- Modify: `services/eval/app/main.py`
+- Test: `services/eval/tests/test_main.py`
+
+- [ ] **Step 1: Write failing recovery tests**
+
+Replace `test_recover_stale_evaluations_uses_max_runtime_plus_grace` in `services/eval/tests/test_main.py` with:
+
+```python
+@pytest.mark.asyncio
+@patch("app.main.get_item_publisher")
+@patch("app.main.get_db")
+async def test_recover_stale_evaluations_republishes_retryable_items(
+    mock_get_db, mock_get_item_publisher
+):
+    mock_db = AsyncMock()
+    mock_db.reset_expired_running_items.return_value = [
+        {"evaluation_id": "eval-1", "id": "item-1", "item_index": 0}
+    ]
+    mock_db.fail_expired_running_items.return_value = []
+    mock_db.list_queued_items_for_republish.return_value = [
+        {"evaluation_id": "eval-2", "id": "item-2", "item_index": 1}
+    ]
+    mock_db.count_stale_running_evaluations.return_value = 0
+    mock_get_db.return_value = mock_db
+    publisher = AsyncMock()
+    mock_get_item_publisher.return_value = publisher
+
+    await recover_stale_evaluations()
+
+    assert publisher.publish.await_count == 2
+    published = [call.args[0] for call in publisher.publish.await_args_list]
+    assert published[0].evaluation_id == "eval-1"
+    assert published[0].item_id == "item-1"
+    assert published[1].evaluation_id == "eval-2"
+    assert published[1].item_id == "item-2"
+    mock_db.fail_stale_running_evaluations.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("app.main.get_item_publisher")
+@patch("app.main.get_db")
+async def test_recover_stale_evaluations_finalizes_failed_expired_items(
+    mock_get_db, mock_get_item_publisher
+):
+    mock_db = AsyncMock()
+    mock_db.reset_expired_running_items.return_value = []
+    mock_db.fail_expired_running_items.return_value = [
+        {"evaluation_id": "eval-1", "id": "item-1", "item_index": 0}
+    ]
+    mock_db.list_queued_items_for_republish.return_value = []
+    mock_db.count_stale_running_evaluations.return_value = 1
+    mock_get_db.return_value = mock_db
+
+    await recover_stale_evaluations()
+
+    mock_db.finalize_evaluation_if_terminal.assert_awaited_once_with("eval-1")
+    mock_get_item_publisher.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run the recovery tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest \
+  services/eval/tests/test_main.py::test_recover_stale_evaluations_republishes_retryable_items \
+  services/eval/tests/test_main.py::test_recover_stale_evaluations_finalizes_failed_expired_items \
+  -v
+```
+
+Expected: fail because `recover_stale_evaluations` still expects counts and fails stale runs.
+
+- [ ] **Step 3: Add recovery publish helper**
+
+In `services/eval/app/main.py`, add this helper after `publish_evaluation_items`:
+
+```python
+async def republish_evaluation_items(items: list[dict]) -> None:
+    if not items:
+        return
+    publisher = await get_item_publisher()
+    for item in items:
+        await publisher.publish(
+            EvalItemMessage(
+                evaluation_id=item["evaluation_id"],
+                item_id=item["id"],
+                item_index=item["item_index"],
+                attempt=item.get("attempt_count", 0) + 1,
+            )
+        )
+        eval_queue_publish_total.labels(status="success").inc()
+```
+
+- [ ] **Step 4: Replace startup recovery logic**
+
+Replace `recover_stale_evaluations` with:
+
+```python
+@app.on_event("startup")
+async def recover_stale_evaluations():
+    db = await get_db()
+    reset_items = await db.reset_expired_running_items(settings.eval_stale_item_seconds)
+    if reset_items:
+        await republish_evaluation_items(reset_items)
+        logger.warning(
+            "Recovered %s expired running evaluation item(s)", len(reset_items)
+        )
+    failed_items = await db.fail_expired_running_items(settings.eval_stale_item_seconds)
+    finalized_eval_ids = {item["evaluation_id"] for item in failed_items}
+    for eval_id in finalized_eval_ids:
+        await db.finalize_evaluation_if_terminal(eval_id)
+    queued_items = await db.list_queued_items_for_republish(
+        settings.eval_stale_item_seconds
+    )
+    if queued_items:
+        await republish_evaluation_items(queued_items)
+        logger.warning("Republished %s stale queued evaluation item(s)", len(queued_items))
+    max_age = settings.eval_run_max_seconds + settings.eval_stale_grace_seconds
+    stale_count = await db.count_stale_running_evaluations(max_age)
+    eval_stale_running_runs.set(stale_count)
+```
+
+- [ ] **Step 5: Run API tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_main.py -v
+```
+
+Expected: all eval API tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/eval/app/main.py services/eval/tests/test_main.py
+git commit -m "feat(eval): republish stale item work"
+```
+
+## Task 5: Evaluator Cancellation Boundaries
+
+**Files:**
+- Modify: `services/eval/app/evaluator.py`
+- Test: `services/eval/tests/test_evaluator.py`
+
+- [ ] **Step 1: Write failing evaluator tests**
+
+Add this test near the existing `evaluate_item` tests in `services/eval/tests/test_evaluator.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_evaluate_item_checks_cancellation_before_each_expensive_stage():
+    events = []
+
+    class FakeRAGClient:
+        async def search(self, *args, **kwargs):
+            events.append("search")
+            return [{"text": "ctx"}]
+
+        async def ask(self, *args, **kwargs):
+            events.append("chat")
+            return {"answer": "answer"}
+
+    async def judge(row):
+        events.append("judge")
+        return JudgeScores(
+            faithfulness=1.0,
+            answer_relevancy=1.0,
+            reasons={"faithfulness": "ok", "answer_relevancy": "ok"},
+        )
+
+    async def check_cancelled():
+        events.append("check")
+
+    await evaluate_item(
+        item={"query": "q", "expected_answer": "a", "expected_sources": []},
+        rag_client=FakeRAGClient(),
+        collection="documents",
+        rerank=False,
+        top_k=5,
+        judge=judge,
+        run_context=None,
+        answer_model=None,
+        item_index=0,
+        check_cancelled=check_cancelled,
+    )
+
+    assert events == ["check", "search", "check", "chat", "check", "judge"]
+```
+
+- [ ] **Step 2: Run the evaluator test and verify it fails**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_evaluator.py::test_evaluate_item_checks_cancellation_before_each_expensive_stage -v
+```
+
+Expected: fail because `evaluate_item` has no `check_cancelled` parameter.
+
+- [ ] **Step 3: Add optional cancellation hook to `evaluate_item`**
+
+In `services/eval/app/evaluator.py`, update the signature:
+
+```python
+async def evaluate_item(
+    *,
+    item: dict,
+    rag_client: RAGClient,
+    collection: str | None,
+    rerank: bool,
+    top_k: int,
+    judge,
+    run_context: EvalRunContext | None,
+    answer_model: dict | None,
+    item_index: int,
+    check_cancelled=None,
+) -> dict:
+```
+
+Then call the hook before each expensive stage:
+
+```python
+        if check_cancelled is not None:
+            await check_cancelled()
+        search_results = await rag_client.search(
+            query, collection=collection, limit=top_k, rerank=rerank
+        )
+        if check_cancelled is not None:
+            await check_cancelled()
+        chat_response = await rag_client.ask(
+            query,
+            collection=collection,
+            rerank=rerank,
+            retrieval_config={"top_k": top_k},
+            answer_model=answer_model,
+        )
+```
+
+and immediately before judging:
+
+```python
+        if check_cancelled is not None:
+            await check_cancelled()
+        judge_scores = await judge(row)
+```
+
+- [ ] **Step 4: Run evaluator tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_evaluator.py -v
+```
+
+Expected: all evaluator tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/eval/app/evaluator.py services/eval/tests/test_evaluator.py
+git commit -m "feat(eval): check cancellation before item stages"
+```
+
+## Task 6: Worker Cancellation Handling
+
+**Files:**
+- Modify: `services/eval/app/worker.py`
+- Test: `services/eval/tests/test_worker.py`
+
+- [ ] **Step 1: Expand fake DB for cancellation tests**
+
+Update `FakeDB.__init__` in `services/eval/tests/test_worker.py`:
+
+```python
+        self.evaluation = {
+            "id": "eval-1",
+            "status": "running",
+            "collection": "documents",
+            "config": {"effective_retrieval_config": {"top_k": 5}},
+        }
+        self.cancelled = None
+        self.running = None
+```
+
+Replace `get_evaluation` with:
+
+```python
+    async def get_evaluation(self, eval_id):
+        return self.evaluation | {"id": eval_id}
+```
+
+Add this method:
+
+```python
+    async def mark_evaluation_item_cancelled(self, item_id):
+        self.cancelled = item_id
+```
+
+- [ ] **Step 2: Write failing worker cancellation tests**
+
+Add these tests after `test_item_processor_completes_claimed_item`:
+
+```python
+@pytest.mark.asyncio
+async def test_item_processor_acks_cancelled_run_without_claiming_item():
+    db = FakeDB()
+    db.evaluation["status"] = "cancelled"
+    db.claimed = False
+
+    async def claim_evaluation_item(item_id, worker_id, lease_seconds):
+        db.claimed = True
+        return db.item
+
+    db.claim_evaluation_item = claim_evaluation_item
+
+    async def evaluate_item(**kwargs):
+        raise AssertionError("cancelled work must not be evaluated")
+
+    processor = ItemProcessor(db=db, evaluate_item_fn=evaluate_item, worker_id="w1")
+
+    await processor.process(
+        EvalItemMessage(
+            evaluation_id="eval-1",
+            item_id="item-1",
+            item_index=0,
+            attempt=1,
+        )
+    )
+
+    assert db.claimed is False
+    assert db.cancelled == "item-1"
+    assert db.failed is None
+
+
+@pytest.mark.asyncio
+async def test_item_processor_marks_item_cancelled_when_stage_check_observes_cancel():
+    db = FakeDB()
+    calls = 0
+
+    async def get_evaluation(eval_id):
+        nonlocal calls
+        calls += 1
+        status = "running" if calls <= 2 else "cancelled"
+        return db.evaluation | {"id": eval_id, "status": status}
+
+    db.get_evaluation = get_evaluation
+
+    async def evaluate_item(**kwargs):
+        await kwargs["check_cancelled"]()
+        raise AssertionError("check_cancelled should raise first")
+
+    processor = ItemProcessor(db=db, evaluate_item_fn=evaluate_item, worker_id="w1")
+
+    await processor.process(
+        EvalItemMessage(
+            evaluation_id="eval-1",
+            item_id="item-1",
+            item_index=0,
+            attempt=1,
+        )
+    )
+
+    assert db.cancelled == "item-1"
+    assert db.failed is None
+    assert not hasattr(db, "released")
+```
+
+- [ ] **Step 3: Run worker tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest \
+  services/eval/tests/test_worker.py::test_item_processor_acks_cancelled_run_without_claiming_item \
+  services/eval/tests/test_worker.py::test_item_processor_marks_item_cancelled_when_stage_check_observes_cancel \
+  -v
+```
+
+Expected: fail because worker cancellation behavior is not implemented.
+
+- [ ] **Step 4: Add cancellation error and helper**
+
+In `services/eval/app/worker.py`, add:
+
+```python
+class CancelledEvaluationError(RuntimeError):
+    pass
+```
+
+Inside `ItemProcessor`, add:
+
+```python
+    async def _raise_if_cancelled(self, eval_id: str) -> None:
+        evaluation = await self.db.get_evaluation(eval_id)
+        if evaluation and evaluation.get("status") == "cancelled":
+            raise CancelledEvaluationError(f"evaluation {eval_id} is cancelled")
+```
+
+- [ ] **Step 5: Check parent status before claim**
+
+At the start of `ItemProcessor.process`, before `claim_evaluation_item`, add:
+
+```python
+        evaluation = await self.db.get_evaluation(message.evaluation_id)
+        if evaluation is None:
+            await self.db.mark_evaluation_item_failed(
+                message.item_id,
+                {"error_type": "missing_evaluation", "retryable": False},
+            )
+            eval_item_dlq_total.labels(reason="missing_evaluation").inc()
+            return
+        if evaluation.get("status") == "cancelled":
+            await self.db.mark_evaluation_item_cancelled(message.item_id)
+            eval_item_messages_total.labels(outcome="cancelled").inc()
+            return
+```
+
+Remove the later missing-evaluation block after claim so missing evaluation is handled once.
+
+- [ ] **Step 6: Re-check after claim and pass stage hook**
+
+After a successful claim, re-read the parent run and add:
+
+```python
+        evaluation = await self.db.get_evaluation(message.evaluation_id)
+        if evaluation.get("status") == "cancelled":
+            await self.db.mark_evaluation_item_cancelled(message.item_id)
+            eval_item_messages_total.labels(outcome="cancelled").inc()
+            return
+```
+
+In the `evaluate_item_fn` call, add:
+
+```python
+                check_cancelled=lambda: self._raise_if_cancelled(
+                    message.evaluation_id
+                ),
+```
+
+- [ ] **Step 7: Handle cancellation as terminal, not retryable**
+
+Add this `except` block before the generic `except Exception as exc`:
+
+```python
+        except CancelledEvaluationError:
+            await self.db.mark_evaluation_item_cancelled(message.item_id)
+            eval_item_messages_total.labels(outcome="cancelled").inc()
+```
+
+- [ ] **Step 8: Run worker tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_worker.py -v
+```
+
+Expected: all worker tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add services/eval/app/worker.py services/eval/tests/test_worker.py
+git commit -m "feat(eval): stop cancelled item work"
+```
+
+## Task 7: MCP Evidence Guidance
+
+**Files:**
+- Modify: `go/eval-mcp-service/internal/evalworkflow/service.go`
+- Test: `go/eval-mcp-service/internal/evalworkflow/service_test.go`
+
+- [ ] **Step 1: Write failing MCP evidence tests**
+
+Add these tests near existing `RunEvidence` tests in `go/eval-mcp-service/internal/evalworkflow/service_test.go`:
+
+```go
+func TestRunEvidenceNextStepsCancelled(t *testing.T) {
+	evidence := RunEvidence{Status: "cancelled"}
+
+	got := runEvidenceNextSteps(evidence)
+
+	if len(got) != 1 || !strings.Contains(got[0], "cancelled") {
+		t.Fatalf("cancelled next steps = %#v", got)
+	}
+}
+
+func TestRunEvidenceNextStepsStaleRetryable(t *testing.T) {
+	evidence := RunEvidence{
+		Status:       "running",
+		StaleRunning: true,
+		ItemCounts: map[string]int{
+			"stale":     2,
+			"retryable": 2,
+		},
+	}
+
+	got := runEvidenceNextSteps(evidence)
+
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "republish") {
+		t.Fatalf("retryable stale next steps should mention republish: %#v", got)
+	}
+}
+
+func TestRunEvidenceNextStepsStaleExhausted(t *testing.T) {
+	evidence := RunEvidence{
+		Status:       "running",
+		StaleRunning: true,
+		ItemCounts: map[string]int{
+			"stale":     2,
+			"retryable": 0,
+		},
+	}
+
+	got := runEvidenceNextSteps(evidence)
+
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "exhausted") {
+		t.Fatalf("exhausted stale next steps should mention exhausted work: %#v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run MCP tests and verify they fail**
+
+Run:
+
+```bash
+go test ./go/eval-mcp-service/internal/evalworkflow -run 'TestRunEvidenceNextSteps(Cancelled|StaleRetryable|StaleExhausted)' -v
+```
+
+Expected: fail because the evidence guidance does not handle these cases yet.
+
+- [ ] **Step 3: Update terminal status helper**
+
+In `go/eval-mcp-service/internal/evalworkflow/service.go`, update `isTerminalRunStatus`:
+
+```go
+func isTerminalRunStatus(status string) bool {
+	return status == "completed" ||
+		status == "completed_with_failures" ||
+		status == "failed" ||
+		status == "cancelled"
+}
+```
+
+- [ ] **Step 4: Update `runEvidenceNextSteps`**
+
+In `runEvidenceNextSteps`, add this case before `case "failed":`:
+
+```go
+	case "cancelled":
+		return []string{
+			"Run was cancelled; start a new eval run if evaluation is still needed.",
+		}
+```
+
+Then replace the `running` stale block with:
+
+```go
+		if evidence.StaleRunning {
+			staleItems := evidence.ItemCounts["stale"]
+			retryableItems := evidence.ItemCounts["retryable"]
+			if staleItems > 0 && retryableItems > 0 {
+				return []string{
+					"Recovery should reset or republish retryable eval item work.",
+					"Inspect eval worker logs if stale or retryable item counts do not change.",
+				}
+			}
+			if staleItems > 0 {
+				return []string{
+					"Stale eval item work appears exhausted or terminal repair is needed.",
+					"Use investigate_eval_run in observability-mcp-service with this eval_id.",
+				}
+			}
+			return []string{
+				"Use investigate_eval_run in observability-mcp-service with this eval_id.",
+				"Check eval service logs for eval_item_start without eval_item_completed.",
+			}
+		}
+```
+
+- [ ] **Step 5: Run MCP tests**
+
+Run:
+
+```bash
+go test ./go/eval-mcp-service/internal/evalworkflow -v
+```
+
+Expected: all eval workflow tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go/eval-mcp-service/internal/evalworkflow/service.go go/eval-mcp-service/internal/evalworkflow/service_test.go
+git commit -m "feat(eval): clarify stale run evidence"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+- Verify Python and Go changes from prior tasks.
+
+- [ ] **Step 1: Run targeted eval Python tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest \
+  services/eval/tests/test_db.py \
+  services/eval/tests/test_main.py \
+  services/eval/tests/test_evaluator.py \
+  services/eval/tests/test_worker.py \
+  -v
+```
+
+Expected: all selected Python tests pass.
+
+- [ ] **Step 2: Run targeted Go eval MCP tests**
+
+Run:
+
+```bash
+go test ./go/eval-mcp-service/internal/evalworkflow -v
+```
+
+Expected: all selected Go tests pass.
+
+- [ ] **Step 3: Run required preflights before final commit or PR**
+
+Run:
+
+```bash
+make preflight-python
+make preflight-go
+make preflight-security
+```
+
+Expected: all preflights pass. If a preflight is blocked by a missing local tool or platform constraint, capture the exact blocker in the final handoff.
+
+- [ ] **Step 4: Review final diff**
+
+Run:
+
+```bash
+git diff --stat qa...HEAD
+git diff qa...HEAD -- services/eval/app services/eval/tests go/eval-mcp-service/internal/evalworkflow
+```
+
+Expected: diff is limited to issue 313 cancellation, recovery, evidence, and tests.

--- a/docs/superpowers/plans/2026-05-20-rag-eval-dlq-triage-replay.md
+++ b/docs/superpowers/plans/2026-05-20-rag-eval-dlq-triage-replay.md
@@ -1,0 +1,1556 @@
+# RAG Eval DLQ Triage Replay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add operator-only RAG eval item DLQ inspection and explicit replay tooling through the eval API and eval MCP service.
+
+**Architecture:** `services/eval` owns RabbitMQ DLQ access, replay state transitions, redaction, metrics, and logs. The Go eval MCP service remains a thin workflow adapter over eval API endpoints and never connects directly to RabbitMQ.
+
+**Tech Stack:** Python 3.11, FastAPI, aiosqlite, aio-pika, Prometheus client, pytest/pytest-asyncio, Go 1.x, MCP Go SDK, `net/http` tests.
+
+---
+
+## File Map
+
+- Modify `services/eval/app/db.py`: add replay metadata columns and item reset helper.
+- Modify `services/eval/app/broker.py`: add DLQ listing/replay primitives and safe DLQ entry models.
+- Modify `services/eval/app/metrics.py`: add DLQ inspection and replay counters.
+- Modify `services/eval/app/models.py`: add API response/request models for DLQ list and replay.
+- Modify `services/eval/app/main.py`: add operator-only dependency plus DLQ list/replay endpoints.
+- Modify `services/eval/tests/test_db.py`: add replay metadata tests.
+- Modify `services/eval/tests/test_broker.py`: add DLQ peek/replay behavior tests with fakes.
+- Modify `services/eval/tests/test_main.py`: add auth, redaction, replay endpoint tests.
+- Modify `go/eval-mcp-service/internal/evalapi/client.go`: add DLQ DTOs and client methods.
+- Modify `go/eval-mcp-service/internal/evalapi/client_test.go`: add API path/body tests.
+- Modify `go/eval-mcp-service/internal/evalworkflow/service.go`: expose DLQ list/replay methods.
+- Modify `go/eval-mcp-service/internal/evalworkflow/service_test.go`: add workflow delegation tests.
+- Modify `go/eval-mcp-service/internal/mcpserver/server.go`: register MCP tools and schemas.
+- Modify `go/eval-mcp-service/internal/mcpserver/server_test.go`: add schema and validation tests.
+
+## Task 1: Eval DB Replay Metadata
+
+**Files:**
+- Modify: `services/eval/app/db.py`
+- Test: `services/eval/tests/test_db.py`
+
+- [ ] **Step 1: Add failing DB tests for replay metadata**
+
+Append these tests to `services/eval/tests/test_db.py` near the existing evaluation item tests:
+
+```python
+@pytest.mark.asyncio
+async def test_requeue_failed_item_for_replay_records_audit_state(db):
+    ds_id = await db.create_dataset(
+        name="ds-replay",
+        items=[{"query": "q", "expected_answer": "a", "expected_sources": []}],
+    )
+    eval_id = await db.create_evaluation(
+        dataset_id=ds_id,
+        collection="documents",
+        status="queued",
+    )
+    [item] = await db.create_evaluation_items(eval_id, (await db.get_dataset(ds_id))["items"], max_attempts=3)
+    claimed = await db.claim_evaluation_item(item["id"], worker_id="worker-1", lease_seconds=30)
+    assert claimed is not None
+    await db.mark_evaluation_item_failed(
+        item["id"], {"error_type": "TimeoutError", "retryable": False}
+    )
+
+    replayed = await db.requeue_failed_item_for_replay(item["id"])
+
+    assert replayed is not None
+    assert replayed["status"] == "queued"
+    assert replayed["attempt_count"] == 1
+    assert replayed["last_error"] == {"error_type": "TimeoutError", "retryable": False}
+    assert replayed["replay_count"] == 1
+    assert replayed["last_replayed_at"] is not None
+    assert replayed["lease_owner"] is None
+    assert replayed["lease_expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_requeue_failed_item_for_replay_rejects_completed_item(db):
+    ds_id = await db.create_dataset(
+        name="ds-no-replay-completed",
+        items=[{"query": "q", "expected_answer": "a", "expected_sources": []}],
+    )
+    eval_id = await db.create_evaluation(
+        dataset_id=ds_id,
+        collection="documents",
+        status="queued",
+    )
+    [item] = await db.create_evaluation_items(eval_id, (await db.get_dataset(ds_id))["items"], max_attempts=3)
+    await db.mark_evaluation_item_completed(
+        item["id"],
+        result={"query": "q", "answer": "a", "contexts": []},
+        scores={"faithfulness": 1.0},
+        score_reasons={},
+    )
+
+    replayed = await db.requeue_failed_item_for_replay(item["id"])
+
+    assert replayed is None
+```
+
+- [ ] **Step 2: Run DB replay tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_db.py::test_requeue_failed_item_for_replay_records_audit_state services/eval/tests/test_db.py::test_requeue_failed_item_for_replay_rejects_completed_item -v
+```
+
+Expected: fail because `requeue_failed_item_for_replay` and replay columns do not exist.
+
+- [ ] **Step 3: Add replay columns and row mapping**
+
+In `services/eval/app/db.py`, add columns to the `evaluation_items` table definition:
+
+```sql
+replay_count INTEGER NOT NULL DEFAULT 0,
+last_replayed_at TEXT,
+```
+
+Add idempotent migrations in `init()` after the existing `ALTER TABLE` statements:
+
+```python
+for column_ddl in (
+    "ALTER TABLE evaluation_items ADD COLUMN replay_count INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE evaluation_items ADD COLUMN last_replayed_at TEXT",
+):
+    try:
+        await self._db.execute(column_ddl)
+    except aiosqlite.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+```
+
+Add these fields to `_item_row_to_dict()`:
+
+```python
+"replay_count": row["replay_count"],
+"last_replayed_at": row["last_replayed_at"],
+```
+
+- [ ] **Step 4: Add failed-item replay reset helper**
+
+Add this method to `EvalDB` after `release_evaluation_item_for_retry`:
+
+```python
+async def requeue_failed_item_for_replay(self, item_id: str) -> dict | None:
+    now = datetime.now(_UTC).isoformat()
+    cursor = await self._db.execute(
+        "UPDATE evaluation_items "
+        "SET status = 'queued', lease_owner = NULL, lease_expires_at = NULL, "
+        "replay_count = replay_count + 1, last_replayed_at = ?, updated_at = ? "
+        "WHERE id = ? AND status = 'failed'",
+        (now, now, item_id),
+    )
+    await self._db.commit()
+    if cursor.rowcount == 0:
+        return None
+    return await self.get_evaluation_item(item_id)
+```
+
+- [ ] **Step 5: Run DB tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_db.py -v
+```
+
+Expected: all DB tests pass.
+
+- [ ] **Step 6: Commit DB replay metadata**
+
+```bash
+git add services/eval/app/db.py services/eval/tests/test_db.py
+git commit -m "feat(eval): record item replay metadata"
+```
+
+## Task 2: RabbitMQ DLQ Broker Primitives
+
+**Files:**
+- Modify: `services/eval/app/broker.py`
+- Test: `services/eval/tests/test_broker.py`
+
+- [ ] **Step 1: Add failing broker tests for safe DLQ parsing**
+
+Append to `services/eval/tests/test_broker.py`:
+
+```python
+from app.broker import (
+    DLQRoutingMetadata,
+    build_dlq_entry,
+    safe_x_death_metadata,
+)
+
+
+class FakeIncomingMessage:
+    def __init__(self, body, headers=None, redelivered=False, delivery_tag=7):
+        self.body = body
+        self.headers = headers or {}
+        self.redelivered = redelivered
+        self.delivery_tag = delivery_tag
+
+
+def test_build_dlq_entry_redacts_payload_to_identifiers():
+    message = FakeIncomingMessage(
+        body=json.dumps(
+            {
+                "message_version": 1,
+                "evaluation_id": "eval-1",
+                "item_id": "item-1",
+                "item_index": 2,
+                "attempt": 3,
+                "query": "secret query",
+                "expected_answer": "secret answer",
+            }
+        ).encode("utf-8"),
+        headers={
+            "x-death": [
+                {
+                    "count": 2,
+                    "reason": "rejected",
+                    "exchange": "",
+                    "routing-keys": ["eval.item.requested"],
+                }
+            ]
+        },
+    )
+
+    entry = build_dlq_entry(index=0, message=message, dlq_name="eval.item.requested.dlq")
+
+    assert entry.payload == {
+        "message_version": 1,
+        "evaluation_id": "eval-1",
+        "item_id": "item-1",
+        "item_index": 2,
+        "attempt": 3,
+    }
+    assert entry.invalid_payload is None
+    assert entry.routing == DLQRoutingMetadata(
+        exchange="",
+        routing_key="eval.item.requested",
+        queue="eval.item.requested.dlq",
+        death_count=2,
+        death_reason="rejected",
+    )
+    assert "secret query" not in json.dumps(entry.__dict__)
+    assert "secret answer" not in json.dumps(entry.__dict__)
+
+
+def test_build_dlq_entry_marks_invalid_payload_without_body_text():
+    entry = build_dlq_entry(
+        index=0,
+        message=FakeIncomingMessage(body=b"{not-json"),
+        dlq_name="eval.item.requested.dlq",
+    )
+
+    assert entry.payload is None
+    assert entry.invalid_payload == "invalid_json"
+    assert "{not-json" not in json.dumps(entry.__dict__)
+```
+
+- [ ] **Step 2: Run broker parsing tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_broker.py::test_build_dlq_entry_redacts_payload_to_identifiers services/eval/tests/test_broker.py::test_build_dlq_entry_marks_invalid_payload_without_body_text -v
+```
+
+Expected: fail because DLQ entry helpers do not exist.
+
+- [ ] **Step 3: Add safe DLQ dataclasses and parsing helpers**
+
+In `services/eval/app/broker.py`, add:
+
+```python
+@dataclass(frozen=True)
+class DLQRoutingMetadata:
+    exchange: str
+    routing_key: str
+    queue: str
+    death_count: int
+    death_reason: str
+
+
+@dataclass(frozen=True)
+class DLQEntry:
+    index: int
+    delivery_tag: str
+    redelivered: bool
+    payload: dict[str, Any] | None
+    routing: DLQRoutingMetadata
+    invalid_payload: str | None = None
+
+
+def safe_x_death_metadata(headers: dict[str, Any], dlq_name: str) -> DLQRoutingMetadata:
+    deaths = headers.get("x-death") or []
+    first = deaths[0] if deaths else {}
+    routing_keys = first.get("routing-keys") or []
+    routing_key = str(routing_keys[0]) if routing_keys else ""
+    return DLQRoutingMetadata(
+        exchange=str(first.get("exchange") or ""),
+        routing_key=routing_key,
+        queue=dlq_name,
+        death_count=int(first.get("count") or 0),
+        death_reason=str(first.get("reason") or ""),
+    )
+
+
+def _safe_payload_dict(decoded: EvalItemMessage) -> dict[str, Any]:
+    return {
+        "message_version": decoded.message_version,
+        "evaluation_id": decoded.evaluation_id,
+        "item_id": decoded.item_id,
+        "item_index": decoded.item_index,
+        "attempt": decoded.attempt,
+    }
+
+
+def build_dlq_entry(index: int, message: Any, dlq_name: str) -> DLQEntry:
+    routing = safe_x_death_metadata(getattr(message, "headers", {}) or {}, dlq_name)
+    try:
+        decoded = decode_eval_item_message(message.body)
+    except json.JSONDecodeError:
+        return DLQEntry(
+            index=index,
+            delivery_tag=str(getattr(message, "delivery_tag", "")),
+            redelivered=bool(getattr(message, "redelivered", False)),
+            payload=None,
+            routing=routing,
+            invalid_payload="invalid_json",
+        )
+    except (KeyError, TypeError, ValueError):
+        return DLQEntry(
+            index=index,
+            delivery_tag=str(getattr(message, "delivery_tag", "")),
+            redelivered=bool(getattr(message, "redelivered", False)),
+            payload=None,
+            routing=routing,
+            invalid_payload="invalid_schema",
+        )
+    return DLQEntry(
+        index=index,
+        delivery_tag=str(getattr(message, "delivery_tag", "")),
+        redelivered=bool(getattr(message, "redelivered", False)),
+        payload=_safe_payload_dict(decoded),
+        routing=routing,
+    )
+```
+
+- [ ] **Step 4: Add failing tests for peek and selected replay mechanics**
+
+Append to `services/eval/tests/test_broker.py`:
+
+```python
+import pytest
+
+from app.broker import EvalItemDLQClient
+
+
+class FakeQueue:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.calls = 0
+
+    async def get(self, fail=True, no_ack=False):
+        assert no_ack is False
+        if self.calls >= len(self.messages):
+            return None
+        message = self.messages[self.calls]
+        self.calls += 1
+        return message
+
+
+class AckableMessage(FakeIncomingMessage):
+    def __init__(self, body, headers=None):
+        super().__init__(body=body, headers=headers)
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nack(self, requeue=True):
+        assert requeue is True
+        self.nacked = True
+
+
+class FakeDLQClient(EvalItemDLQClient):
+    def __init__(self, queue):
+        self.dlq_name = "eval.item.requested.dlq"
+        self._queue = queue
+
+    async def _dlq_queue(self):
+        return self._queue
+
+
+@pytest.mark.asyncio
+async def test_list_peeks_and_requeues_messages():
+    body = encode_eval_item_message(
+        EvalItemMessage("eval-1", "item-1", 0, 3)
+    )
+    msg = AckableMessage(body=body)
+    client = FakeDLQClient(FakeQueue([msg]))
+
+    entries = await client.list(limit=10)
+
+    assert len(entries) == 1
+    assert entries[0].payload["item_id"] == "item-1"
+    assert msg.nacked is True
+    assert msg.acked is False
+
+
+@pytest.mark.asyncio
+async def test_take_by_item_id_acks_only_selected_message_and_requeues_others():
+    first = AckableMessage(
+        body=encode_eval_item_message(EvalItemMessage("eval-1", "item-1", 0, 3))
+    )
+    second = AckableMessage(
+        body=encode_eval_item_message(EvalItemMessage("eval-1", "item-2", 1, 3))
+    )
+    client = FakeDLQClient(FakeQueue([first, second]))
+
+    taken = await client.take(item_id="item-2", index=None, scan_limit=10)
+
+    assert taken is not None
+    assert taken.entry.payload["item_id"] == "item-2"
+    assert first.nacked is True
+    assert second.acked is True
+```
+
+- [ ] **Step 5: Implement DLQ client list and take**
+
+Add this class to `services/eval/app/broker.py`:
+
+```python
+@dataclass(frozen=True)
+class TakenDLQMessage:
+    entry: DLQEntry
+    message: Any
+
+
+class EvalItemDLQClient:
+    def __init__(self, rabbitmq_url: str, dlq_name: str):
+        self.rabbitmq_url = rabbitmq_url
+        self.dlq_name = dlq_name
+        self._conn: Any | None = None
+        self._channel: Any | None = None
+
+    async def connect(self) -> None:
+        import aio_pika
+
+        self._conn = await aio_pika.connect_robust(self.rabbitmq_url)
+        self._channel = await self._conn.channel()
+        await self._channel.declare_queue(self.dlq_name, durable=True)
+
+    async def _dlq_queue(self) -> Any:
+        if self._channel is None:
+            await self.connect()
+        assert self._channel is not None
+        return await self._channel.declare_queue(self.dlq_name, durable=True)
+
+    async def list(self, limit: int) -> list[DLQEntry]:
+        queue = await self._dlq_queue()
+        entries: list[DLQEntry] = []
+        messages: list[Any] = []
+        for index in range(limit):
+            message = await queue.get(fail=False, no_ack=False)
+            if message is None:
+                break
+            messages.append(message)
+            entries.append(build_dlq_entry(index, message, self.dlq_name))
+        for message in messages:
+            await message.nack(requeue=True)
+        return entries
+
+    async def take(
+        self, *, item_id: str | None, index: int | None, scan_limit: int
+    ) -> TakenDLQMessage | None:
+        queue = await self._dlq_queue()
+        for current_index in range(scan_limit):
+            message = await queue.get(fail=False, no_ack=False)
+            if message is None:
+                return None
+            entry = build_dlq_entry(current_index, message, self.dlq_name)
+            matches_index = index is not None and current_index == index
+            matches_item = (
+                item_id is not None
+                and entry.payload is not None
+                and entry.payload.get("item_id") == item_id
+            )
+            if matches_index or matches_item:
+                await message.ack()
+                return TakenDLQMessage(entry=entry, message=message)
+            await message.nack(requeue=True)
+        return None
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            await self._conn.close()
+```
+
+- [ ] **Step 6: Run broker tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_broker.py -v
+```
+
+Expected: all broker tests pass.
+
+- [ ] **Step 7: Commit broker DLQ primitives**
+
+```bash
+git add services/eval/app/broker.py services/eval/tests/test_broker.py
+git commit -m "feat(eval): add DLQ broker primitives"
+```
+
+## Task 3: Eval API DLQ Endpoints
+
+**Files:**
+- Modify: `services/eval/app/models.py`
+- Modify: `services/eval/app/main.py`
+- Modify: `services/eval/app/metrics.py`
+- Test: `services/eval/tests/test_main.py`
+
+- [ ] **Step 1: Add failing endpoint tests for operator-only access and listing redaction**
+
+Append to `services/eval/tests/test_main.py`:
+
+```python
+@patch("app.main.get_dlq_client")
+@patch("app.main.get_db")
+def test_list_eval_item_dlq_requires_operator(mock_get_db, mock_get_dlq_client):
+    response = client.get("/evaluations/items/dlq")
+
+    assert response.status_code == 403
+    mock_get_dlq_client.assert_not_called()
+
+
+@patch("app.main.get_dlq_client")
+@patch("app.main.get_db")
+def test_operator_lists_eval_item_dlq_with_safe_evidence(mock_get_db, mock_get_dlq_client):
+    mock_db = AsyncMock()
+    mock_db.get_evaluation_item.return_value = {
+        "id": "item-1",
+        "evaluation_id": "eval-1",
+        "item_index": 0,
+        "query": "secret query",
+        "expected_answer": "secret answer",
+        "expected_sources": [],
+        "status": "failed",
+        "attempt_count": 3,
+        "max_attempts": 3,
+        "last_error": {"error_type": "TimeoutError", "retryable": False},
+        "replay_count": 0,
+        "last_replayed_at": None,
+    }
+    mock_db.get_evaluation.return_value = {
+        "id": "eval-1",
+        "status": "completed_with_failures",
+        "collection": "documents",
+        "created_at": "2026-05-20T00:00:00+00:00",
+        "completed_at": "2026-05-20T00:01:00+00:00",
+    }
+    mock_get_db.return_value = mock_db
+    entry = MagicMock()
+    entry.index = 0
+    entry.delivery_tag = "7"
+    entry.redelivered = False
+    entry.payload = {
+        "message_version": 1,
+        "evaluation_id": "eval-1",
+        "item_id": "item-1",
+        "item_index": 0,
+        "attempt": 3,
+    }
+    entry.routing.__dict__ = {
+        "exchange": "",
+        "routing_key": "eval.item.requested",
+        "queue": "eval.item.requested.dlq",
+        "death_count": 1,
+        "death_reason": "rejected",
+    }
+    entry.invalid_payload = None
+    dlq_client = AsyncMock()
+    dlq_client.list.return_value = [entry]
+    mock_get_dlq_client.return_value = dlq_client
+
+    response = client.get(
+        "/evaluations/items/dlq",
+        headers={"Authorization": "Bearer operator-token"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    encoded = json.dumps(body)
+    assert body["entries"][0]["payload"]["item_id"] == "item-1"
+    assert body["entries"][0]["item"]["last_error"]["error_type"] == "TimeoutError"
+    assert body["indexes_are_transient"] is True
+    assert "secret query" not in encoded
+    assert "secret answer" not in encoded
+```
+
+In the test fixture setup, monkeypatch auth so `"operator-token"` resolves to `AuthContext(subject="op", email=None, tier="operator")`. Follow existing rate-limit fixture patterns in the file.
+
+- [ ] **Step 2: Run list endpoint tests and verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_main.py::test_list_eval_item_dlq_requires_operator services/eval/tests/test_main.py::test_operator_lists_eval_item_dlq_with_safe_evidence -v
+```
+
+Expected: fail because the endpoint and operator dependency do not exist.
+
+- [ ] **Step 3: Add Pydantic models**
+
+In `services/eval/app/models.py`, add:
+
+```python
+class DLQPayload(BaseModel):
+    message_version: int
+    evaluation_id: str
+    item_id: str
+    item_index: int
+    attempt: int
+
+
+class DLQRouting(BaseModel):
+    exchange: str
+    routing_key: str
+    queue: str
+    death_count: int
+    death_reason: str
+
+
+class DLQItemEvidence(BaseModel):
+    evaluation_id: str
+    item_id: str
+    item_index: int
+    status: str
+    attempt_count: int
+    max_attempts: int
+    last_error: dict[str, Any] | None = None
+    replay_count: int = 0
+    last_replayed_at: str | None = None
+
+
+class DLQEvaluationEvidence(BaseModel):
+    status: str
+    collection: str | None = None
+    created_at: str
+    completed_at: str | None = None
+
+
+class DLQEntryResponse(BaseModel):
+    index: int
+    delivery_tag: str
+    redelivered: bool
+    payload: DLQPayload | None = None
+    routing: DLQRouting
+    item: DLQItemEvidence | None = None
+    evaluation: DLQEvaluationEvidence | None = None
+    invalid_payload: str | None = None
+
+
+class DLQListResponse(BaseModel):
+    entries: list[DLQEntryResponse]
+    indexes_are_transient: bool = True
+
+
+class ReplayDLQItemRequest(BaseModel):
+    item_id: str | None = None
+    index: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def exactly_one_selector(self) -> "ReplayDLQItemRequest":
+        selectors = [self.item_id is not None, self.index is not None]
+        if selectors.count(True) != 1:
+            raise ValueError("provide exactly one of item_id or index")
+        return self
+
+
+class ReplayDLQItemResponse(BaseModel):
+    evaluation_id: str
+    item_id: str
+    item_index: int
+    status: str
+    replay_count: int
+    message_published: bool
+```
+
+- [ ] **Step 4: Add metrics and operator dependency**
+
+In `services/eval/app/metrics.py`, add:
+
+```python
+eval_item_dlq_inspections_total = Counter(
+    "eval_item_dlq_inspections_total",
+    "Evaluation item DLQ inspections by outcome",
+    ["outcome"],
+)
+
+eval_item_dlq_replays_total = Counter(
+    "eval_item_dlq_replays_total",
+    "Evaluation item DLQ replays by outcome",
+    ["outcome"],
+)
+```
+
+In `services/eval/app/main.py`, add:
+
+```python
+async def enforce_eval_operator(request: Request) -> AuthContext:
+    context = await _enforce_eval_rate_limit("eval_write", request)
+    if context.tier != "operator":
+        raise HTTPException(status_code=403, detail="operator access required")
+    return context
+```
+
+- [ ] **Step 5: Add DLQ client factory and safe evidence helper**
+
+In `services/eval/app/main.py`, import `EvalItemDLQClient` and add:
+
+```python
+_dlq_client: EvalItemDLQClient | None = None
+
+
+async def get_dlq_client() -> EvalItemDLQClient:
+    global _dlq_client
+    if _dlq_client is None:
+        if not settings.rabbitmq_url:
+            raise HTTPException(status_code=503, detail="eval queue is not configured")
+        _dlq_client = EvalItemDLQClient(
+            rabbitmq_url=settings.rabbitmq_url,
+            dlq_name=settings.eval_item_dlq,
+        )
+    return _dlq_client
+```
+
+Close `_dlq_client` in `shutdown()`.
+
+Add helper:
+
+```python
+async def _hydrate_dlq_entry(db: EvalDB, entry) -> dict:
+    payload = entry.payload
+    item_evidence = None
+    eval_evidence = None
+    if payload is not None:
+        item = await db.get_evaluation_item(payload["item_id"])
+        if item is not None:
+            item_evidence = {
+                "evaluation_id": item["evaluation_id"],
+                "item_id": item["id"],
+                "item_index": item["item_index"],
+                "status": item["status"],
+                "attempt_count": item["attempt_count"],
+                "max_attempts": item["max_attempts"],
+                "last_error": item["last_error"],
+                "replay_count": item.get("replay_count", 0),
+                "last_replayed_at": item.get("last_replayed_at"),
+            }
+        evaluation = await db.get_evaluation(payload["evaluation_id"])
+        if evaluation is not None:
+            eval_evidence = {
+                "status": evaluation["status"],
+                "collection": evaluation["collection"],
+                "created_at": evaluation["created_at"],
+                "completed_at": evaluation["completed_at"],
+            }
+    return {
+        "index": entry.index,
+        "delivery_tag": entry.delivery_tag,
+        "redelivered": entry.redelivered,
+        "payload": payload,
+        "routing": entry.routing.__dict__,
+        "item": item_evidence,
+        "evaluation": eval_evidence,
+        "invalid_payload": entry.invalid_payload,
+    }
+```
+
+- [ ] **Step 6: Add DLQ listing endpoint**
+
+In `services/eval/app/main.py`, add before `/evaluations/{eval_id}` routes so static path matching wins:
+
+```python
+@app.get(
+    "/evaluations/items/dlq",
+    response_model=DLQListResponse,
+    dependencies=[Depends(enforce_eval_operator)],
+)
+async def list_eval_item_dlq(request: Request, limit: int = 20):
+    bounded_limit = min(max(limit, 1), 200)
+    db = await get_db()
+    dlq = await get_dlq_client()
+    entries = await dlq.list(limit=bounded_limit)
+    outcome = "empty" if not entries else "success"
+    eval_item_dlq_inspections_total.labels(outcome=outcome).inc()
+    return {
+        "entries": [await _hydrate_dlq_entry(db, entry) for entry in entries],
+        "indexes_are_transient": True,
+    }
+```
+
+- [ ] **Step 7: Run list endpoint tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_main.py::test_list_eval_item_dlq_requires_operator services/eval/tests/test_main.py::test_operator_lists_eval_item_dlq_with_safe_evidence -v
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 8: Add failing replay endpoint tests**
+
+Append to `services/eval/tests/test_main.py`:
+
+```python
+@patch("app.main.publish_evaluation_items", new_callable=AsyncMock)
+@patch("app.main.get_dlq_client")
+@patch("app.main.get_db")
+def test_operator_replays_dlq_item_by_item_id(mock_get_db, mock_get_dlq_client, mock_publish):
+    mock_db = AsyncMock()
+    mock_db.get_evaluation_item.return_value = {"id": "item-1", "status": "failed"}
+    mock_db.requeue_failed_item_for_replay.return_value = {
+        "id": "item-1",
+        "evaluation_id": "eval-1",
+        "item_index": 0,
+        "status": "queued",
+        "attempt_count": 3,
+        "replay_count": 1,
+    }
+    mock_get_db.return_value = mock_db
+    entry = MagicMock()
+    entry.payload = {
+        "message_version": 1,
+        "evaluation_id": "eval-1",
+        "item_id": "item-1",
+        "item_index": 0,
+        "attempt": 3,
+    }
+    entry.routing.routing_key = "eval.item.requested"
+    dlq = AsyncMock()
+    dlq.take.return_value = MagicMock(entry=entry)
+    mock_get_dlq_client.return_value = dlq
+
+    response = client.post(
+        "/evaluations/items/dlq/replay",
+        json={"item_id": "item-1"},
+        headers={"Authorization": "Bearer operator-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["item_id"] == "item-1"
+    mock_db.requeue_failed_item_for_replay.assert_awaited_once_with("item-1")
+    mock_publish.assert_awaited_once_with(
+        "eval-1",
+        [{"id": "item-1", "item_index": 0, "attempt_count": 3}],
+    )
+
+
+@patch("app.main.get_dlq_client")
+@patch("app.main.get_db")
+def test_replay_rejects_non_failed_item(mock_get_db, mock_get_dlq_client):
+    mock_db = AsyncMock()
+    mock_db.get_evaluation_item.return_value = {"id": "item-1", "status": "completed"}
+    mock_get_db.return_value = mock_db
+    entry = MagicMock()
+    entry.payload = {
+        "message_version": 1,
+        "evaluation_id": "eval-1",
+        "item_id": "item-1",
+        "item_index": 0,
+        "attempt": 3,
+    }
+    dlq = AsyncMock()
+    dlq.take.return_value = MagicMock(entry=entry)
+    mock_get_dlq_client.return_value = dlq
+
+    response = client.post(
+        "/evaluations/items/dlq/replay",
+        json={"item_id": "item-1"},
+        headers={"Authorization": "Bearer operator-token"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "evaluation item is not failed"
+```
+
+- [ ] **Step 9: Implement replay endpoint**
+
+In `services/eval/app/main.py`, add:
+
+```python
+@app.post(
+    "/evaluations/items/dlq/replay",
+    response_model=ReplayDLQItemResponse,
+    dependencies=[Depends(enforce_eval_operator)],
+)
+async def replay_eval_item_dlq(request: Request, body: ReplayDLQItemRequest):
+    db = await get_db()
+    dlq = await get_dlq_client()
+    taken = await dlq.take(
+        item_id=body.item_id,
+        index=body.index,
+        scan_limit=200,
+    )
+    if taken is None:
+        eval_item_dlq_replays_total.labels(outcome="not_found").inc()
+        raise HTTPException(status_code=404, detail="DLQ message not found")
+    entry = taken.entry
+    if entry.payload is None:
+        eval_item_dlq_replays_total.labels(outcome="invalid_payload").inc()
+        raise HTTPException(status_code=400, detail="invalid DLQ payload")
+    item_id = entry.payload["item_id"]
+    item = await db.get_evaluation_item(item_id)
+    if item is None:
+        eval_item_dlq_replays_total.labels(outcome="not_found").inc()
+        raise HTTPException(status_code=404, detail="evaluation item not found")
+    if item["status"] != "failed":
+        eval_item_dlq_replays_total.labels(outcome="not_failed").inc()
+        raise HTTPException(status_code=409, detail="evaluation item is not failed")
+    replayed = await db.requeue_failed_item_for_replay(item_id)
+    if replayed is None:
+        eval_item_dlq_replays_total.labels(outcome="not_failed").inc()
+        raise HTTPException(status_code=409, detail="evaluation item is not failed")
+    try:
+        await publish_evaluation_items(
+            replayed["evaluation_id"],
+            [
+                {
+                    "id": replayed["id"],
+                    "item_index": replayed["item_index"],
+                    "attempt_count": replayed["attempt_count"],
+                }
+            ],
+        )
+    except Exception as exc:
+        eval_item_dlq_replays_total.labels(outcome="publish_failed").inc()
+        logger.warning(
+            "eval_item_dlq_replay_publish_failed eval_id=%s item_id=%s item_index=%s",
+            replayed["evaluation_id"],
+            replayed["id"],
+            replayed["item_index"],
+        )
+        raise HTTPException(status_code=503, detail="unable to publish replay") from exc
+    eval_item_dlq_replays_total.labels(outcome="success").inc()
+    logger.info(
+        "eval_item_dlq_replayed eval_id=%s item_id=%s item_index=%s selector=%s routing_key=%s",
+        replayed["evaluation_id"],
+        replayed["id"],
+        replayed["item_index"],
+        "item_id" if body.item_id is not None else "index",
+        entry.routing.routing_key,
+    )
+    return {
+        "evaluation_id": replayed["evaluation_id"],
+        "item_id": replayed["id"],
+        "item_index": replayed["item_index"],
+        "status": replayed["status"],
+        "replay_count": replayed["replay_count"],
+        "message_published": True,
+    }
+```
+
+Update `publish_evaluation_items` in the same file so replayed items publish the next explicit attempt value:
+
+```python
+attempt=item.get("attempt_count", 0) + 1
+```
+
+- [ ] **Step 10: Run endpoint tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests/test_main.py::test_operator_replays_dlq_item_by_item_id services/eval/tests/test_main.py::test_replay_rejects_non_failed_item -v
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 11: Run Python eval service tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests -v
+```
+
+Expected: all eval service tests pass.
+
+- [ ] **Step 12: Commit eval API DLQ endpoints**
+
+```bash
+git add services/eval/app/main.py services/eval/app/metrics.py services/eval/app/models.py services/eval/tests/test_main.py
+git commit -m "feat(eval): expose item DLQ triage replay API"
+```
+
+## Task 4: Go Eval API Client Methods
+
+**Files:**
+- Modify: `go/eval-mcp-service/internal/evalapi/client.go`
+- Test: `go/eval-mcp-service/internal/evalapi/client_test.go`
+
+- [ ] **Step 1: Add failing client tests**
+
+Append to `go/eval-mcp-service/internal/evalapi/client_test.go`:
+
+```go
+func TestListEvalItemDLQ(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/evaluations/items/dlq" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("limit") != "5" {
+			t.Fatalf("limit = %q", r.URL.Query().Get("limit"))
+		}
+		_ = json.NewEncoder(w).Encode(DLQListResponse{
+			IndexesAreTransient: true,
+			Entries: []DLQEntry{{
+				Index: 0,
+				Payload: &DLQPayload{
+					MessageVersion: 1,
+					EvaluationID:   "eval-1",
+					ItemID:         "item-1",
+					ItemIndex:      0,
+					Attempt:        3,
+				},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.URL, "", server.Client())
+	got, err := client.ListEvalItemDLQ(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListEvalItemDLQ error: %v", err)
+	}
+	if len(got.Entries) != 1 || got.Entries[0].Payload.ItemID != "item-1" || !got.IndexesAreTransient {
+		t.Fatalf("response = %#v", got)
+	}
+}
+
+func TestReplayEvalItemDLQByItemID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/evaluations/items/dlq/replay" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body ReplayDLQItemRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.ItemID != "item-1" || body.Index != nil {
+			t.Fatalf("body = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(ReplayDLQItemResponse{
+			EvaluationID:      "eval-1",
+			ItemID:            "item-1",
+			ItemIndex:         0,
+			Status:            "queued",
+			ReplayCount:       1,
+			MessagePublished:  true,
+		})
+	}))
+	defer server.Close()
+
+	client := New(server.URL, "", server.Client())
+	got, err := client.ReplayEvalItemDLQ(context.Background(), ReplayDLQItemRequest{ItemID: "item-1"})
+	if err != nil {
+		t.Fatalf("ReplayEvalItemDLQ error: %v", err)
+	}
+	if got.ItemID != "item-1" || !got.MessagePublished {
+		t.Fatalf("response = %#v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run client tests and verify they fail**
+
+Run:
+
+```bash
+cd go/eval-mcp-service && go test ./internal/evalapi -run 'Test(ListEvalItemDLQ|ReplayEvalItemDLQByItemID)' -v
+```
+
+Expected: fail because DTOs and methods do not exist.
+
+- [ ] **Step 3: Add Go DTOs and client methods**
+
+In `go/eval-mcp-service/internal/evalapi/client.go`, add structs near the other DTOs:
+
+```go
+type DLQPayload struct {
+	MessageVersion int    `json:"message_version"`
+	EvaluationID   string `json:"evaluation_id"`
+	ItemID         string `json:"item_id"`
+	ItemIndex      int    `json:"item_index"`
+	Attempt        int    `json:"attempt"`
+}
+
+type DLQRouting struct {
+	Exchange    string `json:"exchange"`
+	RoutingKey  string `json:"routing_key"`
+	Queue       string `json:"queue"`
+	DeathCount  int    `json:"death_count"`
+	DeathReason string `json:"death_reason"`
+}
+
+type DLQItemEvidence struct {
+	EvaluationID   string         `json:"evaluation_id"`
+	ItemID         string         `json:"item_id"`
+	ItemIndex      int            `json:"item_index"`
+	Status         string         `json:"status"`
+	AttemptCount   int            `json:"attempt_count"`
+	MaxAttempts    int            `json:"max_attempts"`
+	LastError      map[string]any `json:"last_error"`
+	ReplayCount    int            `json:"replay_count"`
+	LastReplayedAt *string        `json:"last_replayed_at"`
+}
+
+type DLQEvaluationEvidence struct {
+	Status      string  `json:"status"`
+	Collection *string `json:"collection"`
+	CreatedAt   string  `json:"created_at"`
+	CompletedAt *string `json:"completed_at"`
+}
+
+type DLQEntry struct {
+	Index          int                    `json:"index"`
+	DeliveryTag    string                 `json:"delivery_tag"`
+	Redelivered    bool                   `json:"redelivered"`
+	Payload        *DLQPayload            `json:"payload"`
+	Routing        DLQRouting             `json:"routing"`
+	Item           *DLQItemEvidence       `json:"item"`
+	Evaluation     *DLQEvaluationEvidence `json:"evaluation"`
+	InvalidPayload *string                `json:"invalid_payload"`
+}
+
+type DLQListResponse struct {
+	Entries             []DLQEntry `json:"entries"`
+	IndexesAreTransient bool       `json:"indexes_are_transient"`
+}
+
+type ReplayDLQItemRequest struct {
+	ItemID string `json:"item_id,omitempty"`
+	Index  *int   `json:"index,omitempty"`
+}
+
+type ReplayDLQItemResponse struct {
+	EvaluationID     string `json:"evaluation_id"`
+	ItemID           string `json:"item_id"`
+	ItemIndex        int    `json:"item_index"`
+	Status           string `json:"status"`
+	ReplayCount      int    `json:"replay_count"`
+	MessagePublished bool   `json:"message_published"`
+}
+```
+
+Add methods:
+
+```go
+func (c *Client) ListEvalItemDLQ(ctx context.Context, limit int) (DLQListResponse, error) {
+	values := url.Values{}
+	if limit > 0 {
+		values.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	path := "/evaluations/items/dlq"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var response DLQListResponse
+	if err := c.do(ctx, http.MethodGet, path, nil, &response); err != nil {
+		return DLQListResponse{}, err
+	}
+	return response, nil
+}
+
+func (c *Client) ReplayEvalItemDLQ(ctx context.Context, body ReplayDLQItemRequest) (ReplayDLQItemResponse, error) {
+	var response ReplayDLQItemResponse
+	if err := c.do(ctx, http.MethodPost, "/evaluations/items/dlq/replay", body, &response); err != nil {
+		return ReplayDLQItemResponse{}, err
+	}
+	return response, nil
+}
+```
+
+- [ ] **Step 4: Run eval API client tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service && go test ./internal/evalapi -v
+```
+
+Expected: all eval API client tests pass.
+
+- [ ] **Step 5: Commit Go eval API client**
+
+```bash
+git add go/eval-mcp-service/internal/evalapi/client.go go/eval-mcp-service/internal/evalapi/client_test.go
+git commit -m "feat(eval-mcp): add DLQ eval API client"
+```
+
+## Task 5: Go Workflow And MCP Tools
+
+**Files:**
+- Modify: `go/eval-mcp-service/internal/evalworkflow/service.go`
+- Modify: `go/eval-mcp-service/internal/evalworkflow/service_test.go`
+- Modify: `go/eval-mcp-service/internal/mcpserver/server.go`
+- Modify: `go/eval-mcp-service/internal/mcpserver/server_test.go`
+
+- [ ] **Step 1: Add failing workflow tests**
+
+In `go/eval-mcp-service/internal/evalworkflow/service_test.go`, extend `fakeAPI` with:
+
+```go
+dlqListRequestLimit int
+dlqListResponse     evalapi.DLQListResponse
+dlqReplayRequest    evalapi.ReplayDLQItemRequest
+dlqReplayResponse   evalapi.ReplayDLQItemResponse
+```
+
+Add methods:
+
+```go
+func (f *fakeAPI) ListEvalItemDLQ(_ context.Context, limit int) (evalapi.DLQListResponse, error) {
+	f.dlqListRequestLimit = limit
+	return f.dlqListResponse, nil
+}
+
+func (f *fakeAPI) ReplayEvalItemDLQ(_ context.Context, in evalapi.ReplayDLQItemRequest) (evalapi.ReplayDLQItemResponse, error) {
+	f.dlqReplayRequest = in
+	return f.dlqReplayResponse, nil
+}
+```
+
+Add tests:
+
+```go
+func TestListEvalItemDLQDelegatesToAPI(t *testing.T) {
+	api := &fakeAPI{dlqListResponse: evalapi.DLQListResponse{IndexesAreTransient: true}}
+	svc := New(api, nil, nil, time.Second, time.Minute)
+
+	got, err := svc.ListEvalItemDLQ(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ListEvalItemDLQ error: %v", err)
+	}
+	if api.dlqListRequestLimit != 7 || !got.IndexesAreTransient {
+		t.Fatalf("limit=%d response=%#v", api.dlqListRequestLimit, got)
+	}
+}
+
+func TestReplayEvalItemDLQDelegatesToAPI(t *testing.T) {
+	api := &fakeAPI{dlqReplayResponse: evalapi.ReplayDLQItemResponse{ItemID: "item-1", MessagePublished: true}}
+	svc := New(api, nil, nil, time.Second, time.Minute)
+
+	got, err := svc.ReplayEvalItemDLQ(context.Background(), evalapi.ReplayDLQItemRequest{ItemID: "item-1"})
+	if err != nil {
+		t.Fatalf("ReplayEvalItemDLQ error: %v", err)
+	}
+	if api.dlqReplayRequest.ItemID != "item-1" || !got.MessagePublished {
+		t.Fatalf("request=%#v response=%#v", api.dlqReplayRequest, got)
+	}
+}
+```
+
+- [ ] **Step 2: Update workflow API interface and methods**
+
+In `go/eval-mcp-service/internal/evalworkflow/service.go`, add to the eval API interface:
+
+```go
+ListEvalItemDLQ(context.Context, int) (evalapi.DLQListResponse, error)
+ReplayEvalItemDLQ(context.Context, evalapi.ReplayDLQItemRequest) (evalapi.ReplayDLQItemResponse, error)
+```
+
+Add service methods:
+
+```go
+func (s *Service) ListEvalItemDLQ(ctx context.Context, limit int) (evalapi.DLQListResponse, error) {
+	return s.api.ListEvalItemDLQ(ctx, limit)
+}
+
+func (s *Service) ReplayEvalItemDLQ(ctx context.Context, in evalapi.ReplayDLQItemRequest) (evalapi.ReplayDLQItemResponse, error) {
+	return s.api.ReplayEvalItemDLQ(ctx, in)
+}
+```
+
+- [ ] **Step 3: Run workflow tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service && go test ./internal/evalworkflow -run 'Test(ListEvalItemDLQDelegatesToAPI|ReplayEvalItemDLQDelegatesToAPI)' -v
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 4: Add failing MCP server validation tests**
+
+In `go/eval-mcp-service/internal/mcpserver/server_test.go`, extend `fakeEvalService` with:
+
+```go
+listDLQLimit      int
+listDLQResponse   evalapi.DLQListResponse
+replayDLQRequest  evalapi.ReplayDLQItemRequest
+replayDLQResponse evalapi.ReplayDLQItemResponse
+```
+
+Add methods to `fakeEvalService`:
+
+```go
+func (f *fakeEvalService) ListEvalItemDLQ(_ context.Context, limit int) (evalapi.DLQListResponse, error) {
+	f.listDLQLimit = limit
+	return f.listDLQResponse, nil
+}
+
+func (f *fakeEvalService) ReplayEvalItemDLQ(_ context.Context, in evalapi.ReplayDLQItemRequest) (evalapi.ReplayDLQItemResponse, error) {
+	f.replayDLQRequest = in
+	return f.replayDLQResponse, nil
+}
+```
+
+Update `TestServerRegistersPromptResourceAndTools` expected tool names to include the new tools in sorted order:
+
+```go
+wantTools := []string{
+	"attach_eval_run",
+	"compare_eval_runs",
+	"create_eval_dataset",
+	"get_eval_experiment",
+	"get_eval_run",
+	"get_eval_run_evidence",
+	"get_rag_collection_config",
+	"get_worst_eval_cases",
+	"list_eval_dataset_fixtures",
+	"list_eval_datasets",
+	"list_eval_experiments",
+	"list_eval_item_dlq",
+	"list_rag_collections",
+	"record_eval_experiment_conclusion",
+	"replay_eval_item_dlq",
+	"start_eval_experiment",
+	"start_eval_run",
+	"summarize_eval_experiment",
+	"triage_rag_regression",
+	"wait_for_eval_run",
+}
+```
+
+Add these handler tests:
+
+```go
+func TestReplayEvalItemDLQRejectsMissingSelector(t *testing.T) {
+	service := &fakeEvalService{}
+	result, err := replayEvalItemDLQHandler(service)(context.Background(), callReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatalf("expected MCP tool error")
+	}
+	if got := textResult(t, result); !strings.Contains(got, "provide exactly one of item_id or index") {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestReplayEvalItemDLQRejectsBothSelectors(t *testing.T) {
+	service := &fakeEvalService{}
+	result, err := replayEvalItemDLQHandler(service)(context.Background(), callReq(map[string]any{
+		"item_id": "item-1",
+		"index": 0,
+	}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+
+	if !result.IsError {
+		t.Fatalf("expected MCP tool error")
+	}
+	if got := textResult(t, result); !strings.Contains(got, "provide exactly one of item_id or index") {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestReplayEvalItemDLQCallsServiceByItemID(t *testing.T) {
+	service := &fakeEvalService{
+		replayDLQResponse: evalapi.ReplayDLQItemResponse{ItemID: "item-1", MessagePublished: true},
+	}
+	result, err := replayEvalItemDLQHandler(service)(context.Background(), callReq(map[string]any{
+		"item_id": "item-1",
+	}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handler returned MCP error: %#v", result)
+	}
+
+	if service.replayDLQRequest.ItemID != "item-1" || !strings.Contains(textResult(t, result), "item-1") {
+		t.Fatalf("request=%#v result=%#v", service.replayDLQRequest, result)
+	}
+}
+```
+
+- [ ] **Step 5: Register MCP interface methods and tools**
+
+In `go/eval-mcp-service/internal/mcpserver/server.go`, add to `EvalService`:
+
+```go
+ListEvalItemDLQ(context.Context, int) (evalapi.DLQListResponse, error)
+ReplayEvalItemDLQ(context.Context, evalapi.ReplayDLQItemRequest) (evalapi.ReplayDLQItemResponse, error)
+```
+
+In `New()`, register tools:
+
+```go
+addTool(srv, "list_eval_item_dlq", "List eval item DLQ messages without removing them.", listEvalItemDLQSchema(), listEvalItemDLQHandler(service))
+addTool(srv, "replay_eval_item_dlq", "Explicitly replay one selected eval item DLQ message. This is mutating.", replayEvalItemDLQSchema(), replayEvalItemDLQHandler(service))
+```
+
+Add schemas:
+
+```go
+func listEvalItemDLQSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{"limit":{"type":"integer","minimum":1,"maximum":200}},
+		"additionalProperties":false
+	}`)
+}
+
+func replayEvalItemDLQSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"item_id":{"type":"string","minLength":1},
+			"index":{"type":"integer","minimum":0}
+		},
+		"additionalProperties":false
+	}`)
+}
+```
+
+Add handlers:
+
+```go
+func listEvalItemDLQHandler(service EvalService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args struct {
+			Limit int `json:"limit,omitempty"`
+		}
+		if err := decodeArgs(req, &args); err != nil {
+			return toolError(err.Error()), nil
+		}
+		result, err := service.ListEvalItemDLQ(ctx, args.Limit)
+		return resultOrError(result, err), nil
+	}
+}
+
+func replayEvalItemDLQHandler(service EvalService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args struct {
+			ItemID string `json:"item_id,omitempty"`
+			Index  *int   `json:"index,omitempty"`
+		}
+		if err := decodeArgs(req, &args); err != nil {
+			return toolError(err.Error()), nil
+		}
+		hasItemID := strings.TrimSpace(args.ItemID) != ""
+		hasIndex := args.Index != nil
+		if hasItemID == hasIndex {
+			return toolError("provide exactly one of item_id or index"), nil
+		}
+		result, err := service.ReplayEvalItemDLQ(ctx, evalapi.ReplayDLQItemRequest{
+			ItemID: strings.TrimSpace(args.ItemID),
+			Index:  args.Index,
+		})
+		return resultOrError(result, err), nil
+	}
+}
+```
+
+- [ ] **Step 6: Run MCP service tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service && go test ./internal/evalworkflow ./internal/mcpserver -v
+```
+
+Expected: workflow and MCP server tests pass.
+
+- [ ] **Step 7: Commit MCP tools**
+
+```bash
+git add go/eval-mcp-service/internal/evalworkflow/service.go go/eval-mcp-service/internal/evalworkflow/service_test.go go/eval-mcp-service/internal/mcpserver/server.go go/eval-mcp-service/internal/mcpserver/server_test.go
+git commit -m "feat(eval-mcp): expose eval item DLQ tools"
+```
+
+## Task 6: Final Verification
+
+**Files:**
+- Verify all changed files from previous tasks.
+
+- [ ] **Step 1: Run targeted Python tests**
+
+Run:
+
+```bash
+PYTHONPATH=services pytest services/eval/tests -v
+```
+
+Expected: all eval Python tests pass.
+
+- [ ] **Step 2: Run targeted Go tests**
+
+Run:
+
+```bash
+cd go/eval-mcp-service && go test ./... -v
+```
+
+Expected: all eval MCP Go tests pass.
+
+- [ ] **Step 3: Run required preflights before final commit or PR**
+
+Run from repo root:
+
+```bash
+make preflight-python
+make preflight-go
+make preflight-security
+```
+
+Expected: all required preflights pass. If a preflight is blocked by a local tool or platform issue, capture the exact error and leave that verification to CI.
+
+- [ ] **Step 4: Review redaction and payload safety**
+
+Run:
+
+```bash
+rg -n "query|expected_answer|answer|contexts|api_key|secret" services/eval/app/broker.py services/eval/app/main.py go/eval-mcp-service/internal
+```
+
+Expected: matches are either existing eval result code or explicit redaction/validation code. DLQ list/replay response types and logs must not include raw query text, expected answers, generated answers, contexts, API keys, secret names, or model secret values.
+
+- [ ] **Step 5: Check git status and recent commits**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected: only intended changes are present, and task commits are visible.

--- a/docs/superpowers/specs/2026-05-20-observability-mcp-management-actions-design.md
+++ b/docs/superpowers/specs/2026-05-20-observability-mcp-management-actions-design.md
@@ -1,0 +1,288 @@
+# Observability MCP Management Actions Design
+
+## Summary
+
+Issue 251 adds an opt-in management-action layer to the Observability MCP. The
+goal is agent-autonomous operations without free-form mutation: agents may run
+cataloged, low-risk operational procedures, but every shared-environment write
+must still route through committed ops-as-code artifacts.
+
+The MCP should not become a general shell, Kubernetes client, Grafana write
+client, or arbitrary script launcher. It should expose typed, auditable actions
+whose commands, inputs, risk tier, timeouts, redaction rules, and verification
+expectations are reviewed as code.
+
+## Goals
+
+- Allow agents to autonomously execute low-risk, cataloged operational actions.
+- Preserve ops-as-code: every mutation must be backed by committed repo code.
+- Keep management actions disabled by default so the current read-only contract
+  remains the safe default.
+- Record previews, blocked decisions, executions, failures, and completions in
+  local incident history when history is enabled.
+- Return structured, bounded evidence that lets an agent continue triage after
+  an action runs or is blocked.
+- Start with already-committed low-risk procedures such as Grafana alerting
+  reload and manual Postgres backup verification.
+
+## Non-Goals
+
+- No free-form shell, kubectl arguments, Grafana mutation API, SSH command
+  strings, arbitrary URLs, or arbitrary script paths.
+- No web UI for approving actions.
+- No requirement that Kyle approve every low-risk action before execution.
+- No high-risk execution by default.
+- No persistent server-side queue. The local stdio MCP can execute an action
+  synchronously with timeout-bounded output.
+- No replacement for existing read-only evidence tools.
+
+## Current Context
+
+`go/observability-mcp-service` is a local stdio MCP. It gathers bounded evidence
+from Prometheus, Loki, Jaeger, Grafana alert metadata, embedded runbooks, and
+local SQLite incident history.
+
+The README currently states that the service is read-only and does not silence
+alerts, restart workloads, run ops commands, or mutate external systems. This
+design intentionally changes that only behind explicit opt-in configuration and
+only for committed, cataloged actions.
+
+The `ops-as-code` rule still applies: no mutating action runs against a shared
+environment unless its exact behavior exists as committed code in this repo.
+Existing examples live under `scripts/ops/`, including:
+
+- `scripts/ops/2026-05-09-reload-grafana-alerting.sh`
+- `scripts/ops/2026-05-15-run-postgres-backup-verify.sh`
+- `scripts/ops/check-postboot-health.sh`
+
+## Design
+
+### Action Catalog
+
+Add a management action catalog. The first implementation should use Go code for
+type safety and straightforward unit tests. A file-backed YAML catalog can be
+added later if non-Go editing becomes valuable.
+
+Each action declares:
+
+- `id`
+- `title`
+- `description`
+- `risk_tier`
+- `script_path`
+- `allowed_args`
+- `timeout`
+- `requires_incident`
+- `idempotent`
+- `preflight` summary
+- `postflight` summary
+- `redaction` rules
+- `next_steps` or rollback guidance
+
+Initial risk tiers:
+
+- `diagnostic`: read-only or check-only procedures.
+- `low_risk_mutation`: bounded, idempotent committed procedures that may run
+  autonomously after management actions are enabled.
+- `high_risk_mutation`: destructive, broad, data-owning, or public-impacting
+  procedures. These are preview-only unless a separate high-risk opt-in flag is
+  set.
+
+Initial catalog candidates:
+
+- `reload_grafana_alerting`: low-risk mutation backed by the existing Grafana
+  alerting reload script.
+- `run_postgres_backup_verify`: low-risk mutation backed by the existing manual
+  backup verification script.
+- `check_postboot_health`: diagnostic only after implementation verifies that
+  the existing script performs no shared-environment mutation. If it mutates
+  runtime state, leave it out of the initial catalog.
+
+Catalog validation should reject duplicate IDs, empty descriptions, invalid
+risk tiers, missing or absolute script paths, paths outside the repo, timeout
+values outside a bounded range, unknown argument types, and catalog entries
+whose scripts do not exist.
+
+### Policy
+
+Add a policy evaluator that returns one of:
+
+- `allow`
+- `block`
+- `preview_only`
+
+Default behavior:
+
+- All management execution is disabled unless
+  `OBS_MANAGEMENT_ACTIONS_ENABLED=true`.
+- `diagnostic` actions can run when management actions are enabled.
+- `low_risk_mutation` actions can run when management actions are enabled.
+- `high_risk_mutation` actions return preview-only unless
+  `OBS_MANAGEMENT_ALLOW_HIGH_RISK=true`.
+
+A blocked result should not look like an execution failure. It should report the
+action ID, risk tier, decision, policy reason, and what configuration would be
+required to proceed.
+
+### Runner
+
+Add a runner that executes only catalog entries from the repo root.
+
+Runner constraints:
+
+- No public API accepts shell fragments, kubectl args, SSH commands, or script
+  paths.
+- The command shape is fixed by the catalog. For no-argument actions, it is
+  equivalent to `bash scripts/ops/<name>.sh`.
+- Inputs must match catalog-declared arguments and must be converted without
+  shell interpolation.
+- The runner uses context deadlines and kills timed-out actions.
+- Stdout and stderr are bounded before returning or storing.
+- Output is redacted before it leaves the runner.
+- Missing scripts, path traversal, non-executable paths where required, timeout,
+  and nonzero exits produce structured results.
+
+The runner should not try to infer success from arbitrary output. Catalog
+entries should state what postflight evidence or verification the script itself
+performs. The first cataloged scripts already include their own checks and
+nonzero exit behavior.
+
+### MCP Tools
+
+Add these tools:
+
+- `list_management_actions`
+- `preview_management_action`
+- `execute_management_action`
+- `get_management_action_history`
+
+`list_management_actions` returns the catalog, excluding internal implementation
+details and sensitive redaction patterns.
+
+`preview_management_action` validates inputs and returns the policy decision,
+fixed script path, risk tier, timeout, preflight summary, postflight summary,
+and expected result shape. It never executes the script.
+
+`execute_management_action` validates inputs, evaluates policy, records the
+decision when possible, runs allowed actions, bounds and redacts output, records
+the final result when possible, and returns a structured result.
+
+`get_management_action_history` returns recent action events, optionally filtered
+by `incident_key`, `action_id`, and decision/status.
+
+### Result Shape
+
+Action results should include:
+
+- `action_id`
+- `risk_tier`
+- `decision`
+- `status`
+- `script_path`
+- `incident_key`
+- `started_at`
+- `completed_at`
+- `duration_ms`
+- `exit_code`
+- bounded `stdout`
+- bounded `stderr`
+- `output_truncated`
+- `redactions_applied`
+- `policy_reason`
+- `history_event_ids`
+- `warning`
+
+The result status vocabulary should distinguish policy and execution outcomes:
+
+- `previewed`
+- `blocked`
+- `running`
+- `succeeded`
+- `failed`
+- `timed_out`
+
+### History Integration
+
+Extend the existing local SQLite history store with management action events.
+Suggested event types:
+
+- `management_action_previewed`
+- `management_action_started`
+- `management_action_completed`
+- `management_action_failed`
+- `management_action_blocked`
+
+When `incident_key` is provided, action events should attach to that incident
+timeline. If the incident does not exist, the tool should create it only when
+`incident_title` is also provided; otherwise it should return a structured
+validation error before execution. This avoids orphaned action history with
+empty incident metadata.
+
+When history is disabled, action execution can still run. The result should
+include a warning that no local audit record was persisted.
+
+### Configuration
+
+Add these environment variables:
+
+- `OBS_MANAGEMENT_ACTIONS_ENABLED`: default `false`.
+- `OBS_MANAGEMENT_ALLOW_HIGH_RISK`: default `false`.
+- `OBS_MANAGEMENT_ACTION_TIMEOUT`: optional global maximum timeout.
+- `OBS_MANAGEMENT_MAX_OUTPUT_BYTES`: bounded output cap with a conservative
+  default.
+
+The README should be updated to state that the MCP is read-only by default, and
+that management actions are opt-in, cataloged, and ops-as-code only.
+
+## Error Handling
+
+Unknown action IDs, disabled management actions, high-risk actions without
+explicit enablement, invalid arguments, missing scripts, invalid catalog
+metadata, timeouts, and nonzero exits should all return structured responses.
+
+Blocked actions are policy decisions, not execution failures.
+
+Execution failures should include bounded stdout, bounded stderr, exit code,
+duration, and catalog-declared next steps. Secret-looking values and
+catalog-declared sensitive fields must be redacted before output is returned or
+stored.
+
+If history persistence fails, the action result should include a warning. A
+history write failure should not hide the execution result.
+
+## Testing
+
+Add unit tests for:
+
+- Catalog validation: IDs, paths, risk tiers, duplicate IDs, timeout bounds, and
+  missing scripts.
+- Policy matrix: disabled, diagnostic, low-risk, high-risk with and without
+  high-risk opt-in.
+- Runner behavior: fixed paths only, unknown args rejected, timeout handling,
+  nonzero exits, output bounds, and redaction.
+- MCP handlers: list, preview, execute, history, blocked vs failed behavior.
+- History persistence: action timeline events attach to incidents and can be
+  queried.
+- README/config documentation: management actions are opt-in and cataloged, not
+  free-form mutation.
+
+Before committing implementation, run:
+
+```bash
+make preflight-go
+```
+
+## Acceptance Criteria
+
+- Existing read-only tools keep working with management actions disabled by
+  default.
+- Agents can autonomously run low-risk cataloged ops procedures after opt-in.
+- High-risk actions are preview-only unless explicitly enabled.
+- No free-form shell, kubectl, Grafana mutation, SSH command, or arbitrary
+  script path is exposed.
+- Every executed action returns a structured result.
+- When history is enabled, management action events are persisted on the
+  incident timeline.
+- The initial catalog includes only already-committed low-risk or diagnostic
+  procedures.
+- Documentation clearly explains the agent-autonomous ops-as-code model.

--- a/docs/superpowers/specs/2026-05-20-rag-eval-cancellation-stale-recovery-design.md
+++ b/docs/superpowers/specs/2026-05-20-rag-eval-cancellation-stale-recovery-design.md
@@ -1,0 +1,205 @@
+# RAG Eval Cancellation And Stale Recovery Design
+
+## Goal
+
+Add explicit cancellation and stronger stale work recovery to the RabbitMQ-backed
+RAG eval item worker.
+
+The system should let operators cancel queued or running evals, stop cancelled
+item work safely, preserve retryable stale item work, repair terminal run
+aggregation when item rows already contain the truth, and expose evidence that
+distinguishes stale, cancelled, failed, and retryable states.
+
+## Context
+
+`services/eval` already uses durable evaluation item rows and RabbitMQ messages
+for item-level RAG eval work. The eval API creates a queued run and item rows,
+publishes one message per item, and the worker claims item leases before running
+search, chat, judge scoring, and local metrics for one dataset item.
+
+The current implementation has the right base ownership model, but cancellation
+and recovery are still incomplete:
+
+- There is no explicit cancel endpoint or `cancelled` item state.
+- The worker claims items before checking whether the parent run is already
+  terminal or cancelled.
+- Startup recovery resets expired item leases but does not republish reset work.
+- Startup recovery can still fail stale running runs wholesale, even when item
+  work remains retryable.
+- MCP run evidence reports stale running runs, but does not clearly distinguish
+  queued stale, cancelled, failed, and retryable item states.
+
+## Recommended Approach
+
+Use cooperative cancellation at item boundaries and before expensive stages.
+
+Cancellation should be durable in the eval database. RabbitMQ remains a work
+transport only; duplicate or stale messages are safe because item rows and parent
+run status remain the source of truth. The worker should not try to interrupt an
+already in-flight HTTP or LLM request in this slice. Existing upstream timeouts
+bound that work. The worker should check cancellation before starting the next
+expensive call and stop there.
+
+This keeps the first cancellation slice deterministic and testable while still
+preventing new expensive work after an operator cancels a run.
+
+## Run And Item State
+
+Add `cancelled` as a terminal status for both evaluations and evaluation items.
+
+Terminal evaluation statuses become:
+
+- `completed`
+- `completed_with_failures`
+- `failed`
+- `cancelled`
+
+Terminal item statuses become:
+
+- `completed`
+- `failed`
+- `cancelled`
+
+Operator cancellation wins over partial completion. If a run is marked
+`cancelled`, later aggregation or repair should not convert it to
+`completed_with_failures` because some items completed before the cancellation.
+
+## Cancellation API
+
+Add `POST /evaluations/{eval_id}/cancel`.
+
+The endpoint should:
+
+1. Return `404` when the run does not exist.
+2. Return `409` when the run is already terminal: `completed`,
+   `completed_with_failures`, `failed`, or `cancelled`.
+3. For `queued` or `running`, mark the evaluation `cancelled`, set
+   `completed_at`, and store a bounded reason such as
+   `evaluation cancelled by operator`.
+4. Mark all non-terminal items for the run as `cancelled`.
+5. Clear cancelled item lease fields.
+6. Return the updated evaluation detail, including item counts.
+
+Do not require a cancellation reason in the first slice. It can be added later
+without changing the core state model.
+
+## Worker Behavior
+
+The worker should check cancellation before it starts or continues expensive
+work.
+
+Before claiming an item:
+
+1. Load the parent evaluation by `evaluation_id`.
+2. If the evaluation is missing, keep the existing permanent failure behavior.
+3. If the evaluation status is `cancelled`, mark the item `cancelled` if it is
+   still non-terminal and ack the message.
+
+After claiming an item:
+
+1. Re-check the parent evaluation status.
+2. If it is `cancelled`, mark the claimed item `cancelled`, clear its lease, and
+   ack the message.
+3. If it is still `queued`, mark the parent evaluation `running`.
+
+Before expensive stages:
+
+1. Check cancellation before search.
+2. Check cancellation before chat.
+3. Check cancellation before judge scoring.
+
+If cancellation is observed at any of those boundaries, the item should be
+marked `cancelled` and the message should be acked. A cancelled item should not
+be retried, marked failed, or rejected to the DLQ.
+
+The worker should not cancel an already in-flight upstream request in this
+design. That can be a later enhancement if single upstream calls prove long
+enough to make immediate interruption operationally necessary.
+
+## Recovery
+
+Recovery should repair item work before deciding the parent run is failed.
+
+Expired running item leases:
+
+- If `attempt_count < max_attempts`, reset the item to `queued`, clear lease
+  fields, preserve bounded error evidence, and republish an item message.
+- If attempts are exhausted, mark the item `failed` with a bounded stale lease
+  error and do not republish.
+
+Queued items without live messages:
+
+- Republish queued items for non-terminal, non-cancelled runs during startup or
+  periodic repair.
+- Publishing is idempotent because `claim_evaluation_item` remains the
+  ownership gate.
+
+Terminal item repair:
+
+- For any non-terminal run where all items are terminal, run finalization.
+- If all items completed, mark the run `completed`.
+- If some items failed and at least one completed, mark the run
+  `completed_with_failures`.
+- If every item failed, mark the run `failed`.
+- If the parent run is already `cancelled`, leave it `cancelled`.
+
+Stale parent runs:
+
+- Do not automatically mark a parent run `failed` just because its row is old.
+- Report stale queued or running conditions through evidence.
+- Let unrecoverable item exhaustion or terminal item repair drive final failure.
+
+## Evidence
+
+`GET /evaluations/{eval_id}` should expose item counts for:
+
+- `queued`
+- `running`
+- `completed`
+- `failed`
+- `cancelled`
+- `retryable`
+- `stale`
+- `total`
+
+`retryable` should be derived from item state and attempts remaining. `stale`
+should identify queued or running work older than the configured recovery
+threshold or with expired leases. Evidence must not expose raw query text beyond
+the existing explicit result payloads.
+
+`go/eval-mcp-service` should translate the richer eval API response into clearer
+operator next steps:
+
+- `cancelled`: explain that the run was cancelled and a new run is required if
+  evaluation is still needed.
+- stale with retryable work: explain that recovery should reset or republish
+  item work and suggest checking eval worker logs if counts do not change.
+- stale without retryable work: explain that item attempts may be exhausted or
+  terminal repair may be needed.
+- `failed`: keep current failure triage guidance.
+- `completed_with_failures`: keep current partial-result guidance.
+
+## Testing
+
+Add focused tests for:
+
+- Cancelling queued and running runs through the API.
+- Returning conflict when cancelling terminal runs.
+- Marking non-terminal items `cancelled` and clearing leases.
+- Worker acking cancelled work without retry or DLQ.
+- Worker checking cancellation before expensive stages.
+- Expired leases resetting and republishing when attempts remain.
+- Expired leases becoming failed when attempts are exhausted.
+- Queued item republish for non-terminal, non-cancelled runs.
+- All-terminal item repair finalizing a non-terminal run.
+- Evidence distinguishing stale, retryable, cancelled, and failed states.
+
+## Out Of Scope
+
+This design does not add:
+
+- In-flight HTTP or LLM request interruption.
+- User-supplied cancellation reasons.
+- A new dashboard UI for cancellation.
+- RabbitMQ payloads containing raw queries, expected answers, secrets, or model
+  credentials.

--- a/docs/superpowers/specs/2026-05-20-rag-eval-dlq-triage-replay-design.md
+++ b/docs/superpowers/specs/2026-05-20-rag-eval-dlq-triage-replay-design.md
@@ -1,0 +1,253 @@
+# RAG Eval DLQ Triage And Replay Design
+
+## Goal
+
+Build safe operator tooling for RAG eval item dead-letter queues. Operators and
+MCP workflows should be able to inspect failed item work, load detailed evidence
+from eval API state, and explicitly replay one failed item without exposing raw
+query text, expected answers, answer text, contexts, API keys, or model secrets
+in RabbitMQ payloads or DLQ listing responses.
+
+This follows the RabbitMQ item worker design in
+`docs/superpowers/specs/2026-05-20-rag-eval-rabbitmq-item-worker-design.md`.
+`services/eval` remains the source of truth. RabbitMQ is transport, including
+for DLQ messages.
+
+## Current Context
+
+`services/eval` already creates one durable RabbitMQ message per eval item. The
+message contract contains only:
+
+```json
+{
+  "message_version": 1,
+  "evaluation_id": "uuid",
+  "item_id": "uuid",
+  "item_index": 0,
+  "attempt": 1
+}
+```
+
+The eval database stores item state, attempts, bounded last error data, result
+payloads, scores, and parent evaluation state. Workers reject permanently failed
+messages to `eval.item.requested.dlq`.
+
+The Go eval MCP service already wraps eval API workflows. It should remain a
+workflow adapter and should not connect directly to RabbitMQ.
+
+## Recommended Approach
+
+Add operator-only DLQ inspection and replay endpoints to `services/eval`, then
+add thin MCP tools that call those endpoints.
+
+This keeps queue credentials, replay safety checks, redaction, metrics, logs,
+and item state transitions in the service that owns eval execution state. MCP
+gets an operator-friendly workflow surface without duplicating broker semantics
+or exposing RabbitMQ payloads as evidence.
+
+## API Surface
+
+Add these eval API endpoints:
+
+- `GET /evaluations/items/dlq?limit=...`
+- `POST /evaluations/items/dlq/replay`
+
+Both endpoints are operator-only. They must require authenticated auth context
+tier `operator`, not only the broader `eval_read` or `eval_write` rate-limit
+groups. Anonymous and normal user requests return `403`.
+
+`GET /evaluations/items/dlq` peeks at up to a bounded limit of DLQ messages
+without removing them.
+
+`POST /evaluations/items/dlq/replay` accepts exactly one selector:
+
+```json
+{"item_id": "item-id"}
+```
+
+or:
+
+```json
+{"index": 0}
+```
+
+`item_id` is preferred for MCP automation because queue indexes are transient.
+Index replay remains useful for quick manual workflows after listing the DLQ.
+
+## DLQ Listing Semantics
+
+Listing is a true peek. The implementation may use RabbitMQ `basic.get` with
+`auto_ack=false`, collect up to `limit`, then `nack(requeue=true)` each inspected
+message so the DLQ remains intact.
+
+Each listed entry includes only safe identifiers and bounded metadata:
+
+```json
+{
+  "index": 0,
+  "delivery_tag": "...",
+  "redelivered": false,
+  "payload": {
+    "message_version": 1,
+    "evaluation_id": "eval-id",
+    "item_id": "item-id",
+    "item_index": 3,
+    "attempt": 3
+  },
+  "routing": {
+    "exchange": "",
+    "routing_key": "eval.item.requested",
+    "queue": "eval.item.requested.dlq",
+    "death_count": 1,
+    "death_reason": "rejected"
+  },
+  "item": {
+    "evaluation_id": "eval-id",
+    "item_id": "item-id",
+    "item_index": 3,
+    "status": "failed",
+    "attempt_count": 3,
+    "max_attempts": 3,
+    "last_error": {"error_type": "TimeoutError", "retryable": false}
+  },
+  "evaluation": {
+    "status": "completed_with_failures",
+    "collection": "documents",
+    "created_at": "...",
+    "completed_at": "..."
+  }
+}
+```
+
+Do not return raw query text, expected answers, generated answers, contexts,
+full result payloads, API keys, secret names, or model secret values from DLQ
+listing. Operators who need deeper run evidence should use existing eval run
+evidence APIs and MCP tools by `evaluation_id`.
+
+The response should state that indexes are queue-order dependent and transient.
+
+## Replay Semantics
+
+Replay is explicit and conservative.
+
+The API should:
+
+1. Find exactly one matching DLQ message by `item_id` or transient `index`.
+2. Decode and validate the identifier-only payload.
+3. Load the item row by `item_id`.
+4. Require the item status to be `failed`.
+5. Reset the item to `queued`.
+6. Clear lease fields.
+7. Preserve `attempt_count` and `last_error`.
+8. Increment `replay_count` and set `last_replayed_at`.
+9. Republish a persistent identifier-only message to `eval.item.requested`.
+10. Ack and remove the DLQ message only after the database update and publish
+    succeed.
+
+The replay message body keeps the safe contract:
+
+```json
+{
+  "message_version": 1,
+  "evaluation_id": "eval-id",
+  "item_id": "item-id",
+  "item_index": 3,
+  "attempt": 4
+}
+```
+
+Add `replay_count` and `last_replayed_at` columns to `evaluation_items` rather
+than storing replay history in RabbitMQ headers. The database remains the
+queryable audit source.
+
+Replay does not reset the retry budget. Preserving `attempt_count` means an
+operator replay gives the selected item one explicit new processing attempt; if
+that attempt fails again, the existing worker retry policy can dead-letter it
+again without hiding the earlier failure history.
+
+If publish fails after the item was reset, the operation should return a clear
+failure and leave enough state for existing queued-item recovery to republish
+the work. The DLQ message should not be acked before the publish succeeds.
+
+## MCP Surface
+
+Add two tools to `go/eval-mcp-service`:
+
+- `list_eval_item_dlq(limit?: int)`
+- `replay_eval_item_dlq(item_id?: string, index?: int)`
+
+The MCP service calls eval API endpoints. It does not connect to RabbitMQ, does
+not parse queue internals directly, and does not enrich responses with raw query
+or answer fields.
+
+Tool validation should enforce exactly one replay selector. The replay tool
+description must state that it is explicit and mutating.
+
+## Observability
+
+Add bounded metrics:
+
+- `eval_item_dlq_inspections_total{outcome}`
+- `eval_item_dlq_replays_total{outcome}`
+
+Allowed outcomes should be bounded values such as `success`, `empty`,
+`not_found`, `invalid_payload`, `not_failed`, `publish_failed`, and `error`.
+
+Replay logs should include:
+
+- `evaluation_id`
+- `item_id`
+- `item_index`
+- selector type
+- original routing key
+- outcome
+
+Logs must not include raw query text, expected answers, generated answers,
+contexts, full result payloads, API keys, secret names, or model secret values.
+
+## Error Handling
+
+Invalid DLQ payloads should appear in list output as invalid entries with safe
+metadata and an `invalid_payload` outcome. Replay should reject invalid payloads
+without removing unrelated messages.
+
+If an `item_id` selector matches no DLQ message, return `404`.
+
+If the DLQ message exists but the database item is missing, return a safe error
+that includes only identifiers.
+
+If the item is not `failed`, reject replay with `409`. Completed or currently
+running items must not be replayed from DLQ tooling.
+
+If an index selector is out of range, return `404` and leave all messages in the
+DLQ.
+
+## Testing
+
+Python tests should cover:
+
+- DLQ payload decoding and invalid payload handling.
+- Peek without removal.
+- Listing redaction.
+- Operator-only authorization.
+- Replay selector validation.
+- Replay requiring failed item state.
+- DB reset with `replay_count` and `last_replayed_at`.
+- Publish-before-ack ordering.
+- Bounded metrics and log labels.
+
+Go MCP tests should cover:
+
+- Tool schema registration.
+- Exactly-one selector validation.
+- Eval API method, path, and request body.
+- Safe response propagation without raw query fields.
+
+## Out Of Scope
+
+- A web dashboard for DLQ management.
+- Bulk replay.
+- Automatic replay during listing.
+- Direct RabbitMQ access from MCP.
+- Storing raw query, expected answer, generated answer, contexts, API keys, or
+  model secrets in RabbitMQ payloads.

--- a/go/observability-mcp-service/README.md
+++ b/go/observability-mcp-service/README.md
@@ -40,6 +40,10 @@ codex mcp add observability -- zsh -lc 'source ~/.codex/env/observability-mcp.en
 | `OBS_HISTORY_ENABLED` | `true` | Enables local SQLite incident history. |
 | `OBS_HISTORY_DB_PATH` | `~/.codex/data/observability-mcp/history.db` | Local SQLite history database path. |
 | `OBS_HISTORY_AUTO_CAPTURE` | `false` | Persist investigation evidence even without `incident_key`. |
+| `OBS_MANAGEMENT_ACTIONS_ENABLED` | `false` | Enables cataloged management action execution. Read-only evidence tools work without this. |
+| `OBS_MANAGEMENT_ALLOW_HIGH_RISK` | `false` | Allows high-risk cataloged actions to execute instead of preview-only. Keep false for normal use. |
+| `OBS_MANAGEMENT_ACTION_TIMEOUT` | `45m` | Default maximum action execution timeout unless a catalog entry is lower. |
+| `OBS_MANAGEMENT_MAX_OUTPUT_BYTES` | `32768` | Maximum stdout/stderr bytes returned and stored for each action. |
 
 ## Grafana Gateway Mode
 
@@ -101,6 +105,10 @@ stale-running gauges, and eval service logs filtered by that run ID.
 - `get_incident_history`
 - `add_incident_note`
 - `compare_evidence_windows`
+- `list_management_actions`
+- `preview_management_action`
+- `execute_management_action`
+- `get_management_action_history`
 
 Runbook resources are exposed under:
 
@@ -111,11 +119,12 @@ Runbook resources are exposed under:
 
 ## Safety
 
-External observability and runtime systems remain read-only. The service queries
-metrics, logs, traces, embedded runbook text, and Grafana alert metadata; it
-does not call Kubernetes write APIs, roll out or restart workloads, scale
-deployments, purge queues, silence alerts, mutate external databases, edit
-Grafana rules, or read secrets.
+By default, external observability and runtime systems remain read-only. When
+`OBS_MANAGEMENT_ACTIONS_ENABLED=true`, the MCP can execute cataloged management
+actions only. Those actions must map to committed repo scripts, use fixed
+command shapes, bounded inputs, timeouts, output redaction, and incident-history
+logging. The MCP still does not accept free-form shell, kubectl, SSH commands,
+Grafana mutation payloads, arbitrary URLs, or arbitrary script paths.
 
 When incident history is enabled, the service may write investigation snapshots
 and `add_incident_note` entries to the configured local SQLite history database.

--- a/go/observability-mcp-service/cmd/observability-mcp/main.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main.go
@@ -6,11 +6,14 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/config"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/management"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/mcpserver"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/observability"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/workflows"
@@ -60,8 +63,9 @@ func run(ctx context.Context, logger *log.Logger, runServer serverRunner) error 
 		logger.Printf("observability MCP server running on stdio prometheus=%s loki=%s jaeger=%s", cfg.PrometheusURL, cfg.LokiURL, cfg.JaegerURL)
 	}
 	service := workflows.NewService(prom, loki, jaeger, cfg.MaxLogLines)
+	var historyDB *history.DB
 	if cfg.HistoryEnabled {
-		historyDB, err := history.Open(cfg.HistoryDBPath)
+		historyDB, err = history.Open(cfg.HistoryDBPath)
 		if err != nil {
 			logger.Printf("observability MCP history disabled: open %s: %v", cfg.HistoryDBPath, err)
 		} else if err := historyDB.Migrate(ctx); err != nil {
@@ -72,12 +76,33 @@ func run(ctx context.Context, logger *log.Logger, runServer serverRunner) error 
 			service.WithHistory(historyDB, cfg.HistoryAutoCapture)
 		}
 	}
+	root := repoRoot()
+	catalog := management.DefaultCatalog()
+	if err := catalog.ValidateScripts(root); err != nil {
+		return fmt.Errorf("management catalog: %w", err)
+	}
+	runner := management.Runner{RepoRoot: root, MaxOutputBytes: cfg.ManagementMaxOutputBytes, MaxTimeout: cfg.ManagementActionTimeout}
+	managementService := management.NewService(
+		catalog,
+		management.Policy{ActionsEnabled: cfg.ManagementActionsEnabled, AllowHighRisk: cfg.ManagementAllowHighRisk},
+		runner,
+		historyDB,
+	)
+	service.WithManagement(managementService)
 	if cfg.UseGrafanaGateway() {
 		if grafana, ok := prom.(*observability.GrafanaClient); ok {
 			service.SetGrafanaAlerting(grafana)
 		}
 	}
 	return runServer(ctx, &app{service: service, cfg: cfg})
+}
+
+func repoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
 }
 
 func runMCPServer(ctx context.Context, application *app) error {

--- a/go/observability-mcp-service/cmd/observability-mcp/main_test.go
+++ b/go/observability-mcp-service/cmd/observability-mcp/main_test.go
@@ -102,6 +102,25 @@ func TestRunSkipsHistoryStoreWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestRunWiresManagementWhenEnabled(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "true")
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "30s")
+	err := run(context.Background(), log.New(&bytes.Buffer{}, "", 0), func(ctx context.Context, application *app) error {
+		actions, err := application.service.ListManagementActions(ctx)
+		if err != nil {
+			t.Fatalf("ListManagementActions() error = %v", err)
+		}
+		if len(actions) == 0 {
+			t.Fatal("expected management actions")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+}
+
 func TestRunContinuesWhenHistoryStoreFails(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("OBS_HISTORY_DB_PATH", t.TempDir())
@@ -229,4 +248,8 @@ func clearEnv(t *testing.T) {
 	t.Setenv("OBS_HISTORY_ENABLED", "false")
 	t.Setenv("OBS_HISTORY_DB_PATH", "")
 	t.Setenv("OBS_HISTORY_AUTO_CAPTURE", "")
+	t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "")
+	t.Setenv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", "")
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "")
+	t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "")
 }

--- a/go/observability-mcp-service/internal/config/config.go
+++ b/go/observability-mcp-service/internal/config/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	HistoryEnabled                 bool
 	HistoryDBPath                  string
 	HistoryAutoCapture             bool
+	ManagementActionsEnabled       bool
+	ManagementAllowHighRisk        bool
+	ManagementActionTimeout        time.Duration
+	ManagementMaxOutputBytes       int
 }
 
 func FromEnv() (Config, error) {
@@ -65,6 +69,22 @@ func FromEnv() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	managementActionsEnabled, err := boolEnv("OBS_MANAGEMENT_ACTIONS_ENABLED", false)
+	if err != nil {
+		return Config{}, err
+	}
+	managementAllowHighRisk, err := boolEnv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", false)
+	if err != nil {
+		return Config{}, err
+	}
+	managementActionTimeout, err := durationEnv("OBS_MANAGEMENT_ACTION_TIMEOUT", 45*time.Minute)
+	if err != nil {
+		return Config{}, err
+	}
+	managementMaxOutputBytes, err := intEnv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", 32768)
+	if err != nil {
+		return Config{}, err
+	}
 
 	cfg := Config{
 		PrometheusURL:                  getenv("OBS_PROMETHEUS_URL", defaultPrometheusURL),
@@ -84,6 +104,10 @@ func FromEnv() (Config, error) {
 		HistoryEnabled:                 historyEnabled,
 		HistoryDBPath:                  getenv("OBS_HISTORY_DB_PATH", defaultHistoryDBPath()),
 		HistoryAutoCapture:             historyAutoCapture,
+		ManagementActionsEnabled:       managementActionsEnabled,
+		ManagementAllowHighRisk:        managementAllowHighRisk,
+		ManagementActionTimeout:        managementActionTimeout,
+		ManagementMaxOutputBytes:       managementMaxOutputBytes,
 	}
 	if cfg.QueryTimeout <= 0 {
 		return Config{}, fmt.Errorf("OBS_QUERY_TIMEOUT must be positive")
@@ -102,6 +126,12 @@ func FromEnv() (Config, error) {
 	}
 	if cfg.MaxTraceSpans <= 0 {
 		return Config{}, fmt.Errorf("OBS_MAX_TRACE_SPANS must be positive")
+	}
+	if cfg.ManagementActionTimeout <= 0 {
+		return Config{}, fmt.Errorf("OBS_MANAGEMENT_ACTION_TIMEOUT must be positive")
+	}
+	if cfg.ManagementMaxOutputBytes <= 0 {
+		return Config{}, fmt.Errorf("OBS_MANAGEMENT_MAX_OUTPUT_BYTES must be positive")
 	}
 	if (cfg.GrafanaAccessClientID == "") != (cfg.GrafanaAccessClientSecret == "") {
 		return Config{}, fmt.Errorf("OBS_GRAFANA_ACCESS_CLIENT_ID and OBS_GRAFANA_ACCESS_CLIENT_SECRET must be set together")

--- a/go/observability-mcp-service/internal/config/config_test.go
+++ b/go/observability-mcp-service/internal/config/config_test.go
@@ -159,6 +159,60 @@ func TestFromEnvHistoryOverrides(t *testing.T) {
 	}
 }
 
+func TestFromEnvManagementDefaults(t *testing.T) {
+	clearEnv(t)
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if cfg.ManagementActionsEnabled {
+		t.Fatal("expected management actions disabled by default")
+	}
+	if cfg.ManagementAllowHighRisk {
+		t.Fatal("expected high-risk management actions disabled by default")
+	}
+	if cfg.ManagementActionTimeout != 45*time.Minute {
+		t.Fatalf("ManagementActionTimeout = %s, want 45m", cfg.ManagementActionTimeout)
+	}
+	if cfg.ManagementMaxOutputBytes != 32768 {
+		t.Fatalf("ManagementMaxOutputBytes = %d, want 32768", cfg.ManagementMaxOutputBytes)
+	}
+}
+
+func TestFromEnvManagementOverrides(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "true")
+	t.Setenv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", "true")
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "45s")
+	t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "4096")
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv() error = %v", err)
+	}
+	if !cfg.ManagementActionsEnabled || !cfg.ManagementAllowHighRisk {
+		t.Fatalf("management bool overrides not applied: %+v", cfg)
+	}
+	if cfg.ManagementActionTimeout != 45*time.Second {
+		t.Fatalf("ManagementActionTimeout = %s", cfg.ManagementActionTimeout)
+	}
+	if cfg.ManagementMaxOutputBytes != 4096 {
+		t.Fatalf("ManagementMaxOutputBytes = %d", cfg.ManagementMaxOutputBytes)
+	}
+}
+
+func TestFromEnvRejectsInvalidManagementConfig(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "0s")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("expected non-positive management timeout error")
+	}
+	clearEnv(t)
+	t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "0")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("expected non-positive management output cap error")
+	}
+}
+
 func TestFromEnvRejectsInvalidHistoryBool(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("OBS_HISTORY_ENABLED", "maybe")
@@ -205,6 +259,10 @@ func clearEnv(t *testing.T) {
 	t.Setenv("OBS_HISTORY_ENABLED", "")
 	t.Setenv("OBS_HISTORY_AUTO_CAPTURE", "")
 	t.Setenv("OBS_HISTORY_DB_PATH", "")
+	t.Setenv("OBS_MANAGEMENT_ACTIONS_ENABLED", "")
+	t.Setenv("OBS_MANAGEMENT_ALLOW_HIGH_RISK", "")
+	t.Setenv("OBS_MANAGEMENT_ACTION_TIMEOUT", "")
+	t.Setenv("OBS_MANAGEMENT_MAX_OUTPUT_BYTES", "")
 }
 
 func TestValidateWindow(t *testing.T) {

--- a/go/observability-mcp-service/internal/history/sqlite.go
+++ b/go/observability-mcp-service/internal/history/sqlite.go
@@ -378,6 +378,122 @@ func (d *DB) AddIncidentNote(ctx context.Context, input AddNoteInput) (Event, er
 	return event, nil
 }
 
+func (d *DB) RecordManagementAction(ctx context.Context, input ManagementActionInput) (Event, error) {
+	if input.IncidentKey == "" {
+		return Event{}, errors.New("incident key is required")
+	}
+	if input.ActionID == "" {
+		return Event{}, errors.New("action id is required")
+	}
+	if input.Summary == "" {
+		return Event{}, errors.New("summary is required")
+	}
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Event{}, fmt.Errorf("begin record management action transaction: %w", err)
+	}
+	defer rollback(tx)
+
+	if input.IncidentTitle == "" {
+		if _, err := getIncidentByKeyTx(ctx, tx, input.IncidentKey); err != nil {
+			return Event{}, errors.New("incident title is required for new incident")
+		}
+	}
+
+	now := time.Now().UTC()
+	incidentID, err := upsertIncident(ctx, tx, IncidentUpsert{
+		Key:      input.IncidentKey,
+		Title:    input.IncidentTitle,
+		Status:   StatusInvestigating,
+		Severity: input.Severity,
+		Service:  input.Service,
+	}, now)
+	if err != nil {
+		return Event{}, err
+	}
+	details, err := managementActionDetails(input)
+	if err != nil {
+		return Event{}, err
+	}
+	event, err := insertTimelineEvent(ctx, tx, incidentID, managementEventType(input.Status), input.Summary, details, now)
+	if err != nil {
+		return Event{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Event{}, fmt.Errorf("commit record management action transaction: %w", err)
+	}
+	return event, nil
+}
+
+func (d *DB) ListManagementActions(ctx context.Context, filter ManagementActionFilter) ([]Event, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = defaultListLimit
+	}
+	if limit > defaultListLimit {
+		limit = defaultListLimit
+	}
+	eventTypes := []string{
+		EventManagementActionPreviewed,
+		EventManagementActionStarted,
+		EventManagementActionCompleted,
+		EventManagementActionFailed,
+		EventManagementActionBlocked,
+	}
+	conditions := []string{"e.event_type IN (?, ?, ?, ?, ?)"}
+	args := []any{
+		eventTypes[0],
+		eventTypes[1],
+		eventTypes[2],
+		eventTypes[3],
+		eventTypes[4],
+	}
+	if filter.IncidentKey != "" {
+		conditions = append(conditions, "i.incident_key = ?")
+		args = append(args, filter.IncidentKey)
+	}
+	if filter.ActionID != "" {
+		conditions = append(conditions, "e.details LIKE ?")
+		args = append(args, `%`+jsonFilterFragment("action_id", filter.ActionID)+`%`)
+	}
+	if filter.Status != "" {
+		conditions = append(conditions, "e.details LIKE ?")
+		args = append(args, `%`+jsonFilterFragment("status", filter.Status)+`%`)
+	}
+	if filter.Decision != "" {
+		conditions = append(conditions, "e.details LIKE ?")
+		args = append(args, `%`+jsonFilterFragment("decision", filter.Decision)+`%`)
+	}
+	query := `
+		SELECT e.id, e.incident_id, e.event_type, e.summary, e.details, e.created_at
+		FROM timeline_events e
+		JOIN incidents i ON i.id = e.incident_id
+		WHERE ` + strings.Join(conditions, " AND ") + `
+		ORDER BY e.created_at DESC, e.id DESC
+		LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := d.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list management actions: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		event, err := scanEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate management actions: %w", err)
+	}
+	return events, nil
+}
+
 func (d *DB) GetSnapshot(ctx context.Context, id int64) (Snapshot, error) {
 	row := d.db.QueryRowContext(ctx, snapshotSelectSQL()+` WHERE s.id = ?`, id)
 	snapshot, err := scanSnapshot(row)
@@ -388,6 +504,49 @@ func (d *DB) GetSnapshot(ctx context.Context, id int64) (Snapshot, error) {
 		return Snapshot{}, err
 	}
 	return snapshot, nil
+}
+
+func managementEventType(status string) string {
+	switch status {
+	case "previewed":
+		return EventManagementActionPreviewed
+	case "blocked":
+		return EventManagementActionBlocked
+	case "succeeded":
+		return EventManagementActionCompleted
+	case "failed", "timed_out":
+		return EventManagementActionFailed
+	default:
+		return EventManagementActionStarted
+	}
+}
+
+func managementActionDetails(input ManagementActionInput) (string, error) {
+	if len(input.DetailsJSON) == 0 {
+		data, err := json.Marshal(map[string]string{
+			"action_id": input.ActionID,
+			"risk_tier": input.RiskTier,
+			"decision":  input.Decision,
+			"status":    input.Status,
+		})
+		if err != nil {
+			return "", fmt.Errorf("marshal management action details: %w", err)
+		}
+		return string(data), nil
+	}
+	if !json.Valid(input.DetailsJSON) {
+		return "", errors.New("management action details must be valid JSON")
+	}
+	return string(input.DetailsJSON), nil
+}
+
+func jsonFilterFragment(key, value string) string {
+	encoded, err := json.Marshal(map[string]string{key: value})
+	if err != nil {
+		return ""
+	}
+	fragment := strings.TrimSuffix(strings.TrimPrefix(string(encoded), "{"), "}")
+	return fragment
 }
 
 func upsertIncident(ctx context.Context, tx *sql.Tx, incident IncidentUpsert, now time.Time) (int64, error) {

--- a/go/observability-mcp-service/internal/history/sqlite_test.go
+++ b/go/observability-mcp-service/internal/history/sqlite_test.go
@@ -201,6 +201,66 @@ func TestRecordSnapshotDoesNotOverwriteIncidentMetadataWithEmptyValues(t *testin
 	}
 }
 
+func TestRecordManagementActionCreatesIncidentTimeline(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	event, err := db.RecordManagementAction(ctx, ManagementActionInput{
+		IncidentKey:   "grafana-alerting",
+		IncidentTitle: "Grafana alerting reload",
+		ActionID:      "reload_grafana_alerting",
+		RiskTier:      "low_risk_mutation",
+		Decision:      "allow",
+		Status:        "succeeded",
+		Summary:       "reload_grafana_alerting succeeded",
+		DetailsJSON:   []byte(`{"status":"succeeded"}`),
+	})
+	if err != nil {
+		t.Fatalf("RecordManagementAction() error = %v", err)
+	}
+	if event.ID == 0 || event.Type != EventManagementActionCompleted {
+		t.Fatalf("event = %+v", event)
+	}
+	history, err := db.GetIncidentHistory(ctx, "grafana-alerting")
+	if err != nil {
+		t.Fatalf("GetIncidentHistory() error = %v", err)
+	}
+	if len(history.Events) != 1 {
+		t.Fatalf("events = %d, want 1", len(history.Events))
+	}
+	if history.Events[0].Details != `{"status":"succeeded"}` {
+		t.Fatalf("details = %q", history.Events[0].Details)
+	}
+}
+
+func TestRecordManagementActionRequiresTitleForNewIncident(t *testing.T) {
+	db := openTestDB(t)
+	_, err := db.RecordManagementAction(context.Background(), ManagementActionInput{
+		IncidentKey: "missing-title",
+		ActionID:    "reload_grafana_alerting",
+		RiskTier:    "low_risk_mutation",
+		Decision:    "allow",
+		Status:      "succeeded",
+		Summary:     "reload_grafana_alerting succeeded",
+	})
+	if err == nil {
+		t.Fatal("expected missing title error")
+	}
+}
+
+func TestListManagementActionsFilters(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	_, _ = db.RecordManagementAction(ctx, ManagementActionInput{IncidentKey: "one", IncidentTitle: "One", ActionID: "reload_grafana_alerting", RiskTier: "low_risk_mutation", Decision: "allow", Status: "succeeded", Summary: "one"})
+	_, _ = db.RecordManagementAction(ctx, ManagementActionInput{IncidentKey: "two", IncidentTitle: "Two", ActionID: "run_postgres_backup_verify", RiskTier: "low_risk_mutation", Decision: "block", Status: "blocked", Summary: "two"})
+	events, err := db.ListManagementActions(ctx, ManagementActionFilter{ActionID: "reload_grafana_alerting", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListManagementActions() error = %v", err)
+	}
+	if len(events) != 1 || events[0].Summary != "one" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
 func TestListIncidentsFiltersByStatusServiceSeverity(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()

--- a/go/observability-mcp-service/internal/history/types.go
+++ b/go/observability-mcp-service/internal/history/types.go
@@ -16,6 +16,12 @@ const (
 	EventEvidenceSnapshot = "evidence_snapshot"
 	EventNoteAdded        = "note_added"
 	EventStatusChanged    = "status_changed"
+
+	EventManagementActionPreviewed = "management_action_previewed"
+	EventManagementActionStarted   = "management_action_started"
+	EventManagementActionCompleted = "management_action_completed"
+	EventManagementActionFailed    = "management_action_failed"
+	EventManagementActionBlocked   = "management_action_blocked"
 )
 
 type IncidentUpsert struct {
@@ -116,6 +122,27 @@ type AddNoteInput struct {
 	Status      string
 }
 
+type ManagementActionInput struct {
+	IncidentKey   string
+	IncidentTitle string
+	Severity      string
+	Service       string
+	ActionID      string
+	RiskTier      string
+	Decision      string
+	Status        string
+	Summary       string
+	DetailsJSON   []byte
+}
+
+type ManagementActionFilter struct {
+	IncidentKey string
+	ActionID    string
+	Status      string
+	Decision    string
+	Limit       int
+}
+
 type Store interface {
 	Close() error
 	Migrate(context.Context) error
@@ -124,6 +151,8 @@ type Store interface {
 	GetIncidentHistory(context.Context, string) (IncidentHistory, error)
 	AddIncidentNote(context.Context, AddNoteInput) (Event, error)
 	GetSnapshot(context.Context, int64) (Snapshot, error)
+	RecordManagementAction(context.Context, ManagementActionInput) (Event, error)
+	ListManagementActions(context.Context, ManagementActionFilter) ([]Event, error)
 }
 
 func NormalizeStatus(status string) string {

--- a/go/observability-mcp-service/internal/management/catalog.go
+++ b/go/observability-mcp-service/internal/management/catalog.go
@@ -1,0 +1,151 @@
+package management
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Catalog struct {
+	actions map[string]Action
+	order   []string
+}
+
+func NewCatalog(actions []Action) (Catalog, error) {
+	catalog := Catalog{actions: make(map[string]Action, len(actions)), order: make([]string, 0, len(actions))}
+	for _, action := range actions {
+		if err := validateAction(action); err != nil {
+			return Catalog{}, err
+		}
+		if _, ok := catalog.actions[action.ID]; ok {
+			return Catalog{}, fmt.Errorf("duplicate management action id %q", action.ID)
+		}
+		if action.TimeoutText == "" {
+			action.TimeoutText = action.Timeout.String()
+		}
+		catalog.actions[action.ID] = action
+		catalog.order = append(catalog.order, action.ID)
+	}
+	sort.Strings(catalog.order)
+	return catalog, nil
+}
+
+func (c Catalog) Get(id string) (Action, bool) {
+	action, ok := c.actions[id]
+	return action, ok
+}
+
+func (c Catalog) List() []Action {
+	actions := make([]Action, 0, len(c.order))
+	for _, id := range c.order {
+		actions = append(actions, c.actions[id])
+	}
+	return actions
+}
+
+func (c Catalog) ValidateScripts(repoRoot string) error {
+	root, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return fmt.Errorf("resolve repo root: %w", err)
+	}
+	root = filepath.Clean(root)
+	for _, action := range c.List() {
+		fullPath, err := safeScriptPath(root, action.ScriptPath)
+		if err != nil {
+			return fmt.Errorf("%s: %w", action.ID, err)
+		}
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			return fmt.Errorf("%s: stat script: %w", action.ID, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("%s: script path is a directory", action.ID)
+		}
+	}
+	return nil
+}
+
+func DefaultCatalog() Catalog {
+	catalog, err := NewCatalog([]Action{
+		{
+			ID:          "reload_grafana_alerting",
+			Title:       "Reload Grafana alerting",
+			Description: "Restart Grafana so committed alerting provisioning is loaded and verified.",
+			RiskTier:    RiskLowRiskMutation,
+			ScriptPath:  "scripts/ops/2026-05-09-reload-grafana-alerting.sh",
+			Timeout:     2 * time.Minute,
+			TimeoutText: "2m0s",
+			Idempotent:  true,
+			Preflight:   "Script verifies the expected Grafana alerting ConfigMap content before restart.",
+			Postflight:  "Script waits for rollout and verifies live Grafana alert expression and active alert count.",
+			NextSteps:   "Inspect script output and rerun system health evidence if the action fails.",
+		},
+		{
+			ID:          "run_postgres_backup_verify",
+			Title:       "Run Postgres backup verification",
+			Description: "Create a manual Job from the committed Postgres backup verification CronJob and wait for completion.",
+			RiskTier:    RiskLowRiskMutation,
+			ScriptPath:  "scripts/ops/2026-05-15-run-postgres-backup-verify.sh",
+			Timeout:     40 * time.Minute,
+			TimeoutText: "40m0s",
+			Idempotent:  true,
+			Preflight:   "Script creates a timestamped Job from the existing CronJob.",
+			Postflight:  "Script waits for completion and prints bounded pod logs.",
+			NextSteps:   "Review Job logs and investigate backup-verification alerts if the action fails.",
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return catalog
+}
+
+func validateAction(action Action) error {
+	if strings.TrimSpace(action.ID) == "" {
+		return fmt.Errorf("management action id is required")
+	}
+	if strings.TrimSpace(action.Title) == "" {
+		return fmt.Errorf("%s: title is required", action.ID)
+	}
+	if strings.TrimSpace(action.Description) == "" {
+		return fmt.Errorf("%s: description is required", action.ID)
+	}
+	switch action.RiskTier {
+	case RiskDiagnostic, RiskLowRiskMutation, RiskHighRiskMutation:
+	default:
+		return fmt.Errorf("%s: invalid risk tier %q", action.ID, action.RiskTier)
+	}
+	if action.Timeout <= 0 {
+		return fmt.Errorf("%s: timeout must be positive", action.ID)
+	}
+	if _, err := safeScriptPath(".", action.ScriptPath); err != nil {
+		return fmt.Errorf("%s: %w", action.ID, err)
+	}
+	return nil
+}
+
+func safeScriptPath(repoRoot, scriptPath string) (string, error) {
+	if scriptPath == "" {
+		return "", fmt.Errorf("script path is required")
+	}
+	if filepath.IsAbs(scriptPath) {
+		return "", fmt.Errorf("script path must be relative")
+	}
+	cleanScript := filepath.Clean(scriptPath)
+	if cleanScript == "." || cleanScript == ".." || strings.HasPrefix(cleanScript, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("script path escapes repo root")
+	}
+	root := filepath.Clean(repoRoot)
+	fullPath := filepath.Clean(filepath.Join(root, cleanScript))
+	rel, err := filepath.Rel(root, fullPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve script path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("script path escapes repo root")
+	}
+	return fullPath, nil
+}

--- a/go/observability-mcp-service/internal/management/catalog_test.go
+++ b/go/observability-mcp-service/internal/management/catalog_test.go
@@ -1,0 +1,64 @@
+package management
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDefaultCatalogContainsInitialActions(t *testing.T) {
+	catalog := DefaultCatalog()
+	for _, id := range []string{"reload_grafana_alerting", "run_postgres_backup_verify"} {
+		action, ok := catalog.Get(id)
+		if !ok {
+			t.Fatalf("missing action %q", id)
+		}
+		if action.RiskTier != RiskLowRiskMutation {
+			t.Fatalf("%s risk = %q", id, action.RiskTier)
+		}
+		if action.ScriptPath == "" || filepath.IsAbs(action.ScriptPath) {
+			t.Fatalf("%s script path = %q", id, action.ScriptPath)
+		}
+		if action.Timeout <= 0 || action.Timeout > 45*time.Minute {
+			t.Fatalf("%s timeout = %s", id, action.Timeout)
+		}
+	}
+}
+
+func TestDefaultCatalogScriptsExist(t *testing.T) {
+	catalog := DefaultCatalog()
+	repoRoot := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	if err := catalog.ValidateScripts(repoRoot); err != nil {
+		t.Fatalf("ValidateScripts() error = %v", err)
+	}
+}
+
+func TestCatalogValidationRejectsBadEntries(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []Action
+	}{
+		{name: "duplicate id", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second}, {ID: "a", Title: "B", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/b.sh", Timeout: time.Second}}},
+		{name: "absolute path", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "/tmp/a.sh", Timeout: time.Second}}},
+		{name: "path traversal", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "../a.sh", Timeout: time.Second}}},
+		{name: "invalid risk", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskTier("surprise"), ScriptPath: "scripts/ops/a.sh", Timeout: time.Second}}},
+		{name: "no timeout", actions: []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/a.sh"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewCatalog(tc.actions); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateScriptsRejectsMissingScript(t *testing.T) {
+	catalog, err := NewCatalog([]Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskDiagnostic, ScriptPath: "scripts/ops/missing.sh", Timeout: time.Second}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.ValidateScripts(t.TempDir()); err == nil {
+		t.Fatal("expected missing script error")
+	}
+}

--- a/go/observability-mcp-service/internal/management/policy.go
+++ b/go/observability-mcp-service/internal/management/policy.go
@@ -1,0 +1,16 @@
+package management
+
+type Policy struct {
+	ActionsEnabled bool
+	AllowHighRisk  bool
+}
+
+func (p Policy) Evaluate(action Action) PolicyDecision {
+	if !p.ActionsEnabled {
+		return PolicyDecision{Decision: DecisionBlock, Reason: "management actions are disabled; set OBS_MANAGEMENT_ACTIONS_ENABLED=true"}
+	}
+	if action.RiskTier == RiskHighRiskMutation && !p.AllowHighRisk {
+		return PolicyDecision{Decision: DecisionPreviewOnly, Reason: "high-risk management actions require OBS_MANAGEMENT_ALLOW_HIGH_RISK=true"}
+	}
+	return PolicyDecision{Decision: DecisionAllow, Reason: "action is allowed by management policy"}
+}

--- a/go/observability-mcp-service/internal/management/policy_test.go
+++ b/go/observability-mcp-service/internal/management/policy_test.go
@@ -1,0 +1,27 @@
+package management
+
+import "testing"
+
+func TestPolicyDecisions(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy Policy
+		risk   RiskTier
+		want   Decision
+	}{
+		{name: "disabled diagnostic blocked", policy: Policy{}, risk: RiskDiagnostic, want: DecisionBlock},
+		{name: "disabled low risk blocked", policy: Policy{}, risk: RiskLowRiskMutation, want: DecisionBlock},
+		{name: "enabled diagnostic allowed", policy: Policy{ActionsEnabled: true}, risk: RiskDiagnostic, want: DecisionAllow},
+		{name: "enabled low risk allowed", policy: Policy{ActionsEnabled: true}, risk: RiskLowRiskMutation, want: DecisionAllow},
+		{name: "high risk preview", policy: Policy{ActionsEnabled: true}, risk: RiskHighRiskMutation, want: DecisionPreviewOnly},
+		{name: "high risk enabled", policy: Policy{ActionsEnabled: true, AllowHighRisk: true}, risk: RiskHighRiskMutation, want: DecisionAllow},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.policy.Evaluate(Action{ID: "a", RiskTier: tc.risk})
+			if got.Decision != tc.want {
+				t.Fatalf("Decision = %q, want %q; reason=%s", got.Decision, tc.want, got.Reason)
+			}
+		})
+	}
+}

--- a/go/observability-mcp-service/internal/management/redact.go
+++ b/go/observability-mcp-service/internal/management/redact.go
@@ -1,0 +1,29 @@
+package management
+
+import "regexp"
+
+var redactPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)(token|secret|password|authorization)=\S+`),
+	regexp.MustCompile(`(?i)bearer\s+\S+`),
+}
+
+func boundOutput(value string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value, false
+	}
+	return value[:maxBytes], true
+}
+
+func redactOutput(value string) (string, int) {
+	count := 0
+	for _, pattern := range redactPatterns {
+		value = pattern.ReplaceAllStringFunc(value, func(match string) string {
+			count++
+			if parts := pattern.FindStringSubmatch(match); len(parts) > 1 {
+				return parts[1] + "=[REDACTED]"
+			}
+			return "[REDACTED]"
+		})
+	}
+	return value, count
+}

--- a/go/observability-mcp-service/internal/management/runner.go
+++ b/go/observability-mcp-service/internal/management/runner.go
@@ -1,0 +1,90 @@
+package management
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+type Runner struct {
+	RepoRoot       string
+	MaxOutputBytes int
+	MaxTimeout     time.Duration
+}
+
+func (r Runner) Run(ctx context.Context, action Action) ActionResult {
+	startedAt := time.Now().UTC()
+	result := ActionResult{
+		ActionID:   action.ID,
+		RiskTier:   action.RiskTier,
+		ScriptPath: action.ScriptPath,
+		StartedAt:  startedAt,
+	}
+
+	fullPath, err := safeScriptPath(r.RepoRoot, action.ScriptPath)
+	if err != nil {
+		result.Status = StatusFailed
+		result.Stderr = "unsafe script path: " + err.Error()
+		result.CompletedAt = time.Now().UTC()
+		result.DurationMillis = result.CompletedAt.Sub(startedAt).Milliseconds()
+		return result
+	}
+
+	timeout := effectiveTimeout(action.Timeout, r.MaxTimeout)
+	runCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(runCtx, "bash", fullPath)
+	cmd.Dir = r.RepoRoot
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+
+	result.CompletedAt = time.Now().UTC()
+	result.DurationMillis = result.CompletedAt.Sub(startedAt).Milliseconds()
+	if cmd.ProcessState != nil {
+		result.ExitCode = cmd.ProcessState.ExitCode()
+	}
+	result.Stdout, result.Stderr, result.OutputTruncated, result.RedactionsApplied = filterOutput(stdout.String(), stderr.String(), r.MaxOutputBytes)
+
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		result.Status = StatusTimedOut
+		return result
+	}
+	if err != nil {
+		result.Status = StatusFailed
+		if result.Stderr == "" {
+			result.Stderr = fmt.Sprintf("run script: %v", err)
+		}
+		return result
+	}
+	result.Status = StatusSucceeded
+	return result
+}
+
+func effectiveTimeout(actionTimeout, maxTimeout time.Duration) time.Duration {
+	if actionTimeout <= 0 {
+		return maxTimeout
+	}
+	if maxTimeout > 0 && maxTimeout < actionTimeout {
+		return maxTimeout
+	}
+	return actionTimeout
+}
+
+func filterOutput(stdout, stderr string, maxBytes int) (string, string, bool, int) {
+	stdout, stdoutTruncated := boundOutput(stdout, maxBytes)
+	stderr, stderrTruncated := boundOutput(stderr, maxBytes)
+	stdout, stdoutRedactions := redactOutput(stdout)
+	stderr, stderrRedactions := redactOutput(stderr)
+	return stdout, stderr, stdoutTruncated || stderrTruncated, stdoutRedactions + stderrRedactions
+}

--- a/go/observability-mcp-service/internal/management/runner_test.go
+++ b/go/observability-mcp-service/internal/management/runner_test.go
@@ -1,0 +1,72 @@
+package management
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunnerExecutesCatalogScriptAndBoundsOutput(t *testing.T) {
+	repo := t.TempDir()
+	script := filepath.Join(repo, "scripts/ops/test.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env bash\nprintf 'abcdef'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := Runner{RepoRoot: repo, MaxOutputBytes: 4, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "test", ScriptPath: "scripts/ops/test.sh", Timeout: time.Second})
+	if result.Status != StatusSucceeded {
+		t.Fatalf("status = %q stderr=%q", result.Status, result.Stderr)
+	}
+	if result.Stdout != "abcd" || !result.OutputTruncated {
+		t.Fatalf("stdout=%q truncated=%t", result.Stdout, result.OutputTruncated)
+	}
+}
+
+func TestRunnerRejectsUnsafeScriptPath(t *testing.T) {
+	runner := Runner{RepoRoot: t.TempDir(), MaxOutputBytes: 1024, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "bad", ScriptPath: "../bad.sh", Timeout: time.Second})
+	if result.Status != StatusFailed || !strings.Contains(result.Stderr, "unsafe script path") {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestRunnerRedactsSecretLookingOutput(t *testing.T) {
+	repo := t.TempDir()
+	script := filepath.Join(repo, "scripts/ops/secret.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env bash\necho 'token=super-secret-value'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := Runner{RepoRoot: repo, MaxOutputBytes: 1024, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "secret", ScriptPath: "scripts/ops/secret.sh", Timeout: time.Second})
+	if strings.Contains(result.Stdout, "super-secret-value") {
+		t.Fatalf("secret was not redacted: %q", result.Stdout)
+	}
+	if result.RedactionsApplied == 0 {
+		t.Fatalf("expected redaction count, got %+v", result)
+	}
+}
+
+func TestRunnerTimesOut(t *testing.T) {
+	repo := t.TempDir()
+	script := filepath.Join(repo, "scripts/ops/slow.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte("#!/usr/bin/env bash\nsleep 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := Runner{RepoRoot: repo, MaxOutputBytes: 1024, MaxTimeout: time.Second}
+	result := runner.Run(context.Background(), Action{ID: "slow", ScriptPath: "scripts/ops/slow.sh", Timeout: 10 * time.Millisecond})
+	if result.Status != StatusTimedOut {
+		t.Fatalf("status = %q, want timed_out", result.Status)
+	}
+}

--- a/go/observability-mcp-service/internal/management/service.go
+++ b/go/observability-mcp-service/internal/management/service.go
@@ -1,0 +1,164 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+)
+
+type RunnerInterface interface {
+	Run(context.Context, Action) ActionResult
+}
+
+type HistoryStore interface {
+	RecordManagementAction(context.Context, history.ManagementActionInput) (history.Event, error)
+	ListManagementActions(context.Context, history.ManagementActionFilter) ([]history.Event, error)
+}
+
+type Service struct {
+	catalog Catalog
+	policy  Policy
+	runner  RunnerInterface
+	history HistoryStore
+}
+
+func NewService(catalog Catalog, policy Policy, runner RunnerInterface, store HistoryStore) *Service {
+	return &Service{catalog: catalog, policy: policy, runner: runner, history: store}
+}
+
+func (s *Service) List() []Action {
+	return s.catalog.List()
+}
+
+func (s *Service) Preview(ctx context.Context, req ActionRequest) ActionResult {
+	action, result, ok := s.prepare(req)
+	if !ok {
+		return s.record(ctx, req, result)
+	}
+	decision := s.policy.Evaluate(action)
+	result.Decision = decision.Decision
+	result.PolicyReason = decision.Reason
+	if decision.Decision == DecisionBlock {
+		result.Status = StatusBlocked
+	} else {
+		result.Status = StatusPreviewed
+	}
+	return s.record(ctx, req, result)
+}
+
+func (s *Service) Execute(ctx context.Context, req ActionRequest) ActionResult {
+	action, result, ok := s.prepare(req)
+	if !ok {
+		return s.record(ctx, req, result)
+	}
+	if req.IncidentKey != "" && req.IncidentTitle == "" {
+		result.Status = StatusBlocked
+		result.Decision = DecisionBlock
+		result.PolicyReason = "incident_title is required when incident_key creates action history"
+		return s.record(ctx, req, result)
+	}
+	decision := s.policy.Evaluate(action)
+	result.Decision = decision.Decision
+	result.PolicyReason = decision.Reason
+	if decision.Decision != DecisionAllow {
+		result.Status = StatusBlocked
+		if decision.Decision == DecisionPreviewOnly {
+			result.Status = StatusPreviewed
+		}
+		return s.record(ctx, req, result)
+	}
+	if s.runner == nil {
+		result.Status = StatusFailed
+		result.PolicyReason = "management action runner is unavailable"
+		return s.record(ctx, req, result)
+	}
+	result = s.runner.Run(ctx, action)
+	result.ActionID = action.ID
+	result.RiskTier = action.RiskTier
+	result.Decision = decision.Decision
+	result.PolicyReason = decision.Reason
+	result.ScriptPath = action.ScriptPath
+	result.IncidentKey = req.IncidentKey
+	return s.record(ctx, req, result)
+}
+
+func (s *Service) History(ctx context.Context, filter history.ManagementActionFilter) ([]history.Event, error) {
+	if s.history == nil {
+		return nil, fmt.Errorf("management action history is disabled")
+	}
+	return s.history.ListManagementActions(ctx, filter)
+}
+
+func (s *Service) prepare(req ActionRequest) (Action, ActionResult, bool) {
+	action, ok := s.catalog.Get(req.ActionID)
+	result := ActionResult{
+		ActionID:    req.ActionID,
+		IncidentKey: req.IncidentKey,
+		StartedAt:   time.Now().UTC(),
+	}
+	if !ok {
+		result.Status = StatusBlocked
+		result.Decision = DecisionBlock
+		result.PolicyReason = "unknown management action"
+		return Action{}, result, false
+	}
+	result.RiskTier = action.RiskTier
+	result.ScriptPath = action.ScriptPath
+	return action, result, true
+}
+
+func (s *Service) record(ctx context.Context, req ActionRequest, result ActionResult) ActionResult {
+	if result.CompletedAt.IsZero() {
+		result.CompletedAt = time.Now().UTC()
+	}
+	if result.DurationMillis == 0 && !result.StartedAt.IsZero() {
+		result.DurationMillis = result.CompletedAt.Sub(result.StartedAt).Milliseconds()
+	}
+	if s.history == nil {
+		result.Warning = "management action history is disabled"
+		return result
+	}
+	details, err := json.Marshal(result)
+	if err != nil {
+		result.Warning = "marshal management action history: " + err.Error()
+		return result
+	}
+	event, err := s.history.RecordManagementAction(ctx, history.ManagementActionInput{
+		IncidentKey:   incidentKey(req, result),
+		IncidentTitle: incidentTitle(req, result),
+		Severity:      req.Severity,
+		Service:       req.Service,
+		ActionID:      result.ActionID,
+		RiskTier:      string(result.RiskTier),
+		Decision:      string(result.Decision),
+		Status:        string(result.Status),
+		Summary:       fmt.Sprintf("%s %s", result.ActionID, result.Status),
+		DetailsJSON:   details,
+	})
+	if err != nil {
+		result.Warning = "record management action history: " + err.Error()
+		return result
+	}
+	result.HistoryEventIDs = append(result.HistoryEventIDs, event.ID)
+	return result
+}
+
+func incidentKey(req ActionRequest, result ActionResult) string {
+	if req.IncidentKey != "" {
+		return req.IncidentKey
+	}
+	return "management:" + result.ActionID
+}
+
+func incidentTitle(req ActionRequest, result ActionResult) string {
+	if req.IncidentTitle != "" {
+		return req.IncidentTitle
+	}
+	if req.IncidentKey == "" {
+		return "Management action " + result.ActionID
+	}
+	return ""
+}

--- a/go/observability-mcp-service/internal/management/service_test.go
+++ b/go/observability-mcp-service/internal/management/service_test.go
@@ -1,0 +1,70 @@
+package management
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+)
+
+type fakeRunner struct{ result ActionResult }
+
+func (f fakeRunner) Run(context.Context, Action) ActionResult { return f.result }
+
+type fakeStore struct {
+	inputs []history.ManagementActionInput
+	events []history.Event
+}
+
+func (f *fakeStore) RecordManagementAction(_ context.Context, in history.ManagementActionInput) (history.Event, error) {
+	f.inputs = append(f.inputs, in)
+	return history.Event{ID: int64(len(f.inputs)), Type: history.EventManagementActionCompleted, Summary: in.Summary}, nil
+}
+
+func (f *fakeStore) ListManagementActions(context.Context, history.ManagementActionFilter) ([]history.Event, error) {
+	return f.events, nil
+}
+
+func TestServicePreviewBlocksDisabledPolicy(t *testing.T) {
+	catalog := mustCatalog(t, []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskLowRiskMutation, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second, TimeoutText: "1s"}})
+	service := NewService(catalog, Policy{}, fakeRunner{}, nil)
+	result := service.Preview(context.Background(), ActionRequest{ActionID: "a"})
+	if result.Status != StatusBlocked || result.Decision != DecisionBlock {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestServiceExecuteRunsAllowedActionAndRecordsHistory(t *testing.T) {
+	catalog := mustCatalog(t, []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskLowRiskMutation, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second, TimeoutText: "1s"}})
+	store := &fakeStore{}
+	service := NewService(catalog, Policy{ActionsEnabled: true}, fakeRunner{result: ActionResult{Status: StatusSucceeded, Stdout: "ok"}}, store)
+	result := service.Execute(context.Background(), ActionRequest{ActionID: "a", IncidentKey: "inc", IncidentTitle: "Incident"})
+	if result.Status != StatusSucceeded || result.Decision != DecisionAllow {
+		t.Fatalf("result = %+v", result)
+	}
+	if len(store.inputs) != 1 || store.inputs[0].ActionID != "a" {
+		t.Fatalf("history inputs = %+v", store.inputs)
+	}
+	if len(result.HistoryEventIDs) != 1 {
+		t.Fatalf("history ids = %+v", result.HistoryEventIDs)
+	}
+}
+
+func TestServiceExecuteRequiresTitleForNewIncident(t *testing.T) {
+	catalog := mustCatalog(t, []Action{{ID: "a", Title: "A", Description: "desc", RiskTier: RiskLowRiskMutation, ScriptPath: "scripts/ops/a.sh", Timeout: time.Second, TimeoutText: "1s"}})
+	service := NewService(catalog, Policy{ActionsEnabled: true}, fakeRunner{result: ActionResult{Status: StatusSucceeded}}, &fakeStore{})
+	result := service.Execute(context.Background(), ActionRequest{ActionID: "a", IncidentKey: "inc"})
+	if result.Status != StatusBlocked || result.PolicyReason != "incident_title is required when incident_key creates action history" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func mustCatalog(t *testing.T, actions []Action) Catalog {
+	t.Helper()
+	catalog, err := NewCatalog(actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return catalog
+}

--- a/go/observability-mcp-service/internal/management/types.go
+++ b/go/observability-mcp-service/internal/management/types.go
@@ -49,3 +49,23 @@ type PolicyDecision struct {
 	Decision Decision `json:"decision"`
 	Reason   string   `json:"reason"`
 }
+
+type ActionResult struct {
+	ActionID          string    `json:"action_id"`
+	RiskTier          RiskTier  `json:"risk_tier"`
+	Decision          Decision  `json:"decision"`
+	Status            Status    `json:"status"`
+	ScriptPath        string    `json:"script_path"`
+	IncidentKey       string    `json:"incident_key,omitempty"`
+	StartedAt         time.Time `json:"started_at,omitempty"`
+	CompletedAt       time.Time `json:"completed_at,omitempty"`
+	DurationMillis    int64     `json:"duration_ms,omitempty"`
+	ExitCode          int       `json:"exit_code,omitempty"`
+	Stdout            string    `json:"stdout,omitempty"`
+	Stderr            string    `json:"stderr,omitempty"`
+	OutputTruncated   bool      `json:"output_truncated,omitempty"`
+	RedactionsApplied int       `json:"redactions_applied,omitempty"`
+	PolicyReason      string    `json:"policy_reason,omitempty"`
+	HistoryEventIDs   []int64   `json:"history_event_ids,omitempty"`
+	Warning           string    `json:"warning,omitempty"`
+}

--- a/go/observability-mcp-service/internal/management/types.go
+++ b/go/observability-mcp-service/internal/management/types.go
@@ -1,0 +1,51 @@
+package management
+
+import "time"
+
+type RiskTier string
+type Decision string
+type Status string
+
+const (
+	RiskDiagnostic       RiskTier = "diagnostic"
+	RiskLowRiskMutation RiskTier = "low_risk_mutation"
+	RiskHighRiskMutation RiskTier = "high_risk_mutation"
+
+	DecisionAllow       Decision = "allow"
+	DecisionBlock       Decision = "block"
+	DecisionPreviewOnly Decision = "preview_only"
+
+	StatusPreviewed Status = "previewed"
+	StatusBlocked   Status = "blocked"
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusTimedOut  Status = "timed_out"
+)
+
+type Action struct {
+	ID               string        `json:"id"`
+	Title            string        `json:"title"`
+	Description      string        `json:"description"`
+	RiskTier         RiskTier      `json:"risk_tier"`
+	ScriptPath       string        `json:"script_path"`
+	AllowedArgs      []Argument    `json:"allowed_args,omitempty"`
+	Timeout          time.Duration `json:"-"`
+	TimeoutText      string        `json:"timeout"`
+	RequiresIncident bool          `json:"requires_incident"`
+	Idempotent        bool          `json:"idempotent"`
+	Preflight        string        `json:"preflight"`
+	Postflight       string        `json:"postflight"`
+	RedactPatterns   []string      `json:"-"`
+	NextSteps        string        `json:"next_steps"`
+}
+
+type Argument struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required"`
+}
+
+type PolicyDecision struct {
+	Decision Decision `json:"decision"`
+	Reason   string   `json:"reason"`
+}

--- a/go/observability-mcp-service/internal/management/types.go
+++ b/go/observability-mcp-service/internal/management/types.go
@@ -69,3 +69,12 @@ type ActionResult struct {
 	HistoryEventIDs   []int64   `json:"history_event_ids,omitempty"`
 	Warning           string    `json:"warning,omitempty"`
 }
+
+type ActionRequest struct {
+	ActionID      string         `json:"action_id"`
+	Args          map[string]any `json:"args,omitempty"`
+	IncidentKey   string         `json:"incident_key,omitempty"`
+	IncidentTitle string         `json:"incident_title,omitempty"`
+	Severity      string         `json:"severity,omitempty"`
+	Service       string         `json:"service,omitempty"`
+}

--- a/go/observability-mcp-service/internal/mcpserver/server.go
+++ b/go/observability-mcp-service/internal/mcpserver/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/config"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/management"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/workflows"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/resources/runbooks"
 )
@@ -27,6 +28,10 @@ type WorkflowService interface {
 	GetIncidentHistory(context.Context, string) (history.IncidentHistory, error)
 	AddIncidentNote(context.Context, history.AddNoteInput) (history.Event, error)
 	CompareEvidenceSnapshots(context.Context, int64, int64) (workflows.EvidenceComparison, error)
+	ListManagementActions(context.Context) ([]management.Action, error)
+	PreviewManagementAction(context.Context, management.ActionRequest) (management.ActionResult, error)
+	ExecuteManagementAction(context.Context, management.ActionRequest) (management.ActionResult, error)
+	ListManagementActionHistory(context.Context, history.ManagementActionFilter) ([]history.Event, error)
 }
 
 func New(service WorkflowService, cfg config.Config) *sdkmcp.Server {
@@ -43,6 +48,10 @@ func New(service WorkflowService, cfg config.Config) *sdkmcp.Server {
 	addTool(srv, "get_incident_history", "Return incident timeline and evidence summaries.", incidentHistorySchema(), incidentHistoryHandler(service))
 	addTool(srv, "add_incident_note", "Append an incident note and optionally transition status.", addIncidentNoteSchema(), addIncidentNoteHandler(service))
 	addTool(srv, "compare_evidence_windows", "Compare two persisted observability evidence snapshots.", compareEvidenceWindowsSchema(), compareEvidenceWindowsHandler(service))
+	addTool(srv, "list_management_actions", "List cataloged observability management actions.", listManagementActionsSchema(), listManagementActionsHandler(service))
+	addTool(srv, "preview_management_action", "Validate and preview a cataloged management action without executing it.", managementActionSchema(), previewManagementActionHandler(service))
+	addTool(srv, "execute_management_action", "Execute an allowed cataloged management action.", managementActionSchema(), executeManagementActionHandler(service))
+	addTool(srv, "get_management_action_history", "List persisted management action events.", managementActionHistorySchema(), managementActionHistoryHandler(service))
 	addResource(srv, "observability://runbooks/system-health", "System Health Runbook", "Signals and interpretations for system health.", runbookResourceHandler("observability://runbooks/system-health", "system-health"))
 	addResource(srv, "observability://runbooks/checkout", "Checkout Runbook", "Signals and interpretations for checkout incidents.", runbookResourceHandler("observability://runbooks/checkout", "checkout"))
 	addResource(srv, "observability://runbooks/ai-pipeline", "AI Pipeline Runbook", "Signals and interpretations for AI/RAG incidents.", runbookResourceHandler("observability://runbooks/ai-pipeline", "ai-pipeline"))
@@ -271,6 +280,79 @@ func compareEvidenceWindowsHandler(service WorkflowService) sdkmcp.ToolHandler {
 	}
 }
 
+func listManagementActionsHandler(service WorkflowService) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var in struct{}
+		if err := decodeOptionalArgs(req, &in); err != nil {
+			return toolError(err.Error()), nil
+		}
+		result, err := service.ListManagementActions(ctx)
+		if err != nil {
+			return toolError(err.Error()), nil
+		}
+		return jsonResult(result), nil
+	}
+}
+
+func previewManagementActionHandler(service WorkflowService) sdkmcp.ToolHandler {
+	return managementActionHandler(func(ctx context.Context, req management.ActionRequest) (management.ActionResult, error) {
+		return service.PreviewManagementAction(ctx, req)
+	})
+}
+
+func executeManagementActionHandler(service WorkflowService) sdkmcp.ToolHandler {
+	return managementActionHandler(func(ctx context.Context, req management.ActionRequest) (management.ActionResult, error) {
+		return service.ExecuteManagementAction(ctx, req)
+	})
+}
+
+func managementActionHandler(fn func(context.Context, management.ActionRequest) (management.ActionResult, error)) sdkmcp.ToolHandler {
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var in management.ActionRequest
+		if err := decodeArgs(req, &in); err != nil {
+			return toolError(err.Error()), nil
+		}
+		if in.ActionID == "" {
+			return toolError("action_id is required"), nil
+		}
+		result, err := fn(ctx, in)
+		if err != nil {
+			return toolError(err.Error()), nil
+		}
+		return jsonResult(result), nil
+	}
+}
+
+func managementActionHistoryHandler(service WorkflowService) sdkmcp.ToolHandler {
+	type input struct {
+		IncidentKey string `json:"incident_key,omitempty"`
+		ActionID    string `json:"action_id,omitempty"`
+		Status      string `json:"status,omitempty"`
+		Decision    string `json:"decision,omitempty"`
+		Limit       int    `json:"limit,omitempty"`
+	}
+	return func(ctx context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var in input
+		if err := decodeOptionalArgs(req, &in); err != nil {
+			return toolError(err.Error()), nil
+		}
+		if in.Limit > 100 {
+			return toolError("limit must be <= 100"), nil
+		}
+		result, err := service.ListManagementActionHistory(ctx, history.ManagementActionFilter{
+			IncidentKey: in.IncidentKey,
+			ActionID:    in.ActionID,
+			Status:      in.Status,
+			Decision:    in.Decision,
+			Limit:       in.Limit,
+		})
+		if err != nil {
+			return toolError(err.Error()), nil
+		}
+		return jsonResult(result), nil
+	}
+}
+
 func runbookResourceHandler(uri, name string) sdkmcp.ResourceHandler {
 	return func(context.Context, *sdkmcp.ReadResourceRequest) (*sdkmcp.ReadResourceResult, error) {
 		text, err := runbooks.Read(name)
@@ -344,4 +426,16 @@ func addIncidentNoteSchema() json.RawMessage {
 
 func compareEvidenceWindowsSchema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"baseline_snapshot_id":{"type":"integer"},"candidate_snapshot_id":{"type":"integer"}},"required":["baseline_snapshot_id"],"additionalProperties":false}`)
+}
+
+func listManagementActionsSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`)
+}
+
+func managementActionSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"action_id":{"type":"string"},"args":{"type":"object"},"incident_key":{"type":"string"},"incident_title":{"type":"string"},"severity":{"type":"string"},"service":{"type":"string"}},"required":["action_id"],"additionalProperties":false}`)
+}
+
+func managementActionHistorySchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"incident_key":{"type":"string"},"action_id":{"type":"string"},"status":{"type":"string"},"decision":{"type":"string"},"limit":{"type":"integer","minimum":1,"maximum":100}},"additionalProperties":false}`)
 }

--- a/go/observability-mcp-service/internal/mcpserver/server_test.go
+++ b/go/observability-mcp-service/internal/mcpserver/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/config"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/management"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/workflows"
 )
 
@@ -62,10 +63,43 @@ func TestHistoryToolsAreRegistered(t *testing.T) {
 	for _, tool := range tools.Tools {
 		got[tool.Name] = true
 	}
-	for _, name := range []string{"list_incidents", "get_incident_history", "add_incident_note", "compare_evidence_windows"} {
+	for _, name := range []string{"list_incidents", "get_incident_history", "add_incident_note", "compare_evidence_windows", "list_management_actions", "preview_management_action", "execute_management_action", "get_management_action_history"} {
 		if !got[name] {
 			t.Fatalf("expected registered tool %q; got %v", name, got)
 		}
+	}
+}
+
+func TestManagementActionHandlers(t *testing.T) {
+	fake := &fakeWorkflow{}
+	result, err := previewManagementActionHandler(fake)(context.Background(), callReq(map[string]any{"action_id": "reload_grafana_alerting"}))
+	if err != nil || result.IsError {
+		t.Fatalf("preview failed: result=%#v err=%v", result, err)
+	}
+	if fake.managementRequest.ActionID != "reload_grafana_alerting" {
+		t.Fatalf("request = %+v", fake.managementRequest)
+	}
+
+	result, err = executeManagementActionHandler(fake)(context.Background(), callReq(map[string]any{
+		"action_id":      "reload_grafana_alerting",
+		"incident_key":   "inc",
+		"incident_title": "Incident",
+	}))
+	if err != nil || result.IsError {
+		t.Fatalf("execute failed: result=%#v err=%v", result, err)
+	}
+	if fake.managementRequest.IncidentKey != "inc" {
+		t.Fatalf("request = %+v", fake.managementRequest)
+	}
+}
+
+func TestManagementActionHistoryHandlerValidatesLimit(t *testing.T) {
+	result, err := managementActionHistoryHandler(&fakeWorkflow{})(context.Background(), callReq(map[string]any{"limit": 101}))
+	if err != nil {
+		t.Fatalf("handler transport error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected tool error")
 	}
 }
 
@@ -213,9 +247,10 @@ func TestInvestigateEvalRunHandlerReturnsBundle(t *testing.T) {
 }
 
 type fakeWorkflow struct {
-	window  time.Duration
-	evalID  string
-	capture workflows.CaptureOptions
+	window            time.Duration
+	evalID            string
+	capture           workflows.CaptureOptions
+	managementRequest management.ActionRequest
 }
 
 func (f *fakeWorkflow) GetSystemHealth(_ context.Context, window time.Duration, capture workflows.CaptureOptions) workflows.EvidenceBundle {
@@ -277,6 +312,24 @@ func (f *fakeWorkflow) AddIncidentNote(context.Context, history.AddNoteInput) (h
 
 func (f *fakeWorkflow) CompareEvidenceSnapshots(context.Context, int64, int64) (workflows.EvidenceComparison, error) {
 	return workflows.EvidenceComparison{}, nil
+}
+
+func (f *fakeWorkflow) ListManagementActions(context.Context) ([]management.Action, error) {
+	return []management.Action{{ID: "reload_grafana_alerting"}}, nil
+}
+
+func (f *fakeWorkflow) PreviewManagementAction(_ context.Context, req management.ActionRequest) (management.ActionResult, error) {
+	f.managementRequest = req
+	return management.ActionResult{ActionID: req.ActionID, Status: management.StatusPreviewed}, nil
+}
+
+func (f *fakeWorkflow) ExecuteManagementAction(_ context.Context, req management.ActionRequest) (management.ActionResult, error) {
+	f.managementRequest = req
+	return management.ActionResult{ActionID: req.ActionID, Status: management.StatusSucceeded}, nil
+}
+
+func (f *fakeWorkflow) ListManagementActionHistory(context.Context, history.ManagementActionFilter) ([]history.Event, error) {
+	return []history.Event{}, nil
 }
 
 func testConfig() config.Config {

--- a/go/observability-mcp-service/internal/workflows/service.go
+++ b/go/observability-mcp-service/internal/workflows/service.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/history"
+	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/management"
 	"github.com/kabradshaw1/portfolio/go/observability-mcp-service/internal/observability"
 )
 
@@ -42,6 +43,7 @@ type Service struct {
 
 	historyStore history.Store
 	autoCapture  bool
+	management   *management.Service
 }
 
 func NewService(prometheus Prometheus, loki Loki, jaeger Jaeger, maxLogs int) *Service {
@@ -54,6 +56,11 @@ func NewService(prometheus Prometheus, loki Loki, jaeger Jaeger, maxLogs int) *S
 func (s *Service) WithHistory(store history.Store, autoCapture bool) *Service {
 	s.historyStore = store
 	s.autoCapture = autoCapture
+	return s
+}
+
+func (s *Service) WithManagement(m *management.Service) *Service {
+	s.management = m
 	return s
 }
 
@@ -198,6 +205,34 @@ func (s *Service) CompareEvidenceSnapshots(ctx context.Context, baselineID, cand
 		comparison.Summary = append(comparison.Summary, fmt.Sprintf("signal %s %s from %s to %s", delta.Name, delta.Direction, delta.Before, delta.After))
 	}
 	return comparison, nil
+}
+
+func (s *Service) ListManagementActions(ctx context.Context) ([]management.Action, error) {
+	if s.management == nil {
+		return nil, errors.New("management actions are disabled")
+	}
+	return s.management.List(), nil
+}
+
+func (s *Service) PreviewManagementAction(ctx context.Context, req management.ActionRequest) (management.ActionResult, error) {
+	if s.management == nil {
+		return management.ActionResult{}, errors.New("management actions are disabled")
+	}
+	return s.management.Preview(ctx, req), nil
+}
+
+func (s *Service) ExecuteManagementAction(ctx context.Context, req management.ActionRequest) (management.ActionResult, error) {
+	if s.management == nil {
+		return management.ActionResult{}, errors.New("management actions are disabled")
+	}
+	return s.management.Execute(ctx, req), nil
+}
+
+func (s *Service) ListManagementActionHistory(ctx context.Context, filter history.ManagementActionFilter) ([]history.Event, error) {
+	if s.management == nil {
+		return nil, errors.New("management actions are disabled")
+	}
+	return s.management.History(ctx, filter)
 }
 
 func (s *Service) SearchLogs(ctx context.Context, service string, window time.Duration, pattern string) EvidenceBundle {

--- a/go/observability-mcp-service/internal/workflows/service_test.go
+++ b/go/observability-mcp-service/internal/workflows/service_test.go
@@ -186,6 +186,13 @@ func TestNilHistoryStoreDoesNotPersist(t *testing.T) {
 	}
 }
 
+func TestManagementActionsUnavailableUntilConfigured(t *testing.T) {
+	service := NewService(nil, nil, nil, 10)
+	if _, err := service.ListManagementActions(context.Background()); err == nil {
+		t.Fatal("expected management service disabled error")
+	}
+}
+
 func TestCompareEvidenceSnapshotsReportsStatusAndCountDeltas(t *testing.T) {
 	store := &fakeHistoryStore{snapshotsByID: map[int64]history.Snapshot{
 		1: snapshotWithBundle(t, 1, EvidenceBundle{

--- a/go/observability-mcp-service/internal/workflows/service_test.go
+++ b/go/observability-mcp-service/internal/workflows/service_test.go
@@ -487,6 +487,14 @@ func (f *fakeHistoryStore) GetSnapshot(_ context.Context, id int64) (history.Sna
 	return snapshot, nil
 }
 
+func (f *fakeHistoryStore) RecordManagementAction(context.Context, history.ManagementActionInput) (history.Event, error) {
+	return history.Event{ID: 1}, f.err
+}
+
+func (f *fakeHistoryStore) ListManagementActions(context.Context, history.ManagementActionFilter) ([]history.Event, error) {
+	return []history.Event{}, f.err
+}
+
 type fakeGrafanaAlerting struct {
 	alerts []observability.AlertInstance
 	rules  []observability.AlertRule


### PR DESCRIPTION
## Summary
- added opt-in cataloged management actions for the Observability MCP
- added policy-gated runner, output redaction, and action history persistence
- documented the agent-autonomous ops-as-code safety model

## Tests
- make preflight-go